### PR TITLE
Use <inheritdoc/> on base-class interface implementations

### DIFF
--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -164,13 +164,7 @@ public abstract class ExtractorBase<TSource, TProgress>
 
 
 
-    /// <summary>
-    /// Asynchronously extracts data of type TSource from a source.
-    /// </summary>
-    /// <returns>
-    /// IAsyncEnumerable&lt;TSource&gt;
-    /// The result may be an empty sequence if no data is available or if the extraction fails.
-    /// </returns>
+    /// <inheritdoc/>
     public virtual IAsyncEnumerable<TSource> ExtractAsync()
     {
         return ExtractWorkerAsync(CancellationToken.None);
@@ -178,18 +172,7 @@ public abstract class ExtractorBase<TSource, TProgress>
 
 
 
-    /// <summary>
-    /// Asynchronously extracts data of type TSource from a source.
-    /// </summary>
-    /// <param name="token">A CancellationToken to observe while waiting for the task to complete.</param>
-    /// <returns>
-    /// IAsyncEnumerable&lt;TSource&gt;
-    /// The result may be an empty sequence if no data is available or if the extraction fails.
-    /// </returns>
-    /// <remarks>
-    /// The extractor should be able to handle cancellation requests gracefully.
-    /// If the caller doesn't plan on cancelling the extraction, they can pass CancellationToken.None.
-    /// </remarks>
+    /// <inheritdoc/>
     public virtual IAsyncEnumerable<TSource> ExtractAsync(CancellationToken token)
     {
         return ExtractWorkerAsync(token);
@@ -197,15 +180,7 @@ public abstract class ExtractorBase<TSource, TProgress>
 
 
 
-    /// <summary>
-    /// Asynchronously extracts data of type TSource from a source.
-    /// </summary>
-    /// <param name="progress">A provider for progress updates.</param>
-    /// <returns>
-    /// IAsyncEnumerable&lt;TSource&gt;
-    /// The result may be an empty sequence if no data is available or if the extraction fails.
-    /// </returns>
-    /// <exception cref="ArgumentNullException">The value of progress is null</exception>
+    /// <inheritdoc/>
     public virtual IAsyncEnumerable<TSource> ExtractAsync(IProgress<TProgress> progress)
     {
 #if NET6_0_OR_GREATER
@@ -224,20 +199,7 @@ public abstract class ExtractorBase<TSource, TProgress>
 
 
 
-    /// <summary>
-    /// Asynchronously extracts data of type TSource from a source.
-    /// </summary>
-    /// <param name="progress">A provider for progress updates.</param>
-    /// <param name="token">A CancellationToken to observe while waiting for the task to complete.</param>
-    /// <returns>
-    /// IAsyncEnumerable&lt;TSource&gt;
-    /// The result may be an empty sequence if no data is available or if the extraction fails.
-    /// </returns>
-    /// <remarks>
-    /// The extractor should be able to handle cancellation requests gracefully.
-    /// If the caller doesn't plan on cancelling the extraction, they can pass CancellationToken.None.
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">The value of progress is null</exception>
+    /// <inheritdoc/>
     public virtual IAsyncEnumerable<TSource> ExtractAsync(IProgress<TProgress> progress, CancellationToken token)
     {
 #if NET6_0_OR_GREATER

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -137,15 +137,7 @@ public abstract class LoaderBase<TDestination, TProgress>
 
 
 
-    /// <summary>
-    /// Asynchronously loads data of type TDestination into the target destination.
-    /// </summary>
-    /// <param name="items">The items to be loaded to the destination.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    /// <remarks>
-    /// Items may be an empty sequence if no data is available or if the loading fails.
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">Argument items is null</exception>
+    /// <inheritdoc/>
     public virtual Task LoadAsync(IAsyncEnumerable<TDestination> items)
     {
 #if NET6_0_OR_GREATER
@@ -163,16 +155,7 @@ public abstract class LoaderBase<TDestination, TProgress>
 
 
 
-    /// <summary>
-    /// Asynchronously loads data of type TDestination into the target destination.
-    /// </summary>
-    /// <param name="items">The items to be loaded to the destination.</param>
-    /// <param name="token">A CancellationToken to observe while waiting for the task to complete.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    /// <remarks>
-    /// Items may be an empty sequence if no data is available or if the loading fails.
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">Argument items is null</exception>
+    /// <inheritdoc/>
     public virtual Task LoadAsync(IAsyncEnumerable<TDestination> items, CancellationToken token)
     {
 #if NET6_0_OR_GREATER
@@ -190,17 +173,7 @@ public abstract class LoaderBase<TDestination, TProgress>
 
 
 
-    /// <summary>
-    /// Asynchronously loads data of type TDestination into the target destination.
-    /// </summary>
-    /// <param name="items">The items to be loaded to the destination.</param>
-    /// <param name="progress">A provider for progress updates.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    /// <remarks>
-    /// Items may be an empty sequence if no data is available or if the loading fails.
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">Argument items is null</exception>
-    /// <exception cref="ArgumentNullException">Argument progress is null</exception>
+    /// <inheritdoc/>
     public virtual Task LoadAsync(IAsyncEnumerable<TDestination> items, IProgress<TProgress> progress)
     {
 #if NET6_0_OR_GREATER
@@ -224,18 +197,7 @@ public abstract class LoaderBase<TDestination, TProgress>
 
 
 
-    /// <summary>
-    /// Asynchronously loads data of type TDestination into the target destination.
-    /// </summary>
-    /// <param name="items">The items to be loaded to the destination.</param>
-    /// <param name="progress">A provider for progress updates.</param>
-    /// <param name="token">A CancellationToken to observe while waiting for the task to complete.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    /// <remarks>
-    /// Items may be an empty sequence if no data is available or if the loading fails.
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">Argument items is null</exception>
-    /// <exception cref="ArgumentNullException">Argument progress is null</exception>
+    /// <inheritdoc/>
     public virtual Task LoadAsync(IAsyncEnumerable<TDestination> items, IProgress<TProgress> progress, CancellationToken token)
     {
 #if NET6_0_OR_GREATER

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -140,15 +140,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
 
 
 
-    /// <summary>
-    /// Asynchronously transforms data of type TSource to TDestination
-    /// </summary>
-    /// <param name="items">IAsyncEnumerable&lt;TSource&gt; - A list of 0 or more items to be transformed</param>
-    /// <returns>
-    /// IAsyncEnumerable&lt;TDestination&gt;
-    /// The result may be an empty sequence if no data is available or if the transformation fails.
-    /// </returns>
-    /// <exception cref="ArgumentNullException">The value of items is null</exception>
+    /// <inheritdoc/>
     public virtual IAsyncEnumerable<TDestination> TransformAsync(IAsyncEnumerable<TSource> items)
     {
 #if NET6_0_OR_GREATER
@@ -166,19 +158,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
 
 
 
-    /// <summary>
-    /// Asynchronously transforms data of type TSource to TDestination
-    /// </summary>
-    /// <param name="items">IAsyncEnumerable&lt;TSource&gt; - A list of 0 or more items to be transformed</param>
-    /// <param name="token">A CancellationToken to observe while waiting for the task to complete.</param>
-    /// <returns>
-    /// IAsyncEnumerable&lt;TDestination&gt; - A list of 0 or more transformed items
-    /// </returns>
-    /// <remarks>
-    /// The transformer should be able to handle cancellation requests gracefully.
-    /// If the caller doesn't plan on cancelling the transformation, they can pass CancellationToken.None.
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">The value of items is null</exception>
+    /// <inheritdoc/>
     public virtual IAsyncEnumerable<TDestination> TransformAsync(IAsyncEnumerable<TSource> items, CancellationToken token)
     {
 #if NET6_0_OR_GREATER
@@ -196,16 +176,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
 
 
 
-    /// <summary>
-    /// Asynchronously transforms data of type TSource to TDestination
-    /// </summary>
-    /// <param name="items">IAsyncEnumerable&lt;TSource&gt; - A list of 0 or more items to be transformed</param>
-    /// <param name="progress">A provider for progress updates.</param>
-    /// <returns>
-    /// IAsyncEnumerable&lt;TDestination&gt; - The result may be an empty sequence if no data is available or if the transformation fails.
-    /// </returns>
-    /// <exception cref="ArgumentNullException">The value of items is null</exception>
-    /// <exception cref="ArgumentNullException">The value of progress is null</exception>
+    /// <inheritdoc/>
     public virtual IAsyncEnumerable<TDestination> TransformAsync(IAsyncEnumerable<TSource> items, IProgress<TProgress> progress)
     {
 #if NET6_0_OR_GREATER
@@ -229,21 +200,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
 
 
 
-    /// <summary>
-    /// Asynchronously transforms data of type TSource to TDestination
-    /// </summary>
-    /// <param name="items">IAsyncEnumerable&lt;TSource&gt; - A list of 0 or more items to be transformed</param>
-    /// <param name="progress">A provider for progress updates.</param>
-    /// <param name="token">A CancellationToken to observe while waiting for the task to complete.</param>
-    /// <returns>
-    /// IAsyncEnumerable&lt;TDestination&gt; - The result may be an empty sequence if no data is available or if the transformation fails.
-    /// </returns>
-    /// <remarks>
-    /// The transformer should be able to handle cancellation requests gracefully.
-    /// If the caller doesn't plan on cancelling the transformation, they can pass CancellationToken.None.
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">The value of items is null</exception>
-    /// <exception cref="ArgumentNullException">The value of progress is null</exception>
+    /// <inheritdoc/>
     public virtual IAsyncEnumerable<TDestination> TransformAsync(IAsyncEnumerable<TSource> items, IProgress<TProgress> progress, CancellationToken token)
     {
 #if NET6_0_OR_GREATER


### PR DESCRIPTION
## Summary

Replace 12 hand-duplicated XML doc blocks with `/// <inheritdoc/>` on interface implementations in the base classes. Documentation intent is unchanged — the interface declarations already carry the full `<summary>`, `<param>`, `<returns>`, and `<exception>` tags that the implementations were restating.

**Changed methods (all `virtual`, all implement an interface method with existing docs):**

| File | Methods |
|---|---|
| `src/Wolfgang.Etl.Abstractions/ExtractorBase.cs` | 4 `ExtractAsync` overloads |
| `src/Wolfgang.Etl.Abstractions/LoaderBase.cs` | 4 `LoadAsync` overloads |
| `src/Wolfgang.Etl.Abstractions/TransformerBase.cs` | 4 `TransformAsync` overloads |

`SystemProgressTimer.cs` already uses `<inheritdoc/>` — untouched.

## Motivation

Hand-duplicated docs drift from the interface contract over time. `<inheritdoc/>` gives IntelliSense, DocFX, and Sandcastle a single source of truth: if the interface doc is updated, implementations automatically pick up the change.

## Stats

- 3 files changed, 12 insertions(+), 131 deletions(-)
- No behavior change
- 132/132 unit tests pass in Release on net10.0
- 0 build warnings, 0 errors

## Test plan

- [x] `dotnet build -c Release -f net10.0` clean
- [x] `dotnet test -c Release -f net10.0` — 132/132 pass
- [ ] CI matrix builds across all TFMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)