### PR TITLE
test: CsCheck property-based fuzz suite (#196)

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,0 +1,77 @@
+name: Fuzz
+
+# Continuous fuzz sweep (#196). The unit suite runs the same CsCheck properties
+# at ~1000 cases per PR (seconds); this scheduled workflow runs them at a far
+# higher case count to surface rare edge cases, and auto-files an issue if a
+# property is falsified. CsCheck prints a replayable seed on failure, so the
+# reported case can be pinned as a deterministic regression in the unit suite.
+
+on:
+  schedule:
+    - cron: '0 5 * * 0'   # weekly, Sunday 05:00 UTC
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: 'Cases per property'
+        required: false
+        default: '1000000'
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Property fuzz sweep
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write   # auto-file an issue when a property is falsified
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Run fuzz sweep
+        id: fuzz
+        env:
+          FUZZ_ITER: ${{ github.event.inputs.iterations || '1000000' }}
+        run: |
+          set -o pipefail
+          dotnet test tests/Wolfgang.Etl.Abstractions.Tests.Fuzz/Wolfgang.Etl.Abstractions.Tests.Fuzz.csproj \
+            -c Release --logger "console;verbosity=detailed" 2>&1 | tee fuzz-output.txt
+
+      - name: Upload fuzz log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-output
+          path: fuzz-output.txt
+          retention-days: 30
+
+      - name: File issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # CsCheck prints a replayable seed in the failure output; the issue body
+          # carries the log tail so the seed can be pinned as a regression.
+          {
+            echo "The scheduled fuzz sweep falsified a property."
+            echo ""
+            echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo ""
+            echo '```'
+            tail -c 4000 fuzz-output.txt || true
+            echo '```'
+          } > issue-body.txt
+          gh issue create \
+            --title "Fuzz sweep falsified a property ($(date -u +%Y-%m-%d))" \
+            --label bug \
+            --body-file issue-body.txt

--- a/ETL-Abstractions.sln
+++ b/ETL-Abstractions.sln
@@ -91,6 +91,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example8-EtlPipeline", "exa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example8-EtlPipeline", "examples\Net4.8\Example8-EtlPipeline\Example8-EtlPipeline.csproj", "{B59B4926-9CDD-41C2-A367-42F030DFAF54}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wolfgang.Etl.Abstractions.Tests.Fuzz", "tests\Wolfgang.Etl.Abstractions.Tests.Fuzz\Wolfgang.Etl.Abstractions.Tests.Fuzz.csproj", "{8F775698-9B29-40AB-A02E-A72A9B073040}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -377,6 +379,18 @@ Global
 		{B59B4926-9CDD-41C2-A367-42F030DFAF54}.Release|x64.Build.0 = Release|Any CPU
 		{B59B4926-9CDD-41C2-A367-42F030DFAF54}.Release|x86.ActiveCfg = Release|Any CPU
 		{B59B4926-9CDD-41C2-A367-42F030DFAF54}.Release|x86.Build.0 = Release|Any CPU
+		{8F775698-9B29-40AB-A02E-A72A9B073040}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F775698-9B29-40AB-A02E-A72A9B073040}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F775698-9B29-40AB-A02E-A72A9B073040}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8F775698-9B29-40AB-A02E-A72A9B073040}.Debug|x64.Build.0 = Debug|Any CPU
+		{8F775698-9B29-40AB-A02E-A72A9B073040}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8F775698-9B29-40AB-A02E-A72A9B073040}.Debug|x86.Build.0 = Debug|Any CPU
+		{8F775698-9B29-40AB-A02E-A72A9B073040}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F775698-9B29-40AB-A02E-A72A9B073040}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F775698-9B29-40AB-A02E-A72A9B073040}.Release|x64.ActiveCfg = Release|Any CPU
+		{8F775698-9B29-40AB-A02E-A72A9B073040}.Release|x64.Build.0 = Release|Any CPU
+		{8F775698-9B29-40AB-A02E-A72A9B073040}.Release|x86.ActiveCfg = Release|Any CPU
+		{8F775698-9B29-40AB-A02E-A72A9B073040}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -409,6 +423,7 @@ Global
 		{F26156B5-9FDC-46CA-9152-F888932238E1} = {336D72A1-8E5E-49DE-83D9-DF6BE458BA24}
 		{F97582DD-F8D7-4BA0-B46E-20B7200ADC74} = {3C48157B-5E90-489E-9444-E01F51D59F86}
 		{B59B4926-9CDD-41C2-A367-42F030DFAF54} = {336D72A1-8E5E-49DE-83D9-DF6BE458BA24}
