### PR TITLE
.editorconfig: sync from canonical

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -254,6 +254,10 @@ dotnet_style_readonly_field = true:suggestion
 csharp_prefer_braces = true:suggestion
 csharp_prefer_simple_using_statement = true:suggestion
 csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_using_directive_placement = outside_namespace:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_prefer_system_threading_lock = true:suggestion
 
 # var preferences - prefer 'var' usage for modern C# style
 csharp_style_var_when_type_is_apparent = true:silent
@@ -266,7 +270,9 @@ dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
 csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_expression_bodied_operators = false:silent
 
 # Pattern matching
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
@@ -282,6 +288,7 @@ dotnet_style_null_propagation = true:suggestion
 # Preserve manual line breaks and allow flexible parameter formatting
 csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
 
 # Line length guidance (not enforced by dotnet format, but used by some IDEs)
 csharp_max_line_length = 120
@@ -376,8 +383,8 @@ dotnet_diagnostic.VSTHRD107.severity = none       # Allow Task in using without 
 dotnet_diagnostic.VSTHRD114.severity = none       # Allow returning null from Task methods in tests
 dotnet_diagnostic.VSTHRD200.severity = none       # Async suffix not required in test method names
 
-# Banned API Analyzer - Just warn in tests (allow for testing purposes)
-dotnet_diagnostic.RS0030.severity = warning       # Using banned API - warn instead of error in tests
+# Banned API Analyzer - Allow in tests (sync I/O and Stream overrides are common in test setup)
+dotnet_diagnostic.RS0030.severity = none          # Allow banned APIs in tests
 
 # Meziantou - Relax in tests
 dotnet_diagnostic.MA0004.severity = none         # ConfigureAwait not needed in tests
@@ -422,8 +429,8 @@ dotnet_diagnostic.MA0004.severity = none          # Meziantou: Use ConfigureAwai
 dotnet_diagnostic.S3216.severity = none           # SonarAnalyzer: ConfigureAwait
 dotnet_diagnostic.CA2007.severity = none          # .NET Analyzer: Use ConfigureAwait
 
-# Banned API Analyzer - Just warn in benchmarks (allow for benchmarking purposes)
-dotnet_diagnostic.RS0030.severity = warning       # Using banned API - warn instead of error in benchmarks
+# Banned API Analyzer - Allow in benchmarks (sync APIs are often the benchmark target)
+dotnet_diagnostic.RS0030.severity = none          # Allow banned APIs in benchmarks
 
 # No documentation required for benchmarks
 dotnet_diagnostic.SA1600.severity = none


### PR DESCRIPTION
## Summary
Syncs `.editorconfig` to current canonical (repo-template `main`).

Brings this repo up to date with the canonical changes that landed since the last `.editorconfig` sync, including:
- repo-template#329: `RS0030.severity = none` in `[tests/**/*.cs]` and `[benchmarks/**/*.cs]` (the prior `warning` setting was promoted back to error by `TreatWarningsAsErrors` in Release).
- repo-template#330: 7 modern C# style suggestions (using directive placement, method group conversion, primary constructors, `System.Threading.Lock`, compound assignment, expression-bodied operators, operator placement when wrapping). All at `suggestion`/`silent` severity — non-blocking.

## Expected CI behavior
**`PR Checks v3 (Gated)` → `Detect protected configuration file changes` will fail by design.** `.editorconfig` is a protected file; the PR workflow gates non-Dependabot changes via that step. CI cannot pass automated checks as-is.

**Merge path:** maintainer manual review + admin merge (or temporary ruleset bypass), after locally verifying the diff matches `repo-template/.editorconfig` byte-for-byte.

## Test plan
- [x] `.editorconfig` content matches canonical byte-for-byte (verified locally with `diff` before push)
- [ ] Maintainer reviews diff against `repo-template/.editorconfig`
- [ ] Admin merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)