### PR TITLE
feat: timing + throughput metrics on Report (#144, #91)

### DIFF
--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -22,6 +23,43 @@ public abstract class ExtractorBase<TSource, TProgress>
 {
     private int _currentItemCount;
     private int _currentSkippedItemCount;
+    private long _startTimestamp;
+    private DateTimeOffset _startedAtUtc;
+
+
+
+    /// <summary>
+    /// The UTC time at which the first item was processed (extracted or skipped), or
+    /// <c>null</c> if extraction has not produced any items yet. Captured automatically
+    /// the first time <see cref="IncrementCurrentItemCount"/> or
+    /// <see cref="IncrementCurrentSkippedItemCount"/> is called, so derived classes can
+    /// surface it on their progress report (see <see cref="Report.StartedAt"/>).
+    /// </summary>
+    protected DateTimeOffset? StartedAt =>
+        Volatile.Read(ref _startTimestamp) == 0 ? null : _startedAtUtc;
+
+
+
+    /// <summary>
+    /// The monotonic wall-clock time elapsed since the first item was processed, or
+    /// <see cref="TimeSpan.Zero"/> if extraction has not produced any items yet.
+    /// Read this when building a progress report (see <see cref="Report.Elapsed"/>) to
+    /// snapshot how long extraction has been running.
+    /// </summary>
+    protected TimeSpan Elapsed
+    {
+        get
+        {
+            var start = Volatile.Read(ref _startTimestamp);
+            if (start == 0)
+            {
+                return TimeSpan.Zero;
+            }
+
+            var ticks = Stopwatch.GetTimestamp() - start;
+            return TimeSpan.FromSeconds(ticks / (double)Stopwatch.Frequency);
+        }
+    }
 
 
 
@@ -304,6 +342,7 @@ public abstract class ExtractorBase<TSource, TProgress>
         Justification = "Interlocked.Increment return value intentionally discarded; only the side-effect matters.")]
     protected void IncrementCurrentItemCount()
     {
+        EnsureStarted();
         _ = Interlocked.Increment(ref _currentItemCount);
     }
 
@@ -320,6 +359,27 @@ public abstract class ExtractorBase<TSource, TProgress>
         Justification = "Interlocked.Increment return value intentionally discarded; only the side-effect matters.")]
     protected void IncrementCurrentSkippedItemCount()
     {
+        EnsureStarted();
         _ = Interlocked.Increment(ref _currentSkippedItemCount);
+    }
+
+
+
+    // Captures the start timestamp (monotonic) and wall-clock StartedAt the first
+    // time any item is processed. Idempotent and thread-safe: the first caller to
+    // win the CompareExchange records the start; later calls are a cheap volatile read.
+    private void EnsureStarted()
+    {
+        if (Volatile.Read(ref _startTimestamp) != 0)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var timestamp = Stopwatch.GetTimestamp();
+        if (Interlocked.CompareExchange(ref _startTimestamp, timestamp, 0) == 0)
+        {
+            _startedAtUtc = now;
+        }
     }
 }

