### PR TITLE
chore: finalize v0.13.1 CHANGELOG for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.13.1] - 2026-06-01
+## [0.13.1] - 2026-06-19
 
 Canonical maintenance round + binding-stability fix. No public API or
 runtime behavior change vs v0.13.0. This release is the prerequisite
@@ -66,9 +66,26 @@ dependencies.
   `Fix-BranchRuleset.ps1`).
 - `github/codeql-action/init` and `analyze` bumped v3 → v4 (Node.js
   20 → 24 deprecation).
+- **Docs** — README accuracy pass: corrected the Target Frameworks
+  table (dropped the untargeted .NET 4.7.0 / 4.7.1 rows, added the
+  missing .NET Standard 2.0 row), analyzer count 7 → 8
+  (`Microsoft.CodeAnalysis.PublicApiAnalyzers`), and the build
+  prerequisite (.NET 8.0 → .NET 10.0 SDK). `CONTRIBUTING.md` analyzer
+  list updated to match.
+
+### Removed
+
+- `REPO-INSTRUCTIONS.md` — the repo-template post-setup bootstrap
+  checklist ("once you have completed the checklist below you can
+  delete this file"); setup is long complete.
 
 ### Fixed
 
+- **Docs** — corrected stale XML-doc `<example>` references found in a
+  code-review pass: `LoaderBase` / `TransformerBase` examples referenced
+  a non-existent `MaxItemCount` (corrected to `MaximumItemCount`), and
+  `SystemProgressTimer` pointed at a non-existent `ManualProgressTimer`
+  type (corrected to a resolvable `IProgressTimer` reference).
 - **C4** — restored explicit `<AssemblyVersion>1.0.0.0</AssemblyVersion>`
   and added a prerelease-safe `<FileVersion>` (regex-strip property
   function) to the src csproj. The original C4 fanout had dropped


### PR DESCRIPTION
Final release-prep for **v0.13.1** before vNext (#192) merges to main. Docs-only — no public API or runtime change, so the version stays **0.13.1** (PATCH).

## Why
The `[0.13.1]` CHANGELOG entry was written early in the canonical round and had drifted from what's actually on vNext:
- It was dated **2026-06-01** — a placeholder date that has since passed without the release shipping.
- The tier-1 documentation work that landed afterward (README/CONTRIBUTING accuracy, `REPO-INSTRUCTIONS.md` removal, and the code-review XML-doc fixes via #233 / #234 / #235 / #236) wasn't recorded.

## Changes
- Set the `[0.13.1]` date to **2026-06-19** (today / release-cut date).
- **Changed** — note the README accuracy pass (TFM table, 7 → 8 analyzers, SDK prereq) + matching CONTRIBUTING update.
- **Removed** — `REPO-INSTRUCTIONS.md` (post-setup bootstrap checklist).
- **Fixed** — the stale XML-doc `<example>` references (`MaxItemCount` → `MaximumItemCount`, `ManualProgressTimer` → `IProgressTimer`).

## Release readiness (verified)
- `<Version>` = `0.13.1`, last shipped tag = `v0.13.0` → clean PATCH bump.
- `<AssemblyVersion>1.0.0.0</AssemblyVersion>` + prerelease-safe `<FileVersion>` intact (C4 binding stability).
- `[Unreleased]` section left empty per Keep-a-Changelog.

After this merges into vNext, #192 (vNext → main) is the release; tag `v0.13.1` to fire `release.yaml`.
