### PR TITLE
chore: sync *.ps1 EOL fix from canonical

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,12 +26,13 @@ indent_size = 2
 indent_size = 2
 
 # PowerShell files
-# PowerShell uses CRLF to maintain compatibility with Windows and PowerShell conventions
-# This overrides the global end_of_line = lf setting and aligns with .gitattributes line 14
+# Only the indent override is needed; LF + UTF-8 (no BOM) come from the
+# global [*] section above. LF + no-BOM is required for the
+# `#!/usr/bin/env pwsh` shebang at the top of every script in scripts/
+# to work on Linux/macOS — CR breaks the kernel's exec lookup, and a
+# leading BOM prevents shebang recognition entirely.
 [*.ps1]
 indent_size = 4
-end_of_line = crlf
-charset = utf-8-bom
 
 # C# files
 [*.cs]

--- a/.editorconfig
+++ b/.editorconfig
@@ -25,14 +25,13 @@ indent_size = 2
 [*.{yml,yaml}]
 indent_size = 2
 
-# PowerShell files
-# Only the indent override is needed; LF + UTF-8 (no BOM) come from the
-# global [*] section above. LF + no-BOM is required for the
+# PowerShell files inherit LF + UTF-8 (no BOM) + 4-space indent from
+# the global [*] section above — no [*.ps1] override needed. The
+# `charset = utf-8` setting is what prevents editors from writing a
+# BOM, which together with the LF requirement keeps the
 # `#!/usr/bin/env pwsh` shebang at the top of every script in scripts/
-# to work on Linux/macOS — CR breaks the kernel's exec lookup, and a
-# leading BOM prevents shebang recognition entirely.
-[*.ps1]
-indent_size = 4
+# working on Linux/macOS (CR breaks the kernel's exec lookup, and a
+# leading BOM prevents shebang recognition entirely).
 
 # C# files
 [*.cs]

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,11 +9,14 @@
 *.fsx text eol=lf
 
 # Scripts
-# PowerShell scripts: CRLF line endings (intentional override)
-# Both .gitattributes and .editorconfig consistently configure PowerShell files
-# to use CRLF (Windows-style) line endings for PowerShell convention compliance.
-# See .editorconfig [*.ps1] section for the matching configuration.
-*.ps1 text eol=crlf
+# PowerShell scripts: LF line endings, no BOM. Required for the
+# `#!/usr/bin/env pwsh` shebang to work on Linux/macOS — the kernel
+# parses CR as part of the interpreter name (looking for `pwsh\r`),
+# and a UTF-8 BOM before `#!` prevents shebang recognition entirely.
+# Modern PowerShell 7+ handles LF on Windows transparently; Git's
+# autocrlf still gives Windows users CRLF in their working tree if
+# desired without forcing CRLF into the index.
+*.ps1 text eol=lf
 
 
 # Build and configuration files

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,10 +9,12 @@
 *.fsx text eol=lf
 
 # Scripts
-# PowerShell scripts: LF line endings, no BOM. Required for the
+# PowerShell scripts: LF line endings in the index. Required for the
 # `#!/usr/bin/env pwsh` shebang to work on Linux/macOS — the kernel
-# parses CR as part of the interpreter name (looking for `pwsh\r`),
-# and a UTF-8 BOM before `#!` prevents shebang recognition entirely.
+# parses CR as part of the interpreter name (looking for `pwsh\r`).
+# BOM avoidance is enforced separately via `.editorconfig`
+# (charset = utf-8 in the global [*] section); git attributes can
+# only normalize line endings, not byte-order marks.
 # Modern PowerShell 7+ handles LF on Windows transparently; Git's
 # autocrlf still gives Windows users CRLF in their working tree if
 # desired without forcing CRLF into the index.


### PR DESCRIPTION
## Summary
Syncs the canonical `*.ps1` EOL fix from [repo-template#347](https://github.com/Chris-Wolfgang/repo-template/pull/347) + [#348](https://github.com/Chris-Wolfgang/repo-template/pull/348). Removes the CRLF + UTF-8-BOM overrides for `*.ps1` files in `.gitattributes` and `.editorconfig`.

## Why
The `#!/usr/bin/env pwsh` shebang at the top of every script in `scripts/` doesn't work as an executable on Linux/macOS when files are stored with CRLF + BOM:

1. **CRLF:** kernel parses `#!/usr/bin/env pwsh\r` and tries to find an interpreter named `pwsh\r` — fails.
2. **BOM:** bytes `EF BB BF` appear *before* `#!`, so the kernel doesn't recognize the file as a shebang script at all.

The original "PowerShell uses CRLF for Windows compatibility" rationale predates PowerShell 7+ (cross-platform). The PowerShell team's own canonical repos (`PowerShell/PowerShell`, `PSScriptAnalyzer`) all use LF + no BOM.

## Changes
| File | Before | After |
|---|---|---|
| `.gitattributes` | `*.ps1 text eol=crlf` | `*.ps1 text eol=lf` |
| `.editorconfig [*.ps1]` | `end_of_line = crlf`, `charset = utf-8-bom` | (both removed; LF + utf-8 from `[*]` defaults) |

Comments rewritten to explain the shebang rationale.

## What does NOT change
- **Files in the index:** already LF. The CRLF rule was aspirational policy that never matched reality. No file content rewrites in this PR.
- **Windows users:** `core.autocrlf=true` (Git for Windows default) still gives CRLF in working tree on checkout. Only the index/wire format is LF.
- **Indent:** still 4 spaces for `*.ps1`.

## Note about the protected-files guard
This PR touches `.gitattributes` (in canonical the rule is in `.editorconfig`'s domain too) and `.editorconfig` (protected). The `Detect .NET Projects` guard will fail it. Maintainer override required — same path as the canonical PRs.

## Test plan
- [ ] Maintainer override + merge
- [ ] After merge, `git ls-files --eol scripts/*.ps1` shows `i/lf w/* attr/text eol=lf` everywhere