--- a/src/Wolfgang.Etl.Abstractions/IsExternalInit.cs
+++ b/src/Wolfgang.Etl.Abstractions/IsExternalInit.cs
@@ -1,0 +1,19 @@
+#if !NET5_0_OR_GREATER
+
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Polyfill for the compiler-required <c>IsExternalInit</c> marker type, which enables
+/// <see langword="init"/>-only property setters on target frameworks (.NET Framework,
+/// .NET Standard 2.0) whose reference assemblies do not ship it. Built-in on .NET 5.0+.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+[ExcludeFromCodeCoverage]
+internal static class IsExternalInit
+{
+}
+
+#endif

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,6 +23,43 @@ public abstract class LoaderBase<TDestination, TProgress>
 {
     private int _currentItemCount;
     private int _currentSkippedItemCount;
+    private long _startTimestamp;
+    private DateTimeOffset _startedAtUtc;
+
+
+
+    /// <summary>
+    /// The UTC time at which the first item was processed (loaded or skipped), or
+    /// <c>null</c> if loading has not produced any items yet. Captured automatically
+    /// the first time <see cref="IncrementCurrentItemCount"/> or
+    /// <see cref="IncrementCurrentSkippedItemCount"/> is called, so derived classes can
+    /// surface it on their progress report (see <see cref="Report.StartedAt"/>).
+    /// </summary>
+    protected DateTimeOffset? StartedAt =>
+        Volatile.Read(ref _startTimestamp) == 0 ? null : _startedAtUtc;
+
+
+
+    /// <summary>
+    /// The monotonic wall-clock time elapsed since the first item was processed, or
+    /// <see cref="TimeSpan.Zero"/> if loading has not produced any items yet.
+    /// Read this when building a progress report (see <see cref="Report.Elapsed"/>) to
+    /// snapshot how long loading has been running.
+    /// </summary>
+    protected TimeSpan Elapsed
+    {
+        get
+        {
+            var start = Volatile.Read(ref _startTimestamp);
+            if (start == 0)
+            {
+                return TimeSpan.Zero;
+            }
+
+            var ticks = Stopwatch.GetTimestamp() - start;
+            return TimeSpan.FromSeconds(ticks / (double)Stopwatch.Frequency);
+        }
+    }
 
 
 
@@ -307,6 +345,7 @@ public abstract class LoaderBase<TDestination, TProgress>
         Justification = "Interlocked.Increment return value intentionally discarded; only the side-effect matters.")]
     protected void IncrementCurrentItemCount()
     {
+        EnsureStarted();
         _ = Interlocked.Increment(ref _currentItemCount);
     }
 
@@ -323,6 +362,27 @@ public abstract class LoaderBase<TDestination, TProgress>
         Justification = "Interlocked.Increment return value intentionally discarded; only the side-effect matters.")]
     protected void IncrementCurrentSkippedItemCount()
     {
+        EnsureStarted();
         _ = Interlocked.Increment(ref _currentSkippedItemCount);
+    }
+
+
+
+    // Captures the start timestamp (monotonic) and wall-clock StartedAt the first
+    // time any item is processed. Idempotent and thread-safe: the first caller to
+    // win the CompareExchange records the start; later calls are a cheap volatile read.
+    private void EnsureStarted()
+    {
+        if (Volatile.Read(ref _startTimestamp) != 0)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var timestamp = Stopwatch.GetTimestamp();
+        if (Interlocked.CompareExchange(ref _startTimestamp, timestamp, 0) == 0)
+        {
+            _startedAtUtc = now;
+        }
     }
 }

--- a/src/Wolfgang.Etl.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.Abstractions/PublicAPI.Shipped.txt
@@ -2,6 +2,7 @@
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.CurrentItemCount.get -> int
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.CurrentSkippedItemCount.get -> int
+Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.Elapsed.get -> System.TimeSpan
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.ExtractorBase() -> void
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.IncrementCurrentItemCount() -> void
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.IncrementCurrentSkippedItemCount() -> void
@@ -11,6 +12,7 @@ Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.ReportingInterval.ge
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.ReportingInterval.set -> void
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.SkipItemCount.get -> int
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.SkipItemCount.set -> void
+Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.StartedAt.get -> System.DateTimeOffset?
 Wolfgang.Etl.Abstractions.IExtractAsync<TSource>
 Wolfgang.Etl.Abstractions.IExtractAsync<TSource>.ExtractAsync() -> System.Collections.Generic.IAsyncEnumerable<TSource>!
 Wolfgang.Etl.Abstractions.IExtractStage<TSource>
@@ -71,6 +73,7 @@ Wolfgang.Etl.Abstractions.ITransformWithProgressAsync<TSource, TDestination, TPr
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.CurrentItemCount.get -> int
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.CurrentSkippedItemCount.get -> int
+Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.Elapsed.get -> System.TimeSpan
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.IncrementCurrentItemCount() -> void
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.IncrementCurrentSkippedItemCount() -> void
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.LoaderBase() -> void
@@ -80,13 +83,24 @@ Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.ReportingInterval.
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.ReportingInterval.set -> void
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.SkipItemCount.get -> int
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.SkipItemCount.set -> void
+Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.StartedAt.get -> System.DateTimeOffset?
 Wolfgang.Etl.Abstractions.Pipeline
 Wolfgang.Etl.Abstractions.Report
 Wolfgang.Etl.Abstractions.Report.CurrentItemCount.get -> int
+Wolfgang.Etl.Abstractions.Report.Elapsed.get -> System.TimeSpan
+Wolfgang.Etl.Abstractions.Report.Elapsed.init -> void
+Wolfgang.Etl.Abstractions.Report.EstimatedRemaining.get -> System.TimeSpan?
+Wolfgang.Etl.Abstractions.Report.ItemsPerSecond.get -> double
+Wolfgang.Etl.Abstractions.Report.PercentComplete.get -> double?
 Wolfgang.Etl.Abstractions.Report.Report(int currentItemCount) -> void
+Wolfgang.Etl.Abstractions.Report.StartedAt.get -> System.DateTimeOffset?
+Wolfgang.Etl.Abstractions.Report.StartedAt.init -> void
+Wolfgang.Etl.Abstractions.Report.TotalItemCount.get -> int?
+Wolfgang.Etl.Abstractions.Report.TotalItemCount.init -> void
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.CurrentItemCount.get -> int
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.CurrentSkippedItemCount.get -> int
+Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.Elapsed.get -> System.TimeSpan
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.IncrementCurrentItemCount() -> void
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.IncrementCurrentSkippedItemCount() -> void
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.MaximumItemCount.get -> int
@@ -95,6 +109,7 @@ Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.Repo
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.ReportingInterval.set -> void
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.SkipItemCount.get -> int
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.SkipItemCount.set -> void
+Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.StartedAt.get -> System.DateTimeOffset?
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.TransformerBase() -> void
 abstract Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.CreateProgressReport() -> TProgress
 abstract Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<TSource>!

--- a/src/Wolfgang.Etl.Abstractions/Report.cs
+++ b/src/Wolfgang.Etl.Abstractions/Report.cs
@@ -3,11 +3,23 @@ using System;
 namespace Wolfgang.Etl.Abstractions;
 
 /// <summary>
-/// Provides a report of the current item count in an ETL process.
+/// Provides a point-in-time snapshot of the progress of an ETL process — how many
+/// items have been processed, how long it has been running, and (when the total is
+/// known) how far along it is and how much longer it is expected to take.
 /// </summary>
 /// <remarks>
+/// <para>
 /// This class can be used as a base class for other progress reports and expanded
