### PR TITLE
refactor: EtlPipeline.From as extension method (clear S2325)

### DIFF
--- a/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipeline.cs
+++ b/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipeline.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 
 
@@ -7,10 +6,10 @@ namespace Wolfgang.Etl.Abstractions;
 
 /// <summary>
 /// Entry point for building a generic, format-agnostic ETL pipeline. Obtain a fresh builder with
-/// <see cref="Create"/>, start from a source — either a built-in <see cref="From{T}(IAsyncEnumerable{T})"/> /
-/// <see cref="From{T, TProgress}(ExtractorBase{T, TProgress})"/> factory, or a format-specific factory
-/// hung off the <see cref="EtlPipeline"/> instance by a format package — chain append transformer stages
-/// on <see cref="IEtlPipeline{T}"/>, terminate with a sink, then call
+/// <see cref="Create"/>, start from a source — either a built-in <c>From</c> factory (see
+/// <see cref="EtlPipelineSourceExtensions"/>) or a format-specific factory hung off the
+/// <see cref="EtlPipeline"/> instance by a format package — append transformer stages on
+/// <see cref="IEtlPipeline{T}"/>, terminate with a sink, then call
 /// <see cref="IEtlPipelineSink.RunAsync(IProgress{EtlPipelineProgress}, CancellationToken)"/>.
 /// </summary>
 /// <remarks>
@@ -21,8 +20,8 @@ namespace Wolfgang.Etl.Abstractions;
 /// </para>
 /// <para>
 /// <see cref="Create"/> returns a fresh <see cref="EtlPipeline"/> seed: it carries no data itself and
-/// exists to give source factories a strongly-typed receiver. Format packages extend the instance with
-/// class-named factories — for example a CSV package adds
+/// exists to give source factories a strongly-typed receiver. The built-in <c>From</c> factories and
+/// any format-package factories are extension methods on this type — for example a CSV package adds
 /// <c>public static ICsvExtractorBuilder&lt;T&gt; CsvExtractor&lt;T&gt;(this EtlPipeline pipeline, string path)</c>,
 /// enabling <c>EtlPipeline.Create().CsvExtractor&lt;Order&gt;("orders.csv")</c>.
 /// </para>
@@ -54,46 +53,4 @@ public sealed class EtlPipeline
     /// </summary>
     /// <returns>A fresh builder instance.</returns>
     public static EtlPipeline Create() => new();
-
-
-    /// <summary>
-    /// Begins a pipeline from an existing asynchronous stream — the generic escape hatch for any
-    /// source the caller already has as an <see cref="IAsyncEnumerable{T}"/>.
-    /// </summary>
-    /// <typeparam name="T">The type of item produced by the source.</typeparam>
-    /// <param name="source">The stream that seeds the pipeline.</param>
-    /// <returns>An <see cref="IEtlPipeline{T}"/> for chaining.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-    public IEtlPipeline<T> From<T>(IAsyncEnumerable<T> source)
-        where T : notnull
-    {
-        if (source is null)
-        {
-            throw new ArgumentNullException(nameof(source));
-        }
-
-        return EtlPipelineImpl<T>.FromStream((_, _) => source);
-    }
-
-
-    /// <summary>
-    /// Begins a pipeline from an <see cref="ExtractorBase{TSource, TProgress}"/>. The pipeline's
-    /// cancellation token is forwarded to the extractor.
-    /// </summary>
-    /// <typeparam name="T">The type of item produced by the extractor.</typeparam>
-    /// <typeparam name="TProgress">The extractor's progress-report type.</typeparam>
-    /// <param name="extractor">The extractor that seeds the pipeline.</param>
-    /// <returns>An <see cref="IEtlPipeline{T}"/> for chaining.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="extractor"/> is <see langword="null"/>.</exception>
-    public IEtlPipeline<T> From<T, TProgress>(ExtractorBase<T, TProgress> extractor)
-        where T : notnull
-        where TProgress : notnull
-    {
-        if (extractor is null)
-        {
-            throw new ArgumentNullException(nameof(extractor));
-        }
-
-        return EtlPipelineImpl<T>.FromStream((_, token) => extractor.ExtractAsync(token));
-    }
 }

