### PR TITLE
ci: OSSF Scorecard supply-chain security (#222)

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,52 @@
+name: Scorecard supply-chain security
+
+# OSSF Scorecard (#222): scores the repository's security posture (branch
+# protection, pinned dependencies, dangerous-workflow patterns, token
+# permissions, ...) against ~20 best practices and uploads the result to the
+# code-scanning / Security tab. Distinct from CodeQL — Scorecard grades the repo
+# *configuration*, not the source code. publish_results powers the README badge.
+
+on:
+  # Re-score when branch-protection rules change (a common posture regression).
+  branch_protection_rule:
+  schedule:
+    - cron: '20 7 * * 1'   # weekly, Monday 07:20 UTC
+  push:
+    branches:
+      - main
+
+# Top-level least privilege; the analysis job opts into exactly what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload the SARIF result to code-scanning
+      id-token: write          # publish to the OpenSSF API (badge + transparency log)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the OpenSSF transparency log so the README badge resolves.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Thorough-review item **#222**, ported verbatim from ETL-FixedWidth's `scorecard.yaml` (repo-agnostic — grades repo config, not source).

Runs OSSF Scorecard weekly + on branch-protection changes, scoring ~20 posture best-practices (branch protection, pinned deps, dangerous-workflow patterns, token permissions). Uploads SARIF to Code Scanning and publishes to the OpenSSF transparency log (README badge). Least-privilege `read-all` top-level; analysis job opts into `security-events: write` + `id-token: write`. `scorecard-action` is SHA-pinned.

Closes #222. Adds a protected `.github/workflows/*.yaml` → `Detect .NET Projects` fails by design (handled at vNext→main).