### PR TITLE
Replace stale template placeholder text in docfx API README

### DIFF
--- a/docfx_project/api/README.md
+++ b/docfx_project/api/README.md
@@ -16,8 +16,7 @@ When you run `docfx docfx_project/docfx.json` from the repository root, DocFX wi
 - Hand-authored files like `index.md` and this `README.md` are intentionally maintained by hand and will be preserved across DocFX runs
 - The actual API reference metadata files (`*.yml` files) will be generated automatically
 
-## Template Placeholders
+## Namespace
 
-The `index.md` file uses the following template placeholder:
-- `Wolfgang.Etl.Abstractions` - Will be replaced with your project name
+The generated API documentation covers the `Wolfgang.Etl.Abstractions` namespace and its sub-namespaces.
 


### PR DESCRIPTION
## Summary
- Replaced the "Template Placeholders" section in `docfx_project/api/README.md` with a "Namespace" section that accurately describes the generated API documentation scope

## Test plan
- [x] Verify the README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)