### PR TITLE
ci: cross-platform / ARM64 differential (#209)

### DIFF
--- a/.github/workflows/cross-platform-differential.yaml
+++ b/.github/workflows/cross-platform-differential.yaml
@@ -1,0 +1,111 @@
+name: Cross-Platform Differential
+
+# Cross-platform / multi-arch differential (#209).
+#
+# pr.yaml already runs the suite on Linux/Windows/macOS and requires it to *pass*
+# on each. This workflow verifies it passes the SAME WAY on each — including
+# ARM64, which pr.yaml does not cover. Each runner produces a normalized list of
+# "test name -> outcome"; the diff job fails if any platform's list diverges from
+# the linux-x64 reference (catching a test that passes on x64 but behaves
+# differently on arm64: culture sorts, line endings, timing, FS case).
+
+on:
+  schedule:
+    - cron: '30 6 * * 1'   # weekly, Monday 06:30 UTC
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - vNext
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/cross-platform-differential.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-platform-differential-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    name: Test ${{ matrix.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-latest,    label: linux-x64 }
+          - { runner: ubuntu-24.04-arm, label: linux-arm64 }
+          - { runner: macos-latest,     label: macos-arm64 }
+          - { runner: windows-latest,   label: windows-x64 }
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run tests (net10.0)
+        shell: bash
+        # Do not fail here — a failing/diverging test must reach the diff job,
+        # where a *difference* between platforms is the real signal.
+        run: |
+          dotnet test tests/Wolfgang.Etl.Abstractions.Tests.Unit/Wolfgang.Etl.Abstractions.Tests.Unit.csproj \
+            -c Release -f net10.0 \
+            --logger "trx;LogFileName=results.trx" \
+            --results-directory trx || true
+
+      - name: Normalize outcomes
+        shell: bash
+        run: |
+          python scripts/normalize-trx.py trx "outcomes-${{ matrix.label }}.txt"
+
+      - name: Upload outcomes
+        uses: actions/upload-artifact@v7
+        with:
+          name: outcomes-${{ matrix.label }}
+          path: outcomes-${{ matrix.label }}.txt
+
+  diff:
+    name: Diff outcomes across platforms
+    needs: run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all outcomes
+        uses: actions/download-artifact@v8.0.1
+        with:
+          path: outcomes
+
+      - name: Compare against linux-x64
+        run: |
+          ref="outcomes/outcomes-linux-x64/outcomes-linux-x64.txt"
+          if [ ! -f "$ref" ]; then
+            echo "::error::reference outcomes (linux-x64) missing"
+            exit 1
+          fi
+          fail=0
+          for dir in outcomes/outcomes-*/; do
+            file=$(find "$dir" -name 'outcomes-*.txt' | head -n1)
+            label=$(basename "$dir" | sed 's/^outcomes-//')
+            if ! diff -u "$ref" "$file" > "diff-$label.txt"; then
+              echo "::error::Test outcomes on $label diverge from linux-x64:"
+              cat "diff-$label.txt"
+              fail=1
+            else
+              echo "✅ $label matches linux-x64"
+            fi
+          done
+          exit $fail

--- a/scripts/normalize-trx.py
+++ b/scripts/normalize-trx.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Normalize VSTest .trx output to a sorted, platform-independent list of
+"test name<TAB>outcome" lines, for the cross-platform differential (#209).
+
+Usage: python scripts/normalize-trx.py <trx-dir> <output-file>
+
+Only the test name and outcome are emitted — durations, machine names, and
+timestamps are intentionally excluded so the list is identical across platforms
+when behaviour is identical.
+"""
+import glob
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+NS = "{http://microsoft.com/schemas/VisualStudio/TeamTest/2010}"
+
+
+def main(trx_dir: str, out_file: str) -> None:
+    rows = []
+    for path in glob.glob(os.path.join(trx_dir, "**", "*.trx"), recursive=True):
+        tree = ET.parse(path)
+        for result in tree.iter(NS + "UnitTestResult"):
+            rows.append(f"{result.get('testName')}\t{result.get('outcome')}")
+
+    rows.sort()
+    with open(out_file, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write("\n".join(rows))
+        handle.write("\n")
+
+    print(f"wrote {len(rows)} outcomes to {out_file}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: normalize-trx.py <trx-dir> <output-file>", file=sys.stderr)
+        sys.exit(2)
+    main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
Thorough-review item **#209**, ported from ETL-FixedWidth (adapted to the Abstractions test project).

Runs the net10.0 suite across **linux-x64 / linux-arm64 / macos-arm64 / windows-x64**, normalizes each run to a sorted `test name → outcome` list (`scripts/normalize-trx.py` — strips durations/machine/timestamps, writes LF explicitly to avoid the Windows CRLF stdout issue), and **fails if any platform diverges** from the linux-x64 reference. Catches arm64-only behaviour (culture sorts, line endings, timing, FS case) that pr.yaml's per-platform pass/fail gate can't. Runs weekly + on src/tests PRs.

Closes #209. `normalize-trx.py` is not protected; the workflow file is → `Detect .NET Projects` fails by design (handled at vNext→main).