### PR TITLE
test: rename EtlPipelineTests class (fix MA0049 blocking #278)

### DIFF
--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.EtlPipelineTests;
 
-public class EtlPipelineTests
+public class EtlPipelineCoreTests
 {
     private static async IAsyncEnumerable<T> AsyncSource<T>(params T[] items)
     {


### PR DESCRIPTION
The single InspectCode **error** on vNext (and therefore on #278 vNext→main) is **MA0049** — the test class `EtlPipelineTests` matches its namespace segment `…Tests.Unit.EtlPipelineTests`. Rename it to `EtlPipelineCoreTests`; namespace and file unchanged. One-line change, 25 EtlPipeline tests pass.

Note: an earlier PR of mine (#282's intended content) that also did this rename got superseded — #282 merged a divergent commit, so the rename never reached vNext. This applies it directly off current vNext.

Merge → vNext → #278 re-runs → InspectCode passes.

Separately: `From` on vNext is still an **instance** method (draws non-blocking S2325 warnings). The extension conversion we discussed didn't land either — let me know if you still want it before 0.16.0.