### PR TITLE
fix(docs): version-picker shows selected option on /versions/latest/

### DIFF
--- a/docfx_project/public/version-picker.js
+++ b/docfx_project/public/version-picker.js
@@ -49,38 +49,14 @@
     }
 
     function renderPicker(versions) {
-        // Detect the currently-viewed version from the URL.
+        // Detect the currently-viewed version from the URL. Defaults to
+        // 'latest' — the user landed on the site root or a page that
+        // isn't under /versions/<v>/, so the picker treats them as being
+        // on the latest-alias page.
         var currentVersion = 'latest';
         var m = window.location.pathname.match(/\/versions\/([^\/]+)(?:\/|$)/);
         if (m) {
             currentVersion = m[1];
-        }
-
-        // If we're on /versions/latest/, resolve 'latest' to the concrete
-        // version it points to (matching the `latest` entry's url against
-        // the versioned entries). Without this resolution, the browser
-        // auto-selects the first option in the dropdown — which is usually
-        // the same concrete version 'latest' aliases — and picking that
-        // option doesn't fire `change`, leaving the user unable to navigate
-        // away from /versions/latest/ to the equivalent concrete-version
-        // URL via the picker.
-        if (currentVersion === 'latest') {
-            var latestEntry = null;
-            for (var i = 0; i < versions.length; i++) {
-                if (versions[i] && versions[i].version === 'latest') {
-                    latestEntry = versions[i];
-                    break;
-                }
-            }
-            if (latestEntry && latestEntry.url) {
-                for (var j = 0; j < versions.length; j++) {
-                    var v = versions[j];
-                    if (v && v.version !== 'latest' && v.url === latestEntry.url) {
-                        currentVersion = v.version;
-                        break;
-                    }
-                }
-            }
         }
 
         // Build the <select>.
@@ -113,12 +89,14 @@
         var optionCount = 0;
         versions.forEach(function (v) {
             if (!v || !v.version || !v.url) return;
-            // Skip the "latest" alias — the highest-numbered v* entry
-            // already represents the latest release; surfacing both is
-            // redundant in the picker. versions.json keeps the "latest"
-            // entry so other consumers (links, scripts) can still
-            // resolve it.
-            if (v.version === 'latest') return;
+            // Skip the "latest" alias EXCEPT when the reader is actually
+            // on /versions/latest/. On every other page the highest-
+            // numbered v* entry already represents the latest release
+            // and surfacing both is redundant; on /versions/latest/ we
+            // NEED `latest` in the list because otherwise the picker
+            // would show no selected option and the reader would have
+            // no way to know which version they are viewing.
+            if (v.version === 'latest' && currentVersion !== 'latest') return;
             var opt = document.createElement('option');
             opt.value = v.url;
             opt.textContent = v.version;

--- a/docfx_project/public/version-picker.js
+++ b/docfx_project/public/version-picker.js
@@ -49,11 +49,14 @@
     }
 
     function renderPicker(versions) {
-        // Detect the currently-viewed version from the URL. Defaults to
-        // 'latest' — the user landed on the site root or a page that
-        // isn't under /versions/<v>/, so the picker treats them as being
-        // on the latest-alias page.
-        var currentVersion = 'latest';
+        // Detect the currently-viewed version from the URL. Only a
+        // /versions/<v>/ path names a concrete version; the literal
+        // /versions/latest/ alias yields 'latest'. Anywhere else (site
+        // root, unversioned pages) currentVersion stays null so the
+        // 'latest' alias is NOT surfaced and the browser auto-selects the
+        // highest v* entry — matching the intent that 'latest' appears in
+        // the picker only on /versions/latest/.
+        var currentVersion = null;
         var m = window.location.pathname.match(/\/versions\/([^\/]+)(?:\/|$)/);
         if (m) {
             currentVersion = m[1];


### PR DESCRIPTION
## Summary

Fan-out of [Try-Pattern PR #247](https://github.com/Chris-Wolfgang/Try-Pattern/pull/247). The version-picker JS had a dead URL-match resolution block that tried to match the `latest` alias URL (`/<repo>/versions/latest/`) against concrete version URLs (`/<repo>/versions/vX.Y.Z/`) — structurally different by construction, so the match NEVER succeeded. The render loop then unconditionally skipped the `latest` entry, leaving no option selected on `/versions/latest/`.

**Fix:** delete the dead resolution block; keep `latest` as a first-class option ONLY when the reader is on `/versions/latest/`. On concrete-version pages the skip still applies — no redundant `latest + vX.Y.Z` pair.

Same patch, same file. Direct fan-out of Try-Pattern's canonical.

## Verification

Try-Pattern PR verified via HTML harness across 4 URL cases; change event fires and navigates correctly. See [Try-Pattern #247](https://github.com/Chris-Wolfgang/Try-Pattern/pull/247) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)