### PR TITLE
Cover TransformerBase.CurrentSkippedItemCount getter

### DIFF
--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TransformerBaseTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TransformerBaseTests.cs
@@ -35,6 +35,29 @@ public class TransformerBaseTests
         var sut = CreateSut(1);
         Assert.Equal(1_000, sut.ReportingInterval);
     }
+
+
+    [Fact]
+    public void CurrentSkippedItemCount_default_value_is_zero()
+    {
+        var sut = CreateSut(1);
+        Assert.Equal(0, sut.CurrentSkippedItemCount);
+    }
+
+
+    [Fact]
+    public async Task CurrentSkippedItemCount_reflects_skipped_items_after_transform()
+    {
+        var sut = CreateSut(5);
+        sut.SkipItemCount = 2;
+
+        var source = new[] { "1", "2", "3", "4", "5" }.ToAsyncEnumerable();
+        await foreach (var _ in sut.TransformAsync(source))
+        {
+        }
+
+        Assert.Equal(2, sut.CurrentSkippedItemCount);
+    }
 }
 
 


### PR DESCRIPTION
## Summary

Adds two tests covering the `TransformerBase<,,>.CurrentSkippedItemCount` getter — the last uncovered line in `Wolfgang.Etl.Abstractions`.

- `CurrentSkippedItemCount_default_value_is_zero` — default value assertion
- `CurrentSkippedItemCount_reflects_skipped_items_after_transform` — runs the `IdentityTransformer` with `SkipItemCount = 2` and asserts the property reflects the 2 skipped rows

Found while closing gaps on #83. Out-of-scope for that PR, so landing separately.

## Test plan

- [x] `dotnet test -c Release -f net10.0 --filter TransformerBaseTests` — 42/42 pass
- [ ] CI matrix builds across all TFMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)