### PR TITLE
ci: transitive-dependency license audit (#218)

### DIFF
--- a/.github/license/allowed-licenses.json
+++ b/.github/license/allowed-licenses.json
@@ -1,0 +1,7 @@
+[
+  "MIT",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "MS-PL"
+]

--- a/.github/license/license-url-mappings.json
+++ b/.github/license/license-url-mappings.json
@@ -1,0 +1,4 @@
+{
+  "http://go.microsoft.com/fwlink/?LinkId=329770": "MIT",
+  "https://github.com/dotnet/standard/blob/master/LICENSE.TXT": "MIT"
+}

--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -1,0 +1,57 @@
+name: License Audit
+
+# Transitive-dependency license audit (#218). Dependabot tracks dependency
+# versions and CVEs but not the *licenses* of transitive packages — a new
+# transitive dep under an incompatible license (GPL/AGPL/OSL/source-available)
+# would silently leak into this MIT-licensed package. This job enumerates every
+# transitive package and fails on any license outside the documented allowlist.
+#
+# Allowlist:            .github/license/allowed-licenses.json
+# License-URL mappings: .github/license/license-url-mappings.json
+# Ignored (build-only): SonarAnalyzer.CSharp (SONAR source-available; PrivateAssets=all,
+#                       never distributed to consumers).
+
+on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+  schedule:
+    - cron: '30 7 * * 1'   # weekly, Monday 07:30 UTC
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: License audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+
+      - name: Install nuget-license
+        run: |
+          dotnet tool install --global nuget-license
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Audit transitive licenses
+        run: |
+          nuget-license \
+            -i src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj \
+            -t \
+            -a .github/license/allowed-licenses.json \
+            -mapping .github/license/license-url-mappings.json \
+            -ignore SonarAnalyzer.CSharp \
+            -o Table


### PR DESCRIPTION
Thorough-review item **#218**, ported from ETL-FixedWidth.

`nuget-license` enumerates every **transitive** package and fails on any license outside the allowlist (`MIT`/`Apache-2.0`/`BSD-2-Clause`/`BSD-3-Clause`/`MS-PL`) — catching a source-available/GPL transitive dep silently leaking into this MIT package (Dependabot tracks versions/CVEs, not licenses). Config in `.github/license/` (allowlist + URL mappings for the older Microsoft `licenseUrl` packages); `SonarAnalyzer.CSharp` ignored (build-only, `PrivateAssets=all`).

**Verified locally:** all 15 transitive packages resolve to MIT/Apache-2.0 via the allowlist + 2 URL mappings — audit exits 0.

Closes #218. The two JSON configs aren't protected; the workflow file is → `Detect .NET Projects` fails by design (handled at vNext→main).