+		{8F775698-9B29-40AB-A02E-A72A9B073040} = {8220BC33-6632-4D4C-9A50-B7978141A4E3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F673635D-58CE-48A5-9AE4-31F4484BED9E}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Fuzz/EtlPipelineFuzzTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Fuzz/EtlPipelineFuzzTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CsCheck;
+using Xunit;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Fuzz;
+
+/// <summary>
+/// Property-based fuzz tests (#196) over the generic <see cref="EtlPipeline"/> core:
+/// a source of arbitrary length flows to the sink preserving order and count, a
+/// <c>Through</c> map is applied elementwise, and progress counts both ends
+/// (extracted at the source, loaded at the sink).
+/// </summary>
+public class EtlPipelineFuzzTests
+{
+    // Each case spins up async pipeline machinery, so cap the per-property count —
+    // the pure Report properties carry the deep sweep cheaply.
+    private static long Iterations
+    {
+        get
+        {
+            var n = long.TryParse(Environment.GetEnvironmentVariable("FUZZ_ITER"), out var v) && v > 0 ? v : 1000;
+            return Math.Min(n, 20_000);
+        }
+    }
+
+
+    private static readonly Gen<int[]> Source = Gen.Int[-1_000_000, 1_000_000].Array[0, 64];
+
+
+    [Fact]
+    public void From_To_delivers_the_source_in_order_and_counts_both_ends()
+    {
+        Source.Sample(
+            items =>
+            {
+                var loader = new CollectingLoader<int>();
+                EtlPipelineProgress? last = null;
+                var progress = new InlineProgress<EtlPipelineProgress>(p => last = p);
+
+                EtlPipeline
+                    .Create()
+                    .From(AsyncSeq(items))
+                    .To(loader)
+                    .RunAsync(progress)
+                    .GetAwaiter()
+                    .GetResult();
+
+                Assert.Equal(items, loader.Loaded);
+                Assert.NotNull(last);
+                Assert.Equal(items.Length, last!.RecordsExtracted);
+                Assert.Equal(items.Length, last.RecordsLoaded);
+            },
+            iter: Iterations);
+    }
+
+
+    [Fact]
+    public void Through_map_is_applied_elementwise_preserving_order()
+    {
+        Source.Sample(
+            items =>
+            {
+                var loader = new CollectingLoader<long>();
+
+                EtlPipeline
+                    .Create()
+                    .From(AsyncSeq(items))
+                    .Through(new MapTransformer<int, long>(x => (long)x * 2 + 1))
+                    .To(loader)
+                    .RunAsync()
+                    .GetAwaiter()
+                    .GetResult();
+
+                Assert.Equal(items.Select(x => (long)x * 2 + 1), loader.Loaded);
+            },
+            iter: Iterations);
+    }
+
+
+    private static async IAsyncEnumerable<T> AsyncSeq<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Fuzz/ReportFuzzTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Fuzz/ReportFuzzTests.cs
@@ -1,0 +1,95 @@
+using System;
+using CsCheck;
+using Xunit;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Fuzz;
+
+/// <summary>
+/// Property-based fuzz tests (#196) over <see cref="Report"/>'s derived metrics.
+/// The throughput/completion estimates are pure functions of the snapshot inputs
+/// (<c>CurrentItemCount</c>, <c>Elapsed</c>, <c>TotalItemCount</c>), so a report is
+/// internally consistent for any inputs. Case count is <c>FUZZ_ITER</c> (default
+/// 1000 per PR); fuzz.yaml raises it for the deep sweep. On failure CsCheck shrinks
+/// to a minimal case and prints a replayable seed.
+/// </summary>
+public class ReportFuzzTests
+{
+    private static long Iterations =>
+        long.TryParse(Environment.GetEnvironmentVariable("FUZZ_ITER"), out var n) && n > 0
+            ? n
+            : 1000;
+
+
+    // (currentItemCount, elapsedSeconds, totalItemCount-or-null)
+    private static readonly Gen<(int Current, double Elapsed, int? Total)> Inputs =
+        Gen.Select(
+            Gen.Int[0, int.MaxValue],
+            Gen.Double[0.0, 1_000_000.0],
+            Gen.Bool,
+            Gen.Int[0, int.MaxValue],
+            (current, elapsed, hasTotal, total) => (current, elapsed, hasTotal ? (int?)total : null));
+
+
+    [Fact]
+    public void Report_metrics_are_internally_consistent()
+    {
+        Inputs.Sample(
+            input =>
+            {
+                var (current, elapsedSeconds, total) = input;
+
+                var report = new Report(current)
+                {
+                    Elapsed = TimeSpan.FromSeconds(elapsedSeconds),
+                    TotalItemCount = total,
+                };
+
+                // Throughput is never negative.
+                Assert.True(report.ItemsPerSecond >= 0d);
+
+                if (total is null)
+                {
+                    // Completion estimates require a known total.
+                    Assert.Null(report.PercentComplete);
+                    Assert.Null(report.EstimatedRemaining);
+                }
+                else
+                {
+                    // Percentage is always clamped to [0, 100].
+                    Assert.NotNull(report.PercentComplete);
+                    Assert.InRange(report.PercentComplete!.Value, 0d, 100d);
+
+                    // Once the count reaches the total, nothing remains.
+                    if (current >= total.Value)
+                    {
+                        Assert.Equal(TimeSpan.Zero, report.EstimatedRemaining);
+                    }
+                }
+
+                // When an estimate is produced, it is never negative.
+                if (report.EstimatedRemaining is { } remaining)
+                {
+                    Assert.True(remaining >= TimeSpan.Zero);
+                }
+            },
+            iter: Iterations);
+    }
+
+
+    [Fact]
+    public void Report_ctor_rejects_negative_count()
+    {
+        Gen.Int[int.MinValue, -1].Sample(
+            n => Assert.Throws<ArgumentOutOfRangeException>(() => new Report(n)),
+            iter: Iterations);
+    }
+
+
+    [Fact]
+    public void Report_TotalItemCount_rejects_negative()
+    {
+        Gen.Int[int.MinValue, -1].Sample(
+            n => Assert.Throws<ArgumentOutOfRangeException>(() => new Report(0) { TotalItemCount = n }),
+            iter: Iterations);
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Fuzz/TestDoubles.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Fuzz/TestDoubles.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Fuzz;
+
+/// <summary>Collects every record delivered to it, for asserting pipeline output.</summary>
+internal sealed class CollectingLoader<T> : LoaderBase<T, Report>
+    where T : notnull
+{
+    public List<T> Loaded { get; } = new();
+
+
+    protected override async Task LoadWorkerAsync(IAsyncEnumerable<T> items, CancellationToken token)
+    {
+        await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+        {
+            Loaded.Add(item);
+            IncrementCurrentItemCount();
+        }
+    }
+
+
+    protected override Report CreateProgressReport()
+    {
+        return new Report(CurrentItemCount);
+    }
+}
+
+
+/// <summary>Elementwise projecting transformer, for exercising <c>Through</c>.</summary>
+internal sealed class MapTransformer<TSource, TDestination> : ITransformAsync<TSource, TDestination>
+    where TSource : notnull
+    where TDestination : notnull
+{
+    private readonly Func<TSource, TDestination> _map;
+
+
+    public MapTransformer(Func<TSource, TDestination> map)
+    {
+        _map = map;
+    }
+
+
+    public async IAsyncEnumerable<TDestination> TransformAsync(IAsyncEnumerable<TSource> items)
+    {
+        await foreach (var item in items.ConfigureAwait(false))
+        {
+            yield return _map(item);
+        }
+    }
+}
+
+
+/// <summary>Synchronous <see cref="IProgress{T}"/> so the final snapshot is captured before assertions.</summary>
+internal sealed class InlineProgress<T> : IProgress<T>
+{
+    private readonly Action<T> _callback;
+
+
+    public InlineProgress(Action<T> callback)
+    {
+        _callback = callback;
+    }
+
+
+    public void Report(T value) => _callback(value);
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Fuzz/Wolfgang.Etl.Abstractions.Tests.Fuzz.csproj
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Fuzz/Wolfgang.Etl.Abstractions.Tests.Fuzz.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Fuzz explores input space, not per-TFM runtime behaviour, so a single
+         modern TFM keeps the suite fast. CsCheck itself targets netstandard2.0. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Abstractions\Wolfgang.Etl.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CsCheck" Version="4.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+</Project>


### PR DESCRIPTION
Thorough-review item **#196**, structured after ETL-FixedWidth's fuzz suite but with Abstractions-specific properties.

**New project** `Wolfgang.Etl.Abstractions.Tests.Fuzz` (net10.0, CsCheck 4.7.0), in the solution so the test stages run it per-PR at **1000 cases**:
- **Report metrics** (pure functions of the snapshot inputs): `ItemsPerSecond >= 0`; `PercentComplete` null iff no total, else clamped to [0,100]; `EstimatedRemaining` null-or-non-negative and `Zero` once the count reaches the total; ctor + `TotalItemCount` reject negatives.
- **EtlPipeline invariants**: `From(source).To(loader)` delivers the source in order with `RecordsExtracted == RecordsLoaded == count`; `Through(map)` applies elementwise preserving order.

**`fuzz.yaml`** runs the sweep weekly at **1,000,000 cases** and auto-files a bug (with the replayable CsCheck seed) on falsification.

**Verified:** green locally at 1000 and 50,000 cases; builds clean under Release (warnings-as-errors); `dotnet restore` on the solution succeeds.

Closes #196. Adds `fuzz.yaml` (protected) → `Detect .NET Projects` fails by design (handled at vNext→main).