### PR TITLE
Fix XML doc errors, obsolete API usage, csproj formatting, and README placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,44 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 
 ## 🚀 Quick Start
 
-{{QUICK_START_EXAMPLE}}
+```csharp
+// Create a custom extractor by inheriting from ExtractorBase
+public class MyExtractor : ExtractorBase<string, Report>
+{
+    protected override async IAsyncEnumerable<string> ExtractWorkerAsync(
+        [EnumeratorCancellation] CancellationToken token)
+    {
+        // Yield items from your data source
+        yield return "item1";
+        IncrementCurrentItemCount();
+    }
+
+    protected override Report CreateProgressReport()
+    {
+        return new Report(CurrentItemCount);
+    }
+}
+
+// Use the extractor
+var extractor = new MyExtractor();
+await foreach (var item in extractor.ExtractAsync())
+{
+    Console.WriteLine(item);
+}
+```
 
 ---
 
 ## ✨ Features
 
-{{FEATURES_TABLE}}
-
-**Examples:**
-{{FEATURE_EXAMPLES}}
+| Feature | Description |
+|---------|-------------|
+| Async Streaming | Built on `IAsyncEnumerable<T>` for efficient, non-blocking data pipelines |
+| Progress Reporting | Built-in `IProgress<T>` support with configurable reporting intervals |
+| Cancellation | Full `CancellationToken` support across all operations |
+| Multi-TFM | Targets .NET Framework 4.6.2+, .NET Standard 2.0+, and .NET 5.0–10.0 |
+| Skip & Limit | `SkipItemCount` and `MaximumItemCount` for partial extraction/loading |
+| Thread Safety | `Interlocked`-based counters for safe concurrent progress tracking |
 
 ---
 
@@ -177,5 +205,7 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## 🙏 Acknowledgments
 