--- a/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipelineSourceExtensions.cs
+++ b/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipelineSourceExtensions.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+
+
+namespace Wolfgang.Etl.Abstractions;
+
+/// <summary>
+/// Built-in source factories for <see cref="EtlPipeline"/>. They begin a pipeline from a raw stream or
+/// an extractor. Format packages add their own class-named source factories (for example
+/// <c>CsvExtractor</c>) as extension methods on <see cref="EtlPipeline"/> alongside these, so every
+/// source reads the same way: <c>EtlPipeline.Create().Xxx(...)</c>.
+/// </summary>
+public static class EtlPipelineSourceExtensions
+{
+    /// <summary>
+    /// Begins a pipeline from an existing asynchronous stream — the generic escape hatch for any
+    /// source the caller already has as an <see cref="IAsyncEnumerable{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of item produced by the source.</typeparam>
+    /// <param name="pipeline">The builder returned by <see cref="EtlPipeline.Create"/>.</param>
+    /// <param name="source">The stream that seeds the pipeline.</param>
+    /// <returns>An <see cref="IEtlPipeline{T}"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+    public static IEtlPipeline<T> From<T>(this EtlPipeline pipeline, IAsyncEnumerable<T> source)
+        where T : notnull
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        return EtlPipelineImpl<T>.FromStream((_, _) => source);
+    }
+
+
+    /// <summary>
+    /// Begins a pipeline from an <see cref="ExtractorBase{TSource, TProgress}"/>. The pipeline's
+    /// cancellation token is forwarded to the extractor.
+    /// </summary>
+    /// <typeparam name="T">The type of item produced by the extractor.</typeparam>
+    /// <typeparam name="TProgress">The extractor's progress-report type.</typeparam>
+    /// <param name="pipeline">The builder returned by <see cref="EtlPipeline.Create"/>.</param>
+    /// <param name="extractor">The extractor that seeds the pipeline.</param>
+    /// <returns>An <see cref="IEtlPipeline{T}"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="extractor"/> is <see langword="null"/>.</exception>
+    public static IEtlPipeline<T> From<T, TProgress>(this EtlPipeline pipeline, ExtractorBase<T, TProgress> extractor)
+        where T : notnull
+        where TProgress : notnull
+    {
+        if (extractor is null)
+        {
+            throw new ArgumentNullException(nameof(extractor));
+        }
+
+        return EtlPipelineImpl<T>.FromStream((_, token) => extractor.ExtractAsync(token));
+    }
+}

--- a/src/Wolfgang.Etl.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.Abstractions/PublicAPI.Shipped.txt
@@ -8,6 +8,8 @@ Wolfgang.Etl.Abstractions.EtlPipelineProgress.RecordsExtracted.get -> int
 Wolfgang.Etl.Abstractions.EtlPipelineProgress.RecordsExtracted.init -> void
 Wolfgang.Etl.Abstractions.EtlPipelineProgress.RecordsLoaded.get -> int
 Wolfgang.Etl.Abstractions.EtlPipelineProgress.RecordsLoaded.init -> void
+Wolfgang.Etl.Abstractions.EtlPipelineSinkExtensions
+Wolfgang.Etl.Abstractions.EtlPipelineSourceExtensions
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.CurrentItemCount.get -> int
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.CurrentSkippedItemCount.get -> int
@@ -142,9 +144,10 @@ abstract Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.CreatePro
 abstract Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.LoadWorkerAsync(System.Collections.Generic.IAsyncEnumerable<TDestination>! items, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
 abstract Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.CreateProgressReport() -> TProgress
 abstract Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.TransformWorkerAsync(System.Collections.Generic.IAsyncEnumerable<TSource>! items, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<TDestination>!
-Wolfgang.Etl.Abstractions.EtlPipeline.From<T, TProgress>(Wolfgang.Etl.Abstractions.ExtractorBase<T, TProgress>! extractor) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
-Wolfgang.Etl.Abstractions.EtlPipeline.From<T>(System.Collections.Generic.IAsyncEnumerable<T>! source) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
 static Wolfgang.Etl.Abstractions.EtlPipeline.Create() -> Wolfgang.Etl.Abstractions.EtlPipeline!
+static Wolfgang.Etl.Abstractions.EtlPipelineSinkExtensions.DisposingOwned(this Wolfgang.Etl.Abstractions.IEtlPipelineSink! sink, params object![]! ownedResources) -> Wolfgang.Etl.Abstractions.IEtlPipelineSink!
+static Wolfgang.Etl.Abstractions.EtlPipelineSourceExtensions.From<T, TProgress>(this Wolfgang.Etl.Abstractions.EtlPipeline! pipeline, Wolfgang.Etl.Abstractions.ExtractorBase<T, TProgress>! extractor) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
+static Wolfgang.Etl.Abstractions.EtlPipelineSourceExtensions.From<T>(this Wolfgang.Etl.Abstractions.EtlPipeline! pipeline, System.Collections.Generic.IAsyncEnumerable<T>! source) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
 static Wolfgang.Etl.Abstractions.Pipeline.Extract<TSource, TProgress>(Wolfgang.Etl.Abstractions.IExtractWithProgressAndCancellationAsync<TSource, TProgress>! extractor) -> Wolfgang.Etl.Abstractions.IExtractStageWithProgress<TSource, TProgress>!
 static Wolfgang.Etl.Abstractions.Pipeline.Extract<TSource, TProgress>(Wolfgang.Etl.Abstractions.IExtractWithProgressAsync<TSource, TProgress>! extractor) -> Wolfgang.Etl.Abstractions.IExtractStageWithProgress<TSource, TProgress>!
 static Wolfgang.Etl.Abstractions.Pipeline.Extract<TSource>(Wolfgang.Etl.Abstractions.IExtractAsync<TSource>! extractor) -> Wolfgang.Etl.Abstractions.IExtractStage<TSource>!
@@ -170,5 +173,3 @@ virtual Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgre
 virtual Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.TransformAsync(System.Collections.Generic.IAsyncEnumerable<TSource>! items, System.IProgress<TProgress>! progress) -> System.Collections.Generic.IAsyncEnumerable<TDestination>!
 virtual Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.TransformAsync(System.Collections.Generic.IAsyncEnumerable<TSource>! items, System.IProgress<TProgress>! progress, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<TDestination>!
 virtual Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.TransformAsync(System.Collections.Generic.IAsyncEnumerable<TSource>! items, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<TDestination>!
-Wolfgang.Etl.Abstractions.EtlPipelineSinkExtensions
-static Wolfgang.Etl.Abstractions.EtlPipelineSinkExtensions.DisposingOwned(this Wolfgang.Etl.Abstractions.IEtlPipelineSink! sink, params object![]! ownedResources) -> Wolfgang.Etl.Abstractions.IEtlPipelineSink!


### PR DESCRIPTION
Redo of the From→extension conversion, now on top of current vNext (post-#283).

Moves both `From` overloads out of `EtlPipeline` into a new `EtlPipelineSourceExtensions` static class as `this EtlPipeline` extension methods. **Bodies verbatim; `Create().From(...)` unchanged.** Extension methods are static → clears the two **S2325** warnings, and `From` now matches the format-package source-factory shape. Ships 0.16.0 without the instance-`From` binary-break lock-in.

`Through`/`To`/`AsAsyncEnumerable` untouched (real interface instance methods). `PublicAPI.Shipped.txt` updated. src clean all TFMs (0 warnings), 282 tests pass, Example8 (both TFMs) builds.

Merge → vNext → then #278 (vNext→main) carries it → 0.16.0.