### PR TITLE
ci(pr): make InspectCode solution discovery robust under errexit

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -370,16 +370,23 @@ jobs:
 
       - name: Run InspectCode
         run: |
-          # Find a solution to inspect. Prefer .slnx (new format) then .sln.
-          # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
-          SLN=$(ls *.slnx 2>/dev/null | head -n1)
-          if [ -z "$SLN" ]; then
-            SLN=$(ls *.sln 2>/dev/null | head -n1)
-          fi
-          if [ -z "$SLN" ]; then
+          # Global dotnet tools install under ~/.dotnet/tools; make sure `jb`
+          # resolves regardless of whether that dir is already on PATH.
+          export PATH="$HOME/.dotnet/tools:$PATH"
+          # Find a solution to inspect, preferring .slnx (new format) over .sln.
+          # Use nullglob + array expansion instead of parsing `ls`: a glob with
+          # no match expands to nothing rather than failing, so this is correct
+          # under the step's `set -e -o pipefail` shell by construction — no `ls`
+          # exit-2 to swallow, and no blanket `|| true` that would also hide a
+          # genuine failure. Listing *.slnx before *.sln keeps any .slnx ahead
+          # of a .sln in the array, so ${solutions[0]} is a .slnx when one exists.
+          shopt -s nullglob
+          solutions=(*.slnx *.sln)
+          if [ ${#solutions[@]} -eq 0 ]; then
             echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
             exit 1
           fi
+          SLN="${solutions[0]}"
           echo "Inspecting: $SLN"
           jb inspectcode "$SLN" \
             --output=inspect.sarif \


### PR DESCRIPTION
## The blocker
#267 merged the InspectCode job into `main` at 16:04. Because pr.yaml runs via `pull_request_target`, every open PR now runs InspectCode *from main* — and it fails at the **"Run InspectCode"** step with **exit code 2, before `jb` even starts** (the build step passes). #245 and every other open PR are blocked on this.

## Root cause
GitHub's `shell: bash` runs with `-e -o pipefail`. The step picked a solution by parsing `ls`:
```bash
SLN=$(ls *.slnx 2>/dev/null | head -n1)
```
This repo has `ETL-Abstractions.sln` but **no `.slnx`**, so `ls *.slnx` exits 2 → `pipefail` propagates it → `set -e` aborts the whole step **before the `.sln` fallback runs**. This breaks InspectCode on **every repo that has only a `.sln`** (i.e. essentially all of them).

It slipped through because InspectCode `needs: detect-projects`, and on #267's own PR the protected-file guard failed that job, so InspectCode was *skipped* and never actually executed before #267 was bypass-merged.

## Fix
Rather than band-aid the `ls` pipeline with `|| true` (which would also mask genuine failures), replace the `ls`-parsing with **`nullglob` + array expansion**:
```bash
shopt -s nullglob
solutions=(*.slnx *.sln)
if [ ${#solutions[@]} -eq 0 ]; then
  echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
  exit 1
fi
SLN="${solutions[0]}"
```
A non-matching glob expands to nothing instead of failing, so discovery is correct under `errexit`/`pipefail` **by construction** — no `ls` exit-2 to trip on. Listing `*.slnx` before `*.sln` keeps `.slnx` preferred. Also puts `~/.dotnet/tools` on `PATH` so the `jb` global tool resolves.

Verified in a local `bash -e -o pipefail` harness across all four cases: only-`.sln`, only-`.slnx`, both (`.slnx` wins), and neither (fails loudly, exit 1).

## Merge note
This touches `.github/workflows/pr.yaml` (a protected file), so **Detect .NET Projects will fail by design** — it's the only expected failure. Needs an **admin-bypass merge**. Once merged, I'll re-run InspectCode on #245 (and the other open PRs) to confirm green.

The same bug exists in the canonical repo-template; I'll fold this fix into the open feed-back PR #439.