-{{ACKNOWLEDGMENTS}}
+- Built with [.NET](https://dotnet.microsoft.com/) and the async streaming APIs
+- Static analysis powered by Roslyn, Roslynator, Meziantou, and SonarAnalyzer
+- Documentation generated with [DocFX](https://dotnet.github.io/docfx/)
 

--- a/src/Wolfgang.Etl.Abstractions/IExtractWithProgressAndCancellationAsync.cs
+++ b/src/Wolfgang.Etl.Abstractions/IExtractWithProgressAndCancellationAsync.cs
@@ -39,7 +39,7 @@ public interface IExtractWithProgressAndCancellationAsync<out TSource, out TProg
     /// <param name="progress">A provider for progress updates.</param>
     /// <param name="token">A CancellationToken to observe while waiting for the task to complete.</param>
     /// <returns>
-    /// IAsyncEnumerable&lt;TSource&gt; The result may be an empty sequence if no data is available or if the extraction fails.
+    /// IAsyncEnumerable&lt;TSource&gt; - The result may be an empty sequence if no data is available or if the extraction fails.
     /// </returns> 
     /// <remarks>
     /// The extractor should be able to handle cancellation requests gracefully.

--- a/src/Wolfgang.Etl.Abstractions/ITransformWithProgressAndCancellationAsync.cs
+++ b/src/Wolfgang.Etl.Abstractions/ITransformWithProgressAndCancellationAsync.cs
@@ -32,7 +32,7 @@ public interface ITransformWithProgressAndCancellationAsync<in TSource, out TDes
     /// <summary>
     /// Asynchronously transforms data of type TSource to TDestination.
     /// </summary>
-    /// <param name="items">Asynchronous list of TSource </param>
+    /// <param name="items">An asynchronous sequence of TSource items to be transformed.</param>
     /// <param name="progress">A provider for progress updates.</param>
     /// <param name="token">A CancellationToken to observe while waiting for the task to complete.</param>
     /// <returns>

--- a/src/Wolfgang.Etl.Abstractions/ITransformWithProgressAsync.cs
+++ b/src/Wolfgang.Etl.Abstractions/ITransformWithProgressAsync.cs
@@ -29,7 +29,7 @@ public interface ITransformWithProgressAsync<in TSource, out TDestination, out T
     /// <summary>
     /// Asynchronously transforms data of type TSource to TDestination.
     /// </summary>
-    /// <param name="items">Asynchronous list of TSource </param>
+    /// <param name="items">An asynchronous sequence of TSource items to be transformed.</param>
     /// <param name="progress">A provider for progress updates.</param>
     /// <returns>
     /// IAsyncEnumerable&lt;TDestination&gt; - The result may be an empty sequence if no data is available or if the transformation fails.

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -68,13 +68,13 @@ public abstract class LoaderBase<TDestination, TProgress>
 
     /// <summary>
     /// The maximum number of items to load. Once the loader has reached this limit,
-    /// it should stop loading items as if it had reached the end of the sequence
+    /// it should stop loading items as if it had reached the end of the sequence.
     /// </summary>
     /// <remarks>
     /// This is useful for partially loading data from a source, especially when the source is large
     /// or infinite or during development.
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">The specified value is less than 0.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The specified value is less than 1.</exception>
     /// <example>
     /// <code>
     ///     foreach (var item in items.Skip(SkipItemCount).Take(MaxItemCount))
@@ -107,7 +107,7 @@ public abstract class LoaderBase<TDestination, TProgress>
     /// The loader should skip the specified number of items before starting to process the remaining items.
     /// </summary>
     /// <remarks>
-    /// This is useful for skipping the beginning of the list during testing or because it may already be loaded
+    /// This is useful for skipping the beginning of the list during testing or because it may already be loaded.
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">The specified value is less than 0.</exception>
     /// <example>

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -76,7 +76,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
     /// This is useful for transforming a subset of data, especially when the source is large
     /// or infinite or during development.
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">The specified value is less than 0.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The specified value is less than 1.</exception>
     /// <example>
     /// <code>
     ///     foreach (var item in items.Skip(SkipItemCount).Take(MaxItemCount))
@@ -308,7 +308,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
 
 
 
-        /// <summary>
+    /// <summary>
     /// The worker method that performs the actual transformation.
     /// </summary>
     /// <param name="items">IAsyncEnumerable&lt;TSource&gt; - A list of 0 or more items to be transformed</param>

--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>
-	  net462;net472;net48;net481;
-	  netstandard2.0;
-	  netcoreapp3.1;
-	  net5.0;net6.0;net7.0;
-	  net8.0;net9.0;net10.0
-    </TargetFrameworks>
+	<TargetFrameworks>net462;net472;net48;net481;netstandard2.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
 	<Nullable>enable</Nullable>
 	<Version>0.10.2</Version>

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ExtractorBaseTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ExtractorBaseTests.cs
@@ -317,8 +317,7 @@ public class ExtractorBaseTests
     }
 
 
-    [ExcludeFromCodeCoverage]
-    [Fact(Skip = "Not working due to timing issues")]
+    [Fact]
     public async Task ExtractWithProgressAsync_invokes_progress_callback()
     {
         var sut = new FibonacciExtractorFromExtractorBase();
@@ -332,8 +331,7 @@ public class ExtractorBaseTests
 
 
 
-    [ExcludeFromCodeCoverage]
-    [Fact(Skip = "Not working due to timing issues")]
+    [Fact]
     public async Task ExtractWithProgressAsync_progress_callback_receives_current_item_count()
     {
         var sut = new FibonacciExtractorFromExtractorBase();
@@ -343,13 +341,12 @@ public class ExtractorBaseTests
         await sut.ExtractAsync(progress).ToListAsync();
 
         Assert.NotNull(lastReport);
-        Assert.Equal(sut.CurrentItemCount, lastReport.CurrentCount);
+        Assert.Equal(sut.CurrentItemCount, lastReport.CurrentItemCount);
     }
 
 
 
-    [ExcludeFromCodeCoverage]
-    [Fact(Skip = "Not working due to timing issues")]
+    [Fact]
     public async Task ExtractWithProgressAndCancellationAsync_invokes_progress_callback()
     {
         var sut = new FibonacciExtractorFromExtractorBase();
@@ -363,8 +360,7 @@ public class ExtractorBaseTests
 
 
 
-    [ExcludeFromCodeCoverage]
-    [Fact(Skip = "Not working due to timing issues")]
+    [Fact]
     public async Task ExtractWithProgressAndCancellationAsync_progress_callback_receives_current_item_count()
     {
         var sut = new FibonacciExtractorFromExtractorBase();
@@ -374,7 +370,7 @@ public class ExtractorBaseTests
         await sut.ExtractAsync(progress, CancellationToken.None).ToListAsync();
 
         Assert.NotNull(lastReport);
-        Assert.Equal(sut.CurrentItemCount, lastReport.CurrentCount);
+        Assert.Equal(sut.CurrentItemCount, lastReport.CurrentItemCount);
     }
 }
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/LoaderBaseTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/LoaderBaseTests.cs
@@ -145,8 +145,7 @@ public class LoaderBaseTests(ITestOutputHelper testOutputHelper)
 
 
 
-    [ExcludeFromCodeCoverage]
-    [Fact(Skip = "Not working due to timing issues")]
+    [Fact]
     public async Task LoadWithProgressAsync_invokes_progress_callback()
     {
         var actualResults = new List<string>();
@@ -161,8 +160,7 @@ public class LoaderBaseTests(ITestOutputHelper testOutputHelper)
 
 
 
-    [ExcludeFromCodeCoverage]
-    [Fact(Skip = "Not working due to timing issues")]
+    [Fact]
     public async Task LoadWithProgressAsync_progress_callback_receives_current_item_count()
     {
         var actualResults = new List<string>();
@@ -173,7 +171,7 @@ public class LoaderBaseTests(ITestOutputHelper testOutputHelper)
         await sut.LoadAsync(new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" }.ToAsyncEnumerable(), progress);
 
         Assert.NotNull(lastReport);
-        Assert.Equal(sut.CurrentItemCount, lastReport.CurrentCount);
+        Assert.Equal(sut.CurrentItemCount, lastReport.CurrentItemCount);
     }
 
 
@@ -248,8 +246,7 @@ public class LoaderBaseTests(ITestOutputHelper testOutputHelper)
 
 
 
-    [ExcludeFromCodeCoverage]
-    [Fact(Skip = "Not working due to timing issues")]
+    [Fact]
     public async Task LoadWithProgressAndCancellationAsync_invokes_progress_callback()
     {
         var actualResults = new List<string>();
@@ -264,8 +261,7 @@ public class LoaderBaseTests(ITestOutputHelper testOutputHelper)
 
 
 
-    [ExcludeFromCodeCoverage]
-    [Fact(Skip = "Not working due to timing issues")]
+    [Fact]
     public async Task LoadWithProgressAndCancellationAsync_progress_callback_receives_current_item_count()
     {
         var actualResults = new List<string>();
@@ -276,7 +272,7 @@ public class LoaderBaseTests(ITestOutputHelper testOutputHelper)
         await sut.LoadAsync(new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" }.ToAsyncEnumerable(), progress, CancellationToken.None);
 
         Assert.NotNull(lastReport);
-        Assert.Equal(sut.CurrentItemCount, lastReport.CurrentCount);
+        Assert.Equal(sut.CurrentItemCount, lastReport.CurrentItemCount);
     }
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TransformerBaseTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TransformerBaseTests.cs
@@ -375,8 +375,7 @@ public class TransformerBaseTests
 
 
 
-    [ExcludeFromCodeCoverage]
-    [Fact(Skip = "Not working due to timing issues")]
+    [Fact]
     public async Task TransformWithProgressAsync_invokes_progress_callback()
     {
         var sut = new IntToStringTransformerFromTransformerBase();
@@ -391,8 +390,7 @@ public class TransformerBaseTests
 
 
 
-    [ExcludeFromCodeCoverage]
-    [Fact(Skip = "Not working due to timing issues")]
+    [Fact]
     public async Task TransformWithProgressAsync_progress_callback_receives_current_item_count()
     {
         var sut = new IntToStringTransformerFromTransformerBase();
@@ -403,13 +401,12 @@ public class TransformerBaseTests
         await sut.TransformAsync(items, progress).ToListAsync();
 
         Assert.NotNull(lastReport);
-        Assert.Equal(sut.CurrentItemCount, lastReport.CurrentCount);
+        Assert.Equal(sut.CurrentItemCount, lastReport.CurrentItemCount);
     }
 
 
 
-    [ExcludeFromCodeCoverage]
-    [Fact(Skip = "Not working due to timing issues")]
+    [Fact]
     public async Task TransformWithProgressAndCancellationAsync_invokes_progress_callback()
     {
         var sut = new IntToStringTransformerFromTransformerBase();
@@ -424,8 +421,7 @@ public class TransformerBaseTests
 
 
 
-    [ExcludeFromCodeCoverage]
-    [Fact(Skip = "Not working due to timing issues")]
+    [Fact]
     public async Task TransformWithProgressAndCancellationAsync_progress_callback_receives_current_item_count()
     {
         var sut = new IntToStringTransformerFromTransformerBase();
@@ -436,7 +432,7 @@ public class TransformerBaseTests
         await sut.TransformAsync(items, progress, CancellationToken.None).ToListAsync();
 
         Assert.NotNull(lastReport);
-        Assert.Equal(sut.CurrentItemCount, lastReport.CurrentCount);
+        Assert.Equal(sut.CurrentItemCount, lastReport.CurrentItemCount);
     }
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Models/EtlProgress.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Models/EtlProgress.cs
@@ -2,18 +2,18 @@ namespace Wolfgang.Etl.Abstractions.Tests.Unit.Models;
 
 internal record EtlProgress
 {
-    public EtlProgress(int currentCount)
+    public EtlProgress(int currentItemCount)
     {
-        if (currentCount < 0)
+        if (currentItemCount < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(currentCount), "Current count cannot be less than 0.");
+            throw new ArgumentOutOfRangeException(nameof(currentItemCount), "Current item count cannot be less than 0.");
         }
 
-        CurrentCount = currentCount;
+        CurrentItemCount = currentItemCount;
     }
 
 
 
-    public int CurrentCount { get; }
+    public int CurrentItemCount { get; }
 
 }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Models/EtlProgressTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Models/EtlProgressTests.cs
@@ -6,7 +6,7 @@ public class EtlProgressTests
     public void Constructor_when_passed_a_valid_value_stores_the_value()
     {
         var sut = new EtlProgress(42);
-        Assert.Equal(42, sut.CurrentCount);
+        Assert.Equal(42, sut.CurrentItemCount);
     }
 
 
@@ -15,7 +15,7 @@ public class EtlProgressTests
     public void Constructor_when_passed_zero_stores_zero()
     {
         var sut = new EtlProgress(0);
-        Assert.Equal(0, sut.CurrentCount);
+        Assert.Equal(0, sut.CurrentItemCount);
     }
 
 
@@ -32,15 +32,15 @@ public class EtlProgressTests
     public void Constructor_when_passed_a_negative_value_throws_with_correct_param_name()
     {
         var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new EtlProgress(-1));
-        Assert.Equal("currentCount", ex.ParamName);
+        Assert.Equal("currentItemCount", ex.ParamName);
     }
 
 
 
     [Fact]
-    public void CurrentCount_returns_the_value_passed_to_the_constructor()
+    public void CurrentItemCount_returns_the_value_passed_to_the_constructor()
     {
         var sut = new EtlProgress(99);
-        Assert.Equal(99, sut.CurrentCount);
+        Assert.Equal(99, sut.CurrentItemCount);
     }
 }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Wolfgang.Etl.Abstractions.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Wolfgang.Etl.Abstractions.Tests.Unit.csproj
@@ -1,11 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>
-      net462;net472;net48;net481;
-      netcoreapp3.1;
-      net5.0;net6.0;net7.0;
-      net8.0;net9.0;net10.0
-    </TargetFrameworks>
+    <TargetFrameworks>net462;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <Version>0.10.2</Version>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
- Fix incorrect exception docs on `MaximumItemCount` in `LoaderBase` and `TransformerBase` (said "less than 0", actual threshold is 1)
- Fix missing periods in `LoaderBase` summary/remarks XML docs
- Fix bad indentation on `TransformWorkerAsync` XML doc in `TransformerBase`
- Add missing dash separator in `IExtractWithProgressAndCancellationAsync` returns doc
- Replace vague param docs in `ITransformWithProgressAsync` / `ITransformWithProgressAndCancellationAsync`
- Collapse multi-line `TargetFrameworks` to single line in both csproj files (CI grep requirement)
- Rename `EtlProgress` test model `CurrentCount` to `CurrentItemCount` to align with framework convention
- Un-skip 12 progress callback tests that now pass (final report fires synchronously in `finally` block)
- Replace README placeholder tokens (`{{QUICK_START_EXAMPLE}}`, `{{FEATURES_TABLE}}`, etc.) with actual content

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors across all 12 TFMs
- [x] `dotnet test --configuration Release` — 119 tests pass across all 11 test TFMs (was 107 passing + 12 skipped)
- [ ] Verify CI passes on all target frameworks

🤖 Generated with [Claude Code](https://claude.com/claude-code)