### PR TITLE
chore: prep v0.14.0 release (version bump + changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.14.0] - 2026-06-24
+
+Adds timing/throughput reporting and resource-lifecycle management to the
+base classes. MINOR per SemVer — additions are source- and binary-additive,
+with one behavioral change (per-run counter reset) and one binary-sensitive
+addition: the base classes now implement `IDisposable`/`IAsyncDisposable`,
+so consumers that wrap a component in a `using` will now dispose it.
+
+### Added
+
+- `Report` now surfaces timing and throughput metrics: `StartedAt`,
+  `Elapsed`, `TotalItemCount`, `ItemsPerSecond`, `PercentComplete`, and
+  `EstimatedRemaining`. (#144, #91)
+- `ExtractorBase`, `LoaderBase`, and `TransformerBase` implement
+  `IAsyncDisposable` and `IDisposable`, with overridable `DisposeAsync()`,
+  `Dispose()`, and `Dispose(bool disposing)` so derived components can
+  release resources deterministically. (#92)
+- Protected `StartedAt` and `Elapsed` members on the three base classes,
+  populated automatically once the first item is processed. (#144)
+
+### Changed
+
+- Per-run counters and timing now reset at the start of each enumeration,
+  so a reused extractor, loader, or transformer reports the current run
+  rather than cumulative totals across runs. (#246)
+
 ## [0.13.1] - 2026-06-19
 
 Canonical maintenance round + binding-stability fix. No public API or

--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<TargetFrameworks>net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
-	<Version>0.13.1</Version>
+	<Version>0.14.0</Version>
 	<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 	     do not need to recompile / add binding redirects on every minor/patch
 	     bump. Bump only on a deliberate breaking API change. FileVersion +


### PR DESCRIPTION
## Summary

Prepares the **v0.14.0** release. Bumps `<Version>` `0.13.1` → `0.14.0` and fills in the CHANGELOG from the feature PRs already merged to `main` since v0.13.1.

## What 0.14.0 ships (already on main)
- **Report timing/throughput** — `StartedAt`, `Elapsed`, `TotalItemCount`, `ItemsPerSecond`, `PercentComplete`, `EstimatedRemaining` (#144, #91)
- **Per-run reset** — counters and timing reset at the start of each enumeration (#246)
- **`IDisposable` / `IAsyncDisposable`** on `ExtractorBase` / `LoaderBase` / `TransformerBase` (#92)

## Bump rationale
**MINOR.** All additions are source- and binary-additive. One behavioral change (per-run counter reset) and one binary-sensitive addition (base classes now implement `IDisposable`/`IAsyncDisposable`, so a consumer's `using` will now dispose the component) — both called out in the CHANGELOG header.

## Not included
- **#245 `DisposeStagesOnCompletion()`** is intentionally **excluded** — self-contained, opt-in, no other code depends on it. It will ship as its own release (0.15.0).
- #241 baseline regen / #242–#243 benchmarks are dev-infra, not consumer-facing — omitted from the CHANGELOG.

## After merge
`gh release create v0.14.0 --target main` (release.yaml fires on `release: published`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)