### PR TITLE
Fix low-priority Pipeline review findings (volatile reads, sentinel exception, assertion strengthening)

### DIFF
--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -55,14 +55,14 @@ public abstract class ExtractorBase<TSource, TProgress>
     /// It is the responsibility of the derived class to call <see cref="IncrementCurrentItemCount"/>
     /// as each item is extracted. The base class has no way of knowing when an item has been processed.
     /// </remarks>
-    public int CurrentItemCount => _currentItemCount;
+    public int CurrentItemCount => Volatile.Read(ref _currentItemCount);
 
 
 
     /// <summary>
     /// The current number of items skipped so far during extraction.
     /// </summary>
-    public int CurrentSkippedItemCount => _currentSkippedItemCount;
+    public int CurrentSkippedItemCount => Volatile.Read(ref _currentSkippedItemCount);
 
 
 

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -55,14 +55,14 @@ public abstract class LoaderBase<TDestination, TProgress>
     /// It is the responsibility of the derived class to call <see cref="IncrementCurrentItemCount"/>
     /// as each item is loaded. The base class has no way of knowing when an item has been processed.
     /// </remarks>
-    public int CurrentItemCount => _currentItemCount;
+    public int CurrentItemCount => Volatile.Read(ref _currentItemCount);
 
 
 
     /// <summary>
     /// The current number of items skipped so far during loading.
     /// </summary>
-    public int CurrentSkippedItemCount => _currentSkippedItemCount;
+    public int CurrentSkippedItemCount => Volatile.Read(ref _currentSkippedItemCount);
 
 
 

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -57,14 +57,14 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
     /// It is the responsibility of the derived class to call <see cref="IncrementCurrentItemCount"/>
     /// as each item is transformed. The base class has no way of knowing when an item has been processed.
     /// </remarks>
-    public int CurrentItemCount => _currentItemCount;
+    public int CurrentItemCount => Volatile.Read(ref _currentItemCount);
 
 
 
     /// <summary>
     /// The current number of items skipped so far during transformation.
     /// </summary>
-    public int CurrentSkippedItemCount => _currentSkippedItemCount;
+    public int CurrentSkippedItemCount => Volatile.Read(ref _currentSkippedItemCount);
 
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/CancelOnlyTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/CancelOnlyTests.cs
@@ -67,6 +67,8 @@ public class CancelOnlyTests
                 .Load(loader)
                 .RunAsync(cts.Token)
         );
+
+        Assert.Empty(loader.Loaded);
     }
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/FullTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/FullTests.cs
@@ -101,5 +101,7 @@ public class FullTests
                 .Load(loader)
                 .RunAsync(cts.Token)
         );
+
+        Assert.Empty(loader.Loaded);
     }
 }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Extractors.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Extractors.cs
@@ -53,9 +53,9 @@ internal sealed class CancelOnlyExtractor<T> : IExtractWithCancellationAsync<T>
     }
 
 
-    public IAsyncEnumerable<T> ExtractAsync() => throw new InvalidOperationException
+    public IAsyncEnumerable<T> ExtractAsync() => throw new WrongOverloadCalledException
     (
-        "The pipeline should always call the token-taking overload for a cancellation-capable extractor."
+        "CancelOnlyExtractor<T>.ExtractAsync()"
     );
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Loaders.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Loaders.cs
@@ -38,7 +38,8 @@ internal sealed class CancelOnlyLoader<T> : ILoadWithCancellationAsync<T>
     public bool TokenOverloadWasCalled { get; private set; }
 
 
-    public Task LoadAsync(IAsyncEnumerable<T> items) => throw new InvalidOperationException();
+    public Task LoadAsync(IAsyncEnumerable<T> items)
+        => throw new WrongOverloadCalledException("CancelOnlyLoader<T>.LoadAsync(items)");
 
 
     public async Task LoadAsync(IAsyncEnumerable<T> items, CancellationToken token)

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Transformers.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Transformers.cs
@@ -56,7 +56,7 @@ internal sealed class CancelOnlyTransformer<TSource, TDestination>
 
 
     public IAsyncEnumerable<TDestination> TransformAsync(IAsyncEnumerable<TSource> items)
-        => throw new InvalidOperationException();
+        => throw new WrongOverloadCalledException("CancelOnlyTransformer<TSource, TDestination>.TransformAsync(items)");
 
 
     public async IAsyncEnumerable<TDestination> TransformAsync

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/WrongOverloadCalledException.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/WrongOverloadCalledException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
+
+/// <summary>
+/// Sentinel exception thrown by test doubles when the pipeline routes a call to an
+/// overload that should never be reached for that double's capability interface. Using a
+/// dedicated type instead of a plain <see cref="InvalidOperationException"/> makes accidental
+/// routing regressions easy to diagnose in test failure output.
+/// </summary>
+internal sealed class WrongOverloadCalledException : Exception
+{
+    public WrongOverloadCalledException(string overloadSignature)
+        : base($"Unexpected call to {overloadSignature}. The pipeline routed through the wrong overload.")
+    {
+    }
+}


### PR DESCRIPTION
Stacks on top of #134 (parallel to #137). Addresses the **low-priority** findings from the code review.

## Fixes

| # | Finding | Fix |
|---|---|---|
| 6 | `CurrentItemCount` / `CurrentSkippedItemCount` getters read without `Volatile.Read`, while writers use `Interlocked.Increment`. Theoretical weak-memory-model hazard. | `Volatile.Read(ref _currentItemCount)` in `ExtractorBase`, `LoaderBase`, `TransformerBase`. Free on x86/x64, correct on ARM NetFx. |
| 7 | Test doubles throw raw `InvalidOperationException` on unused overloads. A future routing bug surfaces as a confusing generic exception. | Add `WrongOverloadCalledException` sentinel; `CancelOnly*` doubles now throw it with the overload signature in the message. |
| 11 | Pre-cancelled-token tests only assert "some `OperationCanceledException` was thrown" — a regression where cancellation fires mid-stream after 1-2 items still passes. | Add `Assert.Empty(loader.Loaded)` after the cancellation throw in `CancelOnlyTests` and `FullTests`. |

## Stats

- 9 files changed
- 208/208 tests pass in Release on net10.0 (existing tests strengthened; no new tests needed)
- 0 build warnings / errors

## Not included

Review findings #10 (informational — covariance doc note), #12 (wait for CI signal on `field` keyword), and #13 (style nitpick) were judged not worth the churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)