### PR TITLE
build: gitleaks Linux arm64 arch selection in build-pr.ps1

### DIFF
--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -295,18 +295,13 @@ if (-not $SkipSecurity) {
             $env:PATH = "$dest;$env:PATH"
         }
         else {
-            # gitleaks ships separate darwin / linux builds, and on macOS we
-            # also have to pick between x64 (Intel) and arm64 (Apple Silicon).
-            # Without this branch the macOS path would download the Linux
-            # tarball and either fail to install or install an incompatible
-            # binary.
-            if ($IsMacOS) {
-                $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
-                $archive = "gitleaks_${version}_darwin_${arch}.tar.gz"
-            }
-            else {
-                $archive = "gitleaks_${version}_linux_x64.tar.gz"
-            }
+            # gitleaks ships separate per-OS, per-arch builds. Select BOTH from
+            # the running runtime so this works on x64 and arm64 for macOS AND
+            # Linux (Apple Silicon, AWS Graviton, ARM CI runners) — hard-coding
+            # linux_x64 installs an incompatible binary on ARM64 Linux.
+            $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
+            $os = if ($IsMacOS) { 'darwin' } else { 'linux' }
+            $archive = "gitleaks_${version}_${os}_${arch}.tar.gz"
             $url = "https://github.com/gitleaks/gitleaks/releases/download/v${version}/$archive"
             # Install to a user-writable location instead of /usr/local/bin
             # (which would require sudo for most local dev shells). $HOME/.local/bin


### PR DESCRIPTION
Fixes #270. The non-Windows gitleaks install in `scripts/build-pr.ps1` hard-coded `linux_x64`; #269 added the macOS arch branch but left the Linux path x64-only, so ARM64 Linux (Graviton / ARM CI runners) installs an incompatible binary.

Refactor to compute **both** OS and arch from the runtime:
```powershell
$arch = if ([RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
$os   = if ($IsMacOS) { 'darwin' } else { 'linux' }
$archive = "gitleaks_${version}_${os}_${arch}.tar.gz"
```
Covers all four assets: `darwin_x64`, `darwin_arm64`, `linux_x64`, `linux_arm64`. Script parses clean; all four combos verified to produce the correct asset name.

`build-pr.ps1` is not a protected file, so normal CI (no bypass). Canonical file — worth feeding back to repo-template as a follow-up.