### PR TITLE
tier1: recover orphaned doc fixes into vNext (CONTRIBUTING header + #235)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ You can contribute in several ways:
 
 This project maintains **extremely high code quality standards** through multiple layers of static analysis and automated enforcement.
 
-### The 7 Analyzers
+### The 8 Analyzers
 
 All code is analyzed by these tools during build:
 

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -77,7 +77,7 @@ public abstract class LoaderBase<TDestination, TProgress>
     /// <exception cref="ArgumentOutOfRangeException">The specified value is less than 1.</exception>
     /// <example>
     /// <code>
-    ///     foreach (var item in items.Skip(SkipItemCount).Take(MaxItemCount))
+    ///     foreach (var item in items.Skip(SkipItemCount).Take(MaximumItemCount))
     ///     {
     ///         // Process the item
     ///     }
@@ -112,7 +112,7 @@ public abstract class LoaderBase<TDestination, TProgress>
     /// <exception cref="ArgumentOutOfRangeException">The specified value is less than 0.</exception>
     /// <example>
     /// <code>
-    ///     foreach (var item in items.Skip(SkipItemCount).Take(MaxItemCount))
+    ///     foreach (var item in items.Skip(SkipItemCount).Take(MaximumItemCount))
     ///     {
     ///         // Process the item
     ///     }

--- a/src/Wolfgang.Etl.Abstractions/SystemProgressTimer.cs
+++ b/src/Wolfgang.Etl.Abstractions/SystemProgressTimer.cs
@@ -15,8 +15,9 @@ namespace Wolfgang.Etl.Abstractions;
 /// <c>ExtractorBase.CreateProgressTimer</c>,
 /// <c>TransformerBase.CreateProgressTimer</c>, and
 /// <c>LoaderBase.CreateProgressTimer</c>.
-/// In unit tests, override <c>CreateProgressTimer</c> to return a
-/// <c>ManualProgressTimer</c> instead.
+/// In unit tests, override <c>CreateProgressTimer</c> to return a custom
+/// <see cref="IProgressTimer"/> implementation (for example, a manually
+/// controlled fake whose ticks the test fires on demand).
 /// </remarks>
 internal sealed class SystemProgressTimer : IProgressTimer
 {

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -79,7 +79,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
     /// <exception cref="ArgumentOutOfRangeException">The specified value is less than 1.</exception>
     /// <example>
     /// <code>
-    ///     foreach (var item in items.Skip(SkipItemCount).Take(MaxItemCount))
+    ///     foreach (var item in items.Skip(SkipItemCount).Take(MaximumItemCount))
     ///     {
     ///         // Transform each item and return it
     ///     }
@@ -115,7 +115,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
     /// <exception cref="ArgumentOutOfRangeException">The specified value is less than 0.</exception>
     /// <example>
     /// <code>
-    ///     foreach (var item in items.Skip(SkipItemCount).Take(MaxItemCount))
+    ///     foreach (var item in items.Skip(SkipItemCount).Take(MaximumItemCount))
     ///     {
     ///         // Transform each item and return it
     ///     }


### PR DESCRIPTION
Recovers tier-1 work that was orphaned in `tier1/markdown-audit` after #234 merged an early snapshot to vNext.

When #234 (markdown audit) merged into vNext, two later commits on this branch never made it back:
1. **CONTRIBUTING.md** — the `### The 7 Analyzers` → `### The 8 Analyzers` header fix (the item-8 body landed via #234, but the header correction did not).
2. **#235 code-review doc fixes** — `LoaderBase` / `TransformerBase` `<example>` referenced the non-existent `MaxItemCount` (→ `MaximumItemCount`), and `SystemProgressTimer` doc pointed at a non-existent `ManualProgressTimer` (→ resolvable `IProgressTimer` cref).

vNext currently still has the buggy `MaxItemCount` examples and the "7 Analyzers" header, so this needs to land before v0.13.1 ships. The branch already has vNext merged in, so this is conflict-free.

Net diff: CONTRIBUTING.md + 3 src XML-doc files. No code-behavior change.

Closes #161 · Part of: Chris-Wolfgang/ETL-Abstractions#154
