### PR TITLE
fix(docs): wire the version picker into the DocFX modern template

### DIFF
--- a/docfx_project/public/main.js
+++ b/docfx_project/public/main.js
@@ -1,0 +1,16 @@
+// DocFX's "modern" template automatically loads `public/main.js` on every
+// generated page — it is the one script file the template wires in by name.
+// Plain static resources under `public/` (such as the canonical version
+// picker, `version-picker.js`) are copied to the site but never referenced,
+// so on their own they never run.
+//
+// This file is the wire-up: it loads the version picker as a classic script
+// on every page. The picker itself is a framework-agnostic IIFE that ships
+// unchanged from the canonical repo-template, so we deliberately do NOT inline
+// it here — we just reference it. Resolving the URL via `import.meta.url`
+// keeps the path correct regardless of the page's directory depth or the
+// gh-pages repository prefix (e.g. `/ETL-Abstractions/public/`).
+const picker = document.createElement('script');
+picker.src = new URL('version-picker.js', import.meta.url).href;
+picker.async = true;
+document.head.appendChild(picker);


### PR DESCRIPTION
## Problem

The canonical `version-picker.js` ships under `docfx_project/public/` and is copied to the published site (`/ETL-Abstractions/public/version-picker.js` → 200), **but nothing ever loads it** — so the version dropdown never renders on any page.

Root cause: DocFX's `modern` template only auto-imports **`public/main.js`** (its `docfx.min.js` bundle does `import("./main.js")` at runtime as the user-customization hook). There was no `main.js`, so the picker JS just sat there unreferenced.

This is a **latent gap, not a v0.14.0 regression** — verified the v0.13.1 docs have the same `0` references. The asset has likely never actually rendered on any Wolfgang.* site.

## Fix

Adds `docfx_project/public/main.js` — the one file the template wires in by name. It loads the picker as a classic script, resolving the path via `import.meta.url` so it's correct regardless of page depth or the gh-pages repo prefix:

```js
const picker = document.createElement('script');
picker.src = new URL('version-picker.js', import.meta.url).href;
picker.async = true;
document.head.appendChild(picker);
```

The canonical IIFE picker keeps shipping **unchanged** from repo-template (not inlined here), so this stays fan-out-friendly.

## Verification (local, docfx 2.78.4)
- `_site/index.html` loads `<script type="module" src="./public/docfx.min.js">`
- `docfx.min.js` contains `import("./main.js")`
- `main.js` is emitted to `_site/public/main.js` with content intact
- It injects `public/version-picker.js`, whose IIFE reads `versions.json` (already correct on gh-pages, lists v0.14.0) and renders the dropdown

> Note: this is the same latent bug fleet-wide. After this merges I can fan the one-file fix to the other repos via the canonical repo-template if you want.

## Deploy after merge
`docfx.yaml` only runs on release / `workflow_dispatch` (not on push), so after merge I'll trigger it via `gh workflow run docfx.yaml` with the overlay option to rebuild and redeploy the live site (and optionally backfill older tags so their picker works too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)