### PR TITLE
chore: prep v0.15.0 release (roll CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `ISupportDryRun` — an opt-in interface exposing `bool IsDryRun { get; set; }` for
-  ETL stages that support a dry run: the full pipeline is exercised but the external
-  side effect that mutates a destination or source is skipped. Implemented by the
-  stage that honours it (not by the base classes). (#259)
-
 ### Changed
 
 ### Deprecated
@@ -23,6 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.15.0] - 2026-06-28
+
+Minor release: adds an opt-in dry-run contract. No breaking change.
+
+### Added
+
+- `ISupportDryRun` — an opt-in interface exposing `bool IsDryRun { get; set; }` for
+  ETL stages that support a dry run: the full pipeline is exercised but the external
+  side effect that mutates a destination or source is skipped. Implemented by the
+  stage that honours it (not by the base classes). (#259)
 
 ## [0.14.1] - 2026-06-25
 


### PR DESCRIPTION
## Summary

Rolls the CHANGELOG for the **v0.15.0** release: moves the `ISupportDryRun` (#259) entry from `[Unreleased]` into a dated `[0.15.0] - 2026-06-28` section, matching the release-prep convention used for prior versions (e.g. v0.14.1).

Version was already bumped to `0.15.0` in #260; this is documentation-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
