### PR TITLE
fix: guard Report.EstimatedRemaining against TimeSpan overflow

### DIFF
--- a/src/Wolfgang.Etl.Abstractions/Report.cs
+++ b/src/Wolfgang.Etl.Abstractions/Report.cs
@@ -142,9 +142,17 @@ public record Report
             }
 
             var rate = ItemsPerSecond;
-            return rate > 0
-                ? TimeSpan.FromSeconds(remaining / rate)
-                : (TimeSpan?)null;
+            if (rate <= 0)
+            {
+                return null;
+            }
+
+            // Guard against TimeSpan.FromSeconds overflowing for a pathologically low
+            // rate (e.g. a single item after a very long elapsed time); clamp to TimeSpan.MaxValue.
+            var seconds = remaining / rate;
+            return seconds >= TimeSpan.MaxValue.TotalSeconds
+                ? TimeSpan.MaxValue
+                : TimeSpan.FromSeconds(seconds);
         }
     }
 }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ReportTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ReportTests.cs
@@ -191,6 +191,18 @@ public class ReportTests
 
 
     [Fact]
+    public void EstimatedRemaining_when_projection_overflows_is_clamped_to_max()
+    {
+        // 1 item in 30 days => a near-zero rate; projecting the remaining int.MaxValue
+        // items would exceed TimeSpan.MaxValue, so the estimate is clamped rather than throwing.
+        var sut = new Report(1) { TotalItemCount = int.MaxValue, Elapsed = TimeSpan.FromDays(30) };
+
+        Assert.Equal(TimeSpan.MaxValue, sut.EstimatedRemaining);
+    }
+
+
+
+    [Fact]
     public void StartedAt_and_Elapsed_round_trip_through_init()
     {
         var started = DateTimeOffset.UtcNow;


### PR DESCRIPTION
## ⚠️ Behavior change to a public property (split out of #254 for its own review)

Surfaced during the code review of `main`. This was originally bundled into the docs/polish PR (#254); pulled out here because it changes shipped behavior and deserves a focused look.

### The issue
`Report.EstimatedRemaining`'s getter computes `TimeSpan.FromSeconds(remaining / rate)`. For a pathologically low `rate` — e.g. **1 item processed** after a **multi-day `Elapsed`**, with a large `TotalItemCount` — `remaining / rate` exceeds `TimeSpan.MaxValue.TotalSeconds` (~9.2e14) and `TimeSpan.FromSeconds(...)` **throws `OverflowException`** straight out of the getter.

### The change
Clamp to `TimeSpan.MaxValue` instead of throwing.

```csharp
var rate = ItemsPerSecond;
if (rate <= 0) return null;

var seconds = remaining / rate;
return seconds >= TimeSpan.MaxValue.TotalSeconds
    ? TimeSpan.MaxValue
    : TimeSpan.FromSeconds(seconds);
```

### Design call for the reviewer
The trigger is near-unreachable in normal use, but a progress-estimate property arguably should never throw. Two reasonable resolutions:
- **Clamp to `TimeSpan.MaxValue`** (this PR) — "effectively forever"
- **Return `null`** — "can't estimate"

I went with clamp; say the word and I'll switch to `null`.

### Validation
- 250 unit tests pass (+1 overflow-clamp test)
- net10 Release build clean
- No public API surface change (no `PublicAPI.*` edits) — same signature, changed runtime behavior only

🤖 Generated with [Claude Code](https://claude.com/claude-code)