### PR TITLE
chore: address code-review findings (docs accuracy + minor polish)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,13 @@ public class MyExtractor : ExtractorBase<string, Report>
 
     protected override Report CreateProgressReport()
     {
-        return new Report(CurrentItemCount);
+        // StartedAt/Elapsed are populated by the base class once the first
+        // item is processed; the Report derives ItemsPerSecond / EstimatedRemaining from them.
+        return new Report(CurrentItemCount)
+        {
+            StartedAt = StartedAt,
+            Elapsed = Elapsed,
+        };
     }
 }
 
@@ -105,6 +111,9 @@ is no new runtime behavior, no buffering, and no additional allocations per item
 | Async Streaming | Built on `IAsyncEnumerable<T>` for efficient, non-blocking data pipelines |
 | Fluent Pipeline | `Pipeline.Extract(...).Transform(...).Load(...).RunAsync()` with compile-time stage typing |
 | Progress Reporting | Built-in `IProgress<T>` support with configurable reporting intervals |
+| Throughput & ETA | `Report` exposes `StartedAt`, `Elapsed`, `ItemsPerSecond`, `PercentComplete`, and `EstimatedRemaining` derived from the item count and elapsed time |
+| Resource Disposal | Base classes implement `IDisposable` / `IAsyncDisposable`; override `Dispose(bool)` or `DisposeAsync()` to release resources deterministically |
+| Per-run State | Item counts and timing reset at the start of each enumeration, so a reused component reports the current run rather than cumulative totals |
 | Cancellation | Full `CancellationToken` support across all operations |
 | Multi-TFM | Targets .NET Framework 4.6.2–4.8.1, .NET Standard 2.0, and .NET 5.0–10.0 |
 | Skip & Limit | `SkipItemCount` and `MaximumItemCount` for partial extraction/loading |
@@ -206,7 +215,8 @@ cd docfx_project
 docfx metadata  # Extract API metadata from source code
 docfx build     # Build HTML documentation
 
-# Documentation is generated in the docs/ folder at the repository root
+# The generated site is written to docfx_project/_site/
+# (the release/docs workflow publishes it to the gh-pages branch)
 ```
 
 The documentation is automatically built and deployed to GitHub Pages when changes are pushed to the `main` branch.
@@ -222,7 +232,8 @@ docfx build --serve
 
 **Documentation Structure:**
 - `docfx_project/` - DocFX configuration and source files
-- `docs/` - Generated HTML documentation (published to GitHub Pages)
+- `docfx_project/_site/` - Generated HTML site (published to the `gh-pages` branch → GitHub Pages)
+- `docs/` - Supplementary markdown guides (formatting, release workflow, version picker, workflow security)
 - `docfx_project/index.md` - Main landing page content
 - `docfx_project/docs/` - Additional documentation articles
 - `docfx_project/api/` - Auto-generated API reference YAML files

--- a/src/Wolfgang.Etl.Abstractions/IExtractAsync.cs
+++ b/src/Wolfgang.Etl.Abstractions/IExtractAsync.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 namespace Wolfgang.Etl.Abstractions;
 
 /// <summary>
-/// Defines an asynchronous extractor interface for extracting data of type T. 
+/// Defines an asynchronous extractor interface for extracting data of type T.
 /// A class implementing this interface is intended to be the first step in an
-/// ETL (Extract, Transform, Load) process. 
+/// ETL (Extract, Transform, Load) process.
 /// </summary>
 /// <typeparam name="TSource">Represents a single item from the source of the ETL</typeparam>
 /// <remarks>

--- a/src/Wolfgang.Etl.Abstractions/IExtractWithCancellationAsync.cs
+++ b/src/Wolfgang.Etl.Abstractions/IExtractWithCancellationAsync.cs
@@ -4,9 +4,9 @@ using System.Threading;
 namespace Wolfgang.Etl.Abstractions;
 
 /// <summary>
-/// Defines an asynchronous extractor interface for extracting data of type T. 
+/// Defines an asynchronous extractor interface for extracting data of type T.
 /// A class implementing this interface is intended to be the first step in an
-/// ETL (Extract, Transform, Load) process. 
+/// ETL (Extract, Transform, Load) process.
 /// </summary>
 /// <typeparam name="TSource">Represents a single item from the source of the ETL</typeparam>
 /// <remarks>

--- a/src/Wolfgang.Etl.Abstractions/IExtractWithProgressAndCancellationAsync.cs
+++ b/src/Wolfgang.Etl.Abstractions/IExtractWithProgressAndCancellationAsync.cs
@@ -6,9 +6,9 @@ using System.Threading;
 namespace Wolfgang.Etl.Abstractions;
 
 /// <summary>
-/// Defines an asynchronous extractor interface for extracting data of type T. 
+/// Defines an asynchronous extractor interface for extracting data of type T.
 /// A class implementing this interface is intended to be the first step in an
-/// ETL (Extract, Transform, Load) process. 
+/// ETL (Extract, Transform, Load) process.
 /// </summary>
 /// <typeparam name="TSource">Represents a single item from the source of the ETL</typeparam>
 /// <typeparam name="TProgress">The value of the updated progress</typeparam>
@@ -40,7 +40,7 @@ public interface IExtractWithProgressAndCancellationAsync<out TSource, out TProg
     /// <param name="token">A CancellationToken to observe while waiting for the task to complete.</param>
     /// <returns>
     /// IAsyncEnumerable&lt;TSource&gt; - The result may be an empty sequence if no data is available or if the extraction fails.
-    /// </returns> 
+    /// </returns>
     /// <remarks>
     /// The extractor should be able to handle cancellation requests gracefully.
     /// If the caller doesn't plan on cancelling the extraction, they can pass CancellationToken.None.

--- a/src/Wolfgang.Etl.Abstractions/IExtractWithProgressAsync.cs
+++ b/src/Wolfgang.Etl.Abstractions/IExtractWithProgressAsync.cs
@@ -5,9 +5,9 @@ using System.Collections.Generic;
 namespace Wolfgang.Etl.Abstractions;
 
 /// <summary>
-/// Defines an asynchronous extractor interface for extracting data of type T. 
+/// Defines an asynchronous extractor interface for extracting data of type T.
 /// A class implementing this interface is intended to be the first step in an
-/// ETL (Extract, Transform, Load) process. 
+/// ETL (Extract, Transform, Load) process.
 /// </summary>
 /// <typeparam name="TSource">Represents a single item from the source of the ETL</typeparam>
 /// <typeparam name="TProgress">The value of the updated progress</typeparam>

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/AsyncDisposableTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/AsyncDisposableTests.cs
@@ -61,9 +61,14 @@ public class AsyncDisposableTests
     {
         var sut = new PlainExtractor();
 
-        // Should not throw.
+        // The default base implementation does nothing and must be safe to call
+        // repeatedly, in either form, without throwing or corrupting state.
+        await sut.DisposeAsync();
         await sut.DisposeAsync();
         sut.Dispose();
+        sut.Dispose();
+
+        Assert.Equal(0, sut.CurrentItemCount);
     }
 
 


### PR DESCRIPTION
## Summary

A full-repo code review of `main` found **no must-fix issues**. This PR actions the docs + style findings only. (The `Report.EstimatedRemaining` overflow behavior change has been **split into its own PR** so it gets reviewed on its own merits, not buried here.)

### Docs — should-fix (README)
- **`docs/` HTML claim corrected.** README said generated HTML lands in the `docs/` folder; it's actually written to `docfx_project/_site/` and published to the `gh-pages` branch. `docs/` holds supplementary markdown guides.
- **v0.14.0 features documented.** Added Features-table rows (throughput/ETA metrics, `IDisposable`/`IAsyncDisposable`, per-run reset); enriched the Quick Start to populate `Report.StartedAt`/`Elapsed`.

### Tests — nit
- **`Default_DisposeAsync_is_a_safe_no_op`** now has an explicit assertion and exercises idempotency (was relying solely on no-throw).

### Style — nit
- Stripped trailing whitespace from 4 `IExtract*` interface XML-doc lines.

## Validation
- All unit tests pass; all-TFM Release build clean.
- **No source or public API change** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)