-/// with additional information such as total count, count remaining, etc.
+/// with additional information specific to a particular extractor, transformer, or loader.
+/// </para>
+/// <para>
+/// All values are <em>snapshot</em> values captured at the moment the report is
+/// constructed. <see cref="Elapsed"/> does not advance after construction, mirroring
+/// <see cref="CurrentItemCount"/>. The throughput and completion estimates
+/// (<see cref="ItemsPerSecond"/>, <see cref="PercentComplete"/>,
+/// <see cref="EstimatedRemaining"/>) are derived from those snapshot values, so a
+/// given report is internally consistent.
+/// </para>
 /// </remarks>
 public record Report
 {
@@ -32,4 +44,107 @@ public record Report
     /// The number of items that have been processed so far in the ETL process.
     /// </summary>
     public int CurrentItemCount { get; }
+
+
+
+    /// <summary>
+    /// The wall-clock time (UTC) at which processing started, or <c>null</c> if it
+    /// has not started yet (no items processed) or the producer does not track it.
+    /// </summary>
+    public DateTimeOffset? StartedAt { get; init; }
+
+
+
+    /// <summary>
+    /// The wall-clock time that had elapsed since processing started, captured at the
+    /// moment this report was constructed. <see cref="TimeSpan.Zero"/> when timing is
+    /// not tracked or processing has not started.
+    /// </summary>
+    public TimeSpan Elapsed { get; init; }
+
+
+
+    /// <summary>
+    /// The total number of items expected to be processed, when known (for example a
+    /// file line count or a SQL <c>COUNT(*)</c>). <c>null</c> for unknown-size or
+    /// infinite sources. Must be greater than or equal to 0 when set.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">The specified value is less than 0.</exception>
+    public int? TotalItemCount
+    {
+        get;
+        init
+        {
+            if (value is < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "Total item count cannot be less than 0.");
+            }
+
+            field = value;
+        }
+    }
+
+
+
+    /// <summary>
+    /// The processing throughput, in items per second, derived from
+    /// <see cref="CurrentItemCount"/> and <see cref="Elapsed"/>. Returns 0 until at
+    /// least some time has elapsed.
+    /// </summary>
+    public double ItemsPerSecond =>
+        Elapsed.TotalSeconds > 0
+            ? CurrentItemCount / Elapsed.TotalSeconds
+            : 0d;
+
+
+
+    /// <summary>
+    /// The fraction of work completed, as a percentage in the range [0, 100], when
+    /// <see cref="TotalItemCount"/> is known; otherwise <c>null</c>. Clamped to 100
+    /// if <see cref="CurrentItemCount"/> exceeds <see cref="TotalItemCount"/>.
+    /// </summary>
+    public double? PercentComplete
+    {
+        get
+        {
+            if (TotalItemCount is not { } total)
+            {
+                return null;
+            }
+
+            return total == 0
+                ? 100d
+                : Math.Min(100d, 100d * CurrentItemCount / total);
+        }
+    }
+
+
+
+    /// <summary>
+    /// The estimated time remaining until completion, when both
+    /// <see cref="TotalItemCount"/> is known and throughput can be measured;
+    /// otherwise <c>null</c>. Returns <see cref="TimeSpan.Zero"/> once the current
+    /// count has reached the total.
+    /// </summary>
+    public TimeSpan? EstimatedRemaining
+    {
+        get
+        {
+            if (TotalItemCount is not { } total)
+            {
+                return null;
+            }
+
+            var remaining = total - CurrentItemCount;
+            if (remaining <= 0)
+            {
+                return TimeSpan.Zero;
+            }
+
+            var rate = ItemsPerSecond;
+            return rate > 0
+                ? TimeSpan.FromSeconds(remaining / rate)
+                : (TimeSpan?)null;
+        }
+    }
 }

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -24,6 +25,43 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
 {
     private int _currentItemCount;
     private int _currentSkippedItemCount;
+    private long _startTimestamp;
+    private DateTimeOffset _startedAtUtc;
+
+
+
+    /// <summary>
+    /// The UTC time at which the first item was processed (transformed or skipped), or
+    /// <c>null</c> if transformation has not produced any items yet. Captured automatically
+    /// the first time <see cref="IncrementCurrentItemCount"/> or
+    /// <see cref="IncrementCurrentSkippedItemCount"/> is called, so derived classes can
+    /// surface it on their progress report (see <see cref="Report.StartedAt"/>).
+    /// </summary>
+    protected DateTimeOffset? StartedAt =>
+        Volatile.Read(ref _startTimestamp) == 0 ? null : _startedAtUtc;
+
+
+
+    /// <summary>
+    /// The monotonic wall-clock time elapsed since the first item was processed, or
+    /// <see cref="TimeSpan.Zero"/> if transformation has not produced any items yet.
+    /// Read this when building a progress report (see <see cref="Report.Elapsed"/>) to
+    /// snapshot how long transformation has been running.
+    /// </summary>
+    protected TimeSpan Elapsed
+    {
+        get
+        {
+            var start = Volatile.Read(ref _startTimestamp);
+            if (start == 0)
+            {
+                return TimeSpan.Zero;
+            }
+
+            var ticks = Stopwatch.GetTimestamp() - start;
+            return TimeSpan.FromSeconds(ticks / (double)Stopwatch.Frequency);
+        }
+    }
 
 
 
@@ -311,6 +349,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
         Justification = "Interlocked.Increment return value intentionally discarded; only the side-effect matters.")]
     protected void IncrementCurrentItemCount()
     {
+        EnsureStarted();
         _ = Interlocked.Increment(ref _currentItemCount);
     }
 
