### PR TITLE
chore: prep v0.14.1 release (version bump + changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.14.1] - 2026-06-25
+
+Patch release: a robustness fix and documentation accuracy. No public API change.
+
+### Changed
+
+- **Docs** — README corrected: generated HTML is written to
+  `docfx_project/_site/` and published to the `gh-pages` branch (the `docs/`
+  folder holds supplementary markdown guides, not generated output). Added the
+  v0.14.0 `Report` timing/throughput, disposal, and per-run-reset capabilities
+  to the Features table and Quick Start. (#254)
+
+### Fixed
+
+- `Report.EstimatedRemaining` no longer throws `OverflowException` for a
+  pathologically low throughput (a single item after a very long elapsed time
+  with a large total); the projected estimate is clamped to
+  `TimeSpan.MaxValue`. (#255)
+
 ## [0.14.0] - 2026-06-24
 
 Adds timing/throughput reporting and resource-lifecycle management to the

--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<TargetFrameworks>net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
-	<Version>0.14.0</Version>
+	<Version>0.14.1</Version>
 	<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 	     do not need to recompile / add binding redirects on every minor/patch
 	     bump. Bump only on a deliberate breaking API change. FileVersion +


### PR DESCRIPTION
## Summary

Prepares the **v0.14.1** patch release. Bumps `<Version>` `0.14.0` → `0.14.1` and adds the CHANGELOG `[0.14.1]` entry.

## ⚠️ Merge order
This PR must merge **LAST**, after both content PRs are in `main`:
1. **#254** — docs accuracy + polish
2. **#255** — `Report.EstimatedRemaining` overflow fix
3. **this PR** (version bump + CHANGELOG)
4. then `gh release create v0.14.1 --target main`

## What 0.14.1 ships
- **Fixed** — `Report.EstimatedRemaining` no longer throws `OverflowException` for a pathologically low throughput; clamps to `TimeSpan.MaxValue`. (#255)
- **Changed (docs)** — README corrected (`docs/` vs generated `_site/`) + v0.14.0 features documented. (#254)

## Bump rationale
**PATCH.** No public API surface change — #255 is a runtime-behavior bug fix (same signature), #254 is docs only. `#245` (`DisposeStagesOnCompletion`, new API) is intentionally **excluded** and remains deferred to a future **0.15.0** MINOR.

## Notes
- CHANGELOG date is `2026-06-25` — verify it matches the actual tag date at release time.
- `release.yaml` fires on `release: published`, so `gh release create v0.14.1 --target main` both tags and triggers the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)