### PR TITLE
ci(release): NuGet trusted publishing (OIDC) instead of stored API key

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -672,6 +672,9 @@ jobs:
     needs: [pack-and-validate, verify-docs-build]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
+    permissions:
+      id-token: write  # OIDC token for NuGet trusted publishing (no stored API key)
+      contents: read
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -691,22 +694,16 @@ jobs:
           name: nuget-packages
           path: ./packages
 
-      - name: Validate NuGet API key
-        shell: pwsh
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: |
-          if ([string]::IsNullOrEmpty($env:NUGET_API_KEY)) {
-            Write-Error "❌ NUGET_API_KEY secret not configured!"
-            Write-Host "Please add it in: Repository Settings → Secrets and variables → Actions → New repository secret"
-            exit 1
-          }
-          Write-Host "✅ NUGET_API_KEY is configured" -ForegroundColor Green
+      - name: NuGet login (OIDC trusted publishing)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: Chris-Wolfgang
 
       - name: Publish to NuGet
         shell: pwsh
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
           $packages = Get-ChildItem -Path './packages' -Filter '*.nupkg' -ErrorAction SilentlyContinue
           


### PR DESCRIPTION
Switches `release.yaml`'s publish step from the stored `NUGET_API_KEY` to **NuGet trusted publishing** via GitHub OIDC — the fix for what killed the v0.16.0 publish (403 expired key).

**Changes (publish-nuget job only):**
- Adds `permissions: id-token: write` (mints the OIDC token).
- Replaces the `Validate NuGet API key` + key-based push with a `NuGet/login@v1` step (`user: Chris-Wolfgang`) that returns a short-lived key, used by the existing `dotnet nuget push`.
- No stored, expiring secret in the publish path anymore.

**Requires (you, on nuget.org):** a trusted-publisher policy — Repository owner `Chris-Wolfgang`, Repository `ETL-Abstractions`, Workflow `release.yaml`, Environment blank, package `Wolfgang.Etl.Abstractions` (or `Wolfgang.Etl.*`). Once live, you can delete the `NUGET_API_KEY` secret.

**Merge note:** touches the protected `release.yaml`, so `Detect .NET Projects` fails by design — this is a protected-file **admin-bypass** merge. Only affects the *next* release; 0.16.0 already shipped.

Closes #272
