### PR TITLE
Add initial DocFX documentation setup

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -1,0 +1,42 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [ "**/*.csproj" ],
+          "src": "../src"
+        }
+      ],
+      "dest": "api",
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false,
+      "properties": {
+        "TargetFramework": "net8.0"
+      }
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [ "api/**.yml", "api/index.md" ]
+      },
+      {
+        "files": [ "toc.yml", "*.md" ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [ "images/**" ]
+      }
+    ],
+    "dest": "_site",
+    "globalMetadata": {
+      "_appTitle": "Wolfgang.Etl.Abstractions Documentation",
+      "_appName": "Wolfgang.Etl.Abstractions",
+      "_enableSearch": true
+    },
+    "template": [
+      "default"
+    ]
+  }
+}

--- a/docfx_project/index.md
+++ b/docfx_project/index.md
@@ -1,0 +1,21 @@
+# Wolfgang.Etl.Abstractions Documentation
+
+Welcome to the Wolfgang.Etl.Abstractions API documentation.
+
+## Overview
+
+This package contains interfaces and base classes for building ETLs using a specific design pattern.
+
+The ETL design pattern is a common approach in data processing that involves three main stages:
+- **Extract**: Retrieving data from various sources.
+- **Transform**: Processing and transforming the extracted data into a desired format.
+- **Load**: Storing the transformed data into a target system.
+
+## Getting Started
+
+See the [API Documentation](api/index.md) for detailed information about the available interfaces and classes.
+
+## Links
+
+- [GitHub Repository](https://github.com/Chris-Wolfgang/ETL-Abstractions)
+- [NuGet Package](https://www.nuget.org/packages/Wolfgang.Etl.Abstractions)

--- a/docfx_project/toc.yml
+++ b/docfx_project/toc.yml
@@ -1,0 +1,5 @@
+- name: Home
+  href: index.md
+- name: API Documentation
+  href: api/
+  homepage: api/index.md


### PR DESCRIPTION
Added docfx.json for API metadata extraction and site build configuration. Included index.md with project overview and toc.yml for navigation structure. This sets up the foundation for generating project documentation with DocFX.

## Description

<!-- Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes/Complete # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

<!-- Please add any screenshots or gifs to help reviewers understand your changes. -->

## Additional context

<!-- Add any other context about the pull request here. -->