@@ -327,6 +366,27 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
         Justification = "Interlocked.Increment return value intentionally discarded; only the side-effect matters.")]
     protected void IncrementCurrentSkippedItemCount()
     {
+        EnsureStarted();
         _ = Interlocked.Increment(ref _currentSkippedItemCount);
+    }
+
+
+
+    // Captures the start timestamp (monotonic) and wall-clock StartedAt the first
+    // time any item is processed. Idempotent and thread-safe: the first caller to
+    // win the CompareExchange records the start; later calls are a cheap volatile read.
+    private void EnsureStarted()
+    {
+        if (Volatile.Read(ref _startTimestamp) != 0)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var timestamp = Stopwatch.GetTimestamp();
+        if (Interlocked.CompareExchange(ref _startTimestamp, timestamp, 0) == 0)
+        {
+            _startedAtUtc = now;
+        }
     }
 }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/BaseClassTimingTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/BaseClassTimingTests.cs
@@ -80,4 +80,99 @@ public class BaseClassTimingTests
         Assert.NotNull(sut.StartedAtForTest);
         Assert.True(sut.ElapsedForTest >= System.TimeSpan.Zero);
     }
+
+
+
+    private static async IAsyncEnumerable<int> Range(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return i;
+        }
+
+        await Task.CompletedTask;
+    }
+
+
+    private sealed class TimedLoader : LoaderBase<int, EtlProgress>
+    {
+        public System.DateTimeOffset? StartedAtForTest => StartedAt;
+
+        public System.TimeSpan ElapsedForTest => Elapsed;
+
+        protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
+        {
+            await foreach (var _ in items.WithCancellation(token))
+            {
+                IncrementCurrentItemCount();
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+
+
+    private sealed class TimedTransformer : TransformerBase<int, int, EtlProgress>
+    {
+        public System.DateTimeOffset? StartedAtForTest => StartedAt;
+
+        public System.TimeSpan ElapsedForTest => Elapsed;
+
+        protected override async IAsyncEnumerable<int> TransformWorkerAsync(IAsyncEnumerable<int> items, [EnumeratorCancellation] CancellationToken token)
+        {
+            await foreach (var item in items.WithCancellation(token))
+            {
+                IncrementCurrentItemCount();
+                yield return item;
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+
+
+    [Fact]
+    public void LoaderBase_StartedAt_is_null_before_any_item_is_processed()
+    {
+        var sut = new TimedLoader();
+
+        Assert.Null(sut.StartedAtForTest);
+        Assert.Equal(System.TimeSpan.Zero, sut.ElapsedForTest);
+    }
+
+
+    [Fact]
+    public async Task LoaderBase_StartedAt_is_captured_once_loading_has_processed_items()
+    {
+        var sut = new TimedLoader();
+
+        await sut.LoadAsync(Range(5));
+
+        Assert.NotNull(sut.StartedAtForTest);
+        Assert.True(sut.ElapsedForTest >= System.TimeSpan.Zero);
+    }
+
+
+    [Fact]
+    public void TransformerBase_StartedAt_is_null_before_any_item_is_processed()
+    {
+        var sut = new TimedTransformer();
+
+        Assert.Null(sut.StartedAtForTest);
+        Assert.Equal(System.TimeSpan.Zero, sut.ElapsedForTest);
+    }
+
+
+    [Fact]
+    public async Task TransformerBase_StartedAt_is_captured_once_transformation_has_processed_items()
+    {
+        var sut = new TimedTransformer();
+
+        await foreach (var _ in sut.TransformAsync(Range(5)))
+        {
+        }
+
+        Assert.NotNull(sut.StartedAtForTest);
+        Assert.True(sut.ElapsedForTest >= System.TimeSpan.Zero);
+    }
 }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/BaseClassTimingTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/BaseClassTimingTests.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
+
+/// <summary>
+/// Verifies the timing instrumentation that <see cref="ExtractorBase{TSource, TProgress}"/>
+/// (and its loader/transformer siblings) capture automatically on the first processed item.
+/// </summary>
+public class BaseClassTimingTests
+{
+    // Minimal extractor that exposes the protected StartedAt / Elapsed timing
+    // signals so the base-class instrumentation can be asserted directly.
+    private sealed class TimedExtractor : ExtractorBase<int, EtlProgress>
+    {
+        private readonly int _count;
+
+
+
+        public TimedExtractor(int count)
+        {
+            _count = count;
+        }
+
+
+
+        public System.DateTimeOffset? StartedAtForTest => StartedAt;
+
+        public System.TimeSpan ElapsedForTest => Elapsed;
+
+
+
+        protected override async IAsyncEnumerable<int> ExtractWorkerAsync
+        (
+            [EnumeratorCancellation] CancellationToken token
+        )
+        {
+            for (var i = 0; i < _count; i++)
+            {
+                IncrementCurrentItemCount();
+                yield return i;
+            }
+
+            await Task.CompletedTask;
+        }
+
+
+
+        protected override EtlProgress CreateProgressReport()
+        {
+            return new EtlProgress(CurrentItemCount);
+        }
+    }
+
+
+
+    [Fact]
+    public void StartedAt_is_null_before_any_item_is_processed()
+    {
+        var sut = new TimedExtractor(3);
+
+        Assert.Null(sut.StartedAtForTest);
+        Assert.Equal(System.TimeSpan.Zero, sut.ElapsedForTest);
+    }
+
+
+
+    [Fact]
+    public async Task StartedAt_is_captured_once_extraction_has_produced_items()
+    {
+        var sut = new TimedExtractor(5);
+
+        await foreach (var _ in sut.ExtractAsync())
+        {
+        }
+
+        Assert.NotNull(sut.StartedAtForTest);
+        Assert.True(sut.ElapsedForTest >= System.TimeSpan.Zero);
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ReportTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ReportTests.cs
@@ -63,4 +63,140 @@ public class ReportTests
         var b = new Report(10);
         Assert.NotEqual(a, b);
     }
+
+
+
+    [Fact]
+    public void New_report_has_default_timing_and_throughput_values()
+    {
+        var sut = new Report(10);
+
+        Assert.Null(sut.StartedAt);
+        Assert.Equal(TimeSpan.Zero, sut.Elapsed);
+        Assert.Null(sut.TotalItemCount);
+        Assert.Equal(0d, sut.ItemsPerSecond);
+        Assert.Null(sut.PercentComplete);
+        Assert.Null(sut.EstimatedRemaining);
+    }
+
+
+
+    [Fact]
+    public void TotalItemCount_when_set_to_a_negative_value_throws_ArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Report(0) { TotalItemCount = -1 });
+    }
+
+
+
+    [Fact]
+    public void ItemsPerSecond_when_time_has_elapsed_is_count_divided_by_seconds()
+    {
+        var sut = new Report(10) { Elapsed = TimeSpan.FromSeconds(2) };
+
+        Assert.Equal(5d, sut.ItemsPerSecond);
+    }
+
+
+
+    [Fact]
+    public void ItemsPerSecond_when_no_time_has_elapsed_is_zero()
+    {
+        var sut = new Report(10) { Elapsed = TimeSpan.Zero };
+
+        Assert.Equal(0d, sut.ItemsPerSecond);
+    }
+
+
+
+    [Fact]
+    public void PercentComplete_when_total_is_known_is_the_fraction_done()
+    {
+        var sut = new Report(50) { TotalItemCount = 200 };
+
+        Assert.Equal(25d, sut.PercentComplete);
+    }
+
+
+
+    [Fact]
+    public void PercentComplete_when_count_exceeds_total_is_clamped_to_100()
+    {
+        var sut = new Report(150) { TotalItemCount = 100 };
+
+        Assert.Equal(100d, sut.PercentComplete);
+    }
+
+
+
+    [Fact]
+    public void PercentComplete_when_total_is_zero_is_100()
+    {
+        var sut = new Report(0) { TotalItemCount = 0 };
+
+        Assert.Equal(100d, sut.PercentComplete);
+    }
+
+
+
+    [Fact]
+    public void PercentComplete_when_total_is_unknown_is_null()
+    {
+        var sut = new Report(50);
+
+        Assert.Null(sut.PercentComplete);
+    }
+
+
+
+    [Fact]
+    public void EstimatedRemaining_when_total_and_throughput_are_known_projects_remaining_time()
+    {
+        // 50 of 100 done in 10s => 5 items/s => 50 remaining => 10s left.
+        var sut = new Report(50) { TotalItemCount = 100, Elapsed = TimeSpan.FromSeconds(10) };
+
+        Assert.Equal(TimeSpan.FromSeconds(10), sut.EstimatedRemaining);
+    }
+
+
+
+    [Fact]
+    public void EstimatedRemaining_when_count_has_reached_total_is_zero()
+    {
+        var sut = new Report(100) { TotalItemCount = 100, Elapsed = TimeSpan.FromSeconds(10) };
+
+        Assert.Equal(TimeSpan.Zero, sut.EstimatedRemaining);
+    }
+
+
+
+    [Fact]
+    public void EstimatedRemaining_when_total_is_unknown_is_null()
+    {
+        var sut = new Report(50) { Elapsed = TimeSpan.FromSeconds(10) };
+
+        Assert.Null(sut.EstimatedRemaining);
+    }
+
+
+
+    [Fact]
+    public void EstimatedRemaining_when_throughput_is_zero_is_null()
+    {
+        var sut = new Report(50) { TotalItemCount = 100, Elapsed = TimeSpan.Zero };
+
+        Assert.Null(sut.EstimatedRemaining);
+    }
+
+
+
+    [Fact]
+    public void StartedAt_and_Elapsed_round_trip_through_init()
+    {
+        var started = DateTimeOffset.UtcNow;
+        var sut = new Report(1) { StartedAt = started, Elapsed = TimeSpan.FromSeconds(3) };
+
+        Assert.Equal(started, sut.StartedAt);
+        Assert.Equal(TimeSpan.FromSeconds(3), sut.Elapsed);
+    }
 }


### PR DESCRIPTION
Adds timing and throughput metrics to `Report`. Closes #144 and #91.

**MINOR** (additive public API). The library is already released as v0.13.1, so this rolls into the next release as 0.14.0.

## `Report` — new members (snapshot semantics)
Producer-set (`init`): `StartedAt`, `Elapsed`, `TotalItemCount`.
Computed (derived from the snapshot, always internally consistent):
- `ItemsPerSecond` = `CurrentItemCount / Elapsed`
- `PercentComplete` — [0,100] when total known (clamped), else `null`
- `EstimatedRemaining` — projected from throughput when total known, `null` for unknown-size/infinite sources

Per #144's open question, timing is a **snapshot** captured at construction (consistent with `CurrentItemCount`), not a live-updating value.

## Base classes — automatic timing
`ExtractorBase` / `LoaderBase` / `TransformerBase` capture the start time on the first processed item and expose protected `StartedAt` + `Elapsed` (monotonic via `Stopwatch.GetTimestamp()`, cross-TFM). Derived `CreateProgressReport` implementations can surface them with zero per-package boilerplate — which was the core motivation in #144 (every downstream report was reinventing "how long has this run").

## Notes
- Internal `IsExternalInit` polyfill so the new `init` setters compile on net462/472/48/481 + netstandard2.0.
- `TotalItemCount` validates `>= 0`.
- `PublicAPI.Shipped.txt` regenerated (headless).
- Verified: full Release build clean across all TFMs (0 warnings); **231 tests pass** (15 new Report tests + 2 base-class timing tests).

Part of: Chris-Wolfgang/ETL-Abstractions#154
