### PR TITLE
docs: Architecture Decision Records (docs/adr/) (#220)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,6 +233,11 @@ View the complete configuration in [.editorconfig](.editorconfig).
 - Reference related issues in your pull request description.
 - Keep changes focused and atomic - one feature/fix per PR.
 - Update documentation if you change public APIs.
+- If your change makes a non-obvious design decision (a trade-off a future
+  maintainer would otherwise re-derive), add an Architecture Decision Record in
+  [`docs/adr/`](docs/adr/index.md) in the same PR — copy
+  [`TEMPLATE.md`](docs/adr/TEMPLATE.md) and add a row to the index. See
+  [ADR-0001](docs/adr/0001-record-architecture-decisions.md) for the practice.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 - **GitHub Repository:** [https://github.com/Chris-Wolfgang/ETL-Abstractions](https://github.com/Chris-Wolfgang/ETL-Abstractions)
 - **API Documentation:** https://Chris-Wolfgang.github.io/ETL-Abstractions/
 - **Formatting Guide:** [README-FORMATTING.md](docs/README-FORMATTING.md)
+- **Architecture Decisions:** [docs/adr/](docs/adr/index.md) — the *why* behind non-obvious design choices
 - **Contributing Guide:** [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ---

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,47 @@
+# ADR 0001 — Record architecture decisions
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Deciders:** Chris Wolfgang
+
+## Context
+
+`Wolfgang.Etl.Abstractions` carries a number of design choices that are not
+obvious from the code and not recoverable from the type signatures — why the
+generic pipeline's operators live in a *different* package, why the entry point
+is an extension method rather than an instance method, why `<AssemblyVersion>` is
+frozen at `1.0.0.0`. Six months after the PR that introduced each one, the
+rationale is gone: the commit message is terse, the PR discussion is buried, and
+the next maintainer (often the same person) re-derives the trade-off from scratch,
+sometimes landing on a different answer and regressing the original intent.
+
+## Decision
+
+We will keep short **Architecture Decision Records** under `docs/adr/`, one file
+per non-obvious decision, using [Michael Nygard's format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions):
+Context / Decision / Alternatives / Consequences. Each ADR is immutable once
+Accepted — a reversal is a *new* ADR that supersedes the old one, and the old one
+is marked `Superseded by` rather than deleted, so the history of the thinking
+survives.
+
+New decisions land **in the same PR** as the code that implements them, so the ADR
+is part of the review rather than an afterthought.
+
+## Alternatives considered
+
+- **Wiki / external doc site** — drifts out of sync with the code because it is
+  not versioned alongside it and is not part of the PR review.
+- **Long XML-doc comments on the types** — good for *how to use* an API, poor for
+  *why the API is shaped this way*; they also can't capture cross-cutting or
+  rejected-alternative reasoning that spans multiple types.
+- **Nothing (status quo)** — the rationale keeps evaporating; this ADR exists
+  precisely because that cost is real.
+
+## Consequences
+
+- Every reviewer of a non-trivial design PR now expects an accompanying ADR; this
+  is a small, deliberate tax on such PRs.
+- The `docs/adr/` folder becomes the canonical answer to "why is it like this?"
+  and the first place to look before changing a load-bearing decision.
+- ADRs are retroactive where useful: the initial set (0002–0008) documents choices
+  made before this practice began.

--- a/docs/adr/0002-etlpipeline-core-in-abstractions-operators-in-transformers.md
+++ b/docs/adr/0002-etlpipeline-core-in-abstractions-operators-in-transformers.md
@@ -1,0 +1,55 @@
+# ADR 0002 — EtlPipeline core lives in Abstractions; operators live in Transformers
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Deciders:** Chris Wolfgang
+
+## Context
+
+The generic `EtlPipeline` (issue #147) is a format-agnostic builder:
+`Create().From(source).Through(stage).To(loader).RunAsync()`. The natural next
+question is where the *operators* — `Where`, `Select`, `Distinct`, `Take`,
+`Buffer`, … — should live. The first implementation put the full LINQ-style
+operator surface directly on the pipeline in this package.
+
+That was wrong for a structural reason: the companion package
+`Wolfgang.Etl.Transformers` **already ships** those operators as transformers
+(`WhereTransformer<T>`, `SelectTransformer<TIn,TOut>`, …), and its dependency
+arrow points *at* Abstractions (`Transformers → Abstractions`). Abstractions
+therefore cannot reference Transformers to reuse them. Re-implementing the
+operators in the core would create a **third** copy of the same logic (after
+`System.Linq.Async` and `ETL-Transformers`), with three places to fix a bug.
+
+## Decision
+
+We will keep only the **plumbing** in Abstractions — `From`, `Through`, `To`,
+`AsAsyncEnumerable` — and provide the **operators** in `Wolfgang.Etl.Transformers`
+as extension methods over `Through`, reusing the transformers that package already
+owns. **Format factories** (`CsvExtractor<T>`, sink terminators) live in the
+individual format packages, again as extension methods. This is "Option B" from
+the #147 discussion.
+
+The layering is: `EtlPipeline.Create().From(...)` (Abstractions) →
+`.Where(...).Select(...)` (Transformers) → `.To(...)` /
+`.CsvLoader(...)` (format packages).
+
+## Alternatives considered
+
+- **Operators in the core (Option A)** — rejected: forces a third reimplementation
+  of `Where`/`Select`/… and couples the format-agnostic core to LINQ semantics it
+  doesn't need.
+- **Move the transformers down into Abstractions** — rejected: Abstractions is the
+  dependency root; pulling concrete transformers into it inverts the intended
+  layering and bloats the base package every consumer takes.
+
+## Consequences
+
+- The core stays small and has no operator surface of its own; `Through` is the
+  single extension seam that both Transformers and format packages build on.
+- Operator extensions are gated on Abstractions **0.16.0+** being published
+  (tracked as ETL-Transformers #150) — downstream work waits on the core shipping.
+- A caller who wants `Where`/`Select` must reference `Wolfgang.Etl.Transformers`;
+  the core alone gives them `Through` with an explicit transformer or delegate.
+- See [ADR-0004](0004-etlpipelineprogress-extracted-loaded-elapsed.md): because the
+  core never sees per-record operator decisions, its progress model reports only
+  extracted/loaded counts.

--- a/docs/adr/0003-from-as-extension-method.md
+++ b/docs/adr/0003-from-as-extension-method.md
@@ -1,0 +1,58 @@
+# ADR 0003 — `EtlPipeline.Create().From()` with `From` as an extension method
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Deciders:** Chris Wolfgang
+
+## Context
+
+The generic pipeline's entry point reads `EtlPipeline.Create().From(source)`.
+`Create()` is a static factory on the `sealed class EtlPipeline` (private ctor),
+returning an instance so that *source factories* from format packages can hang off
+it uniformly — `Create().CsvExtractor<T>(...)`, `Create().From(...)`, all as
+`this EtlPipeline` extensions.
+
+The question was how to declare `From` itself. It has three plausible shapes, and
+each has a specific compiler or compatibility problem:
+
+- An **instance method** `From` never touches `this` (it just wraps the argument in
+  a new pipeline node), so the analyzer flags **S2325 "make static."**
+- A **plain static method** clears S2325 but then `Create().From(...)` fails to
+  compile — **CS0176**, "cannot access static member through an instance."
+- Shipping `From` as an instance method now and converting it to static later
+  would be a **binary-breaking change** for `net462`/`netstandard` consumers.
+
+## Decision
+
+We will declare `From` as a **static extension method** on `EtlPipeline` (in
+`EtlPipelineSourceExtensions`). An extension method is static under the hood — so
+it clears S2325 — yet is invoked with instance syntax, so `Create().From(...)`
+compiles and reads naturally. It also sidesteps the binary-break trap: extension
+methods are resolved at the call site and carry no instance-vs-static ABI lock-in.
+
+Format-package source factories follow the same `this EtlPipeline` extension
+pattern, giving every source a uniform `Create().Xxx(...)` shape.
+
+The downstream builder methods — `Through`, `To`, `AsAsyncEnumerable` — stay
+**interface instance methods** on `IEtlPipeline<T>`, because they genuinely use the
+node's `_factory` state (no S2325 there).
+
+## Alternatives considered
+
+- **Instance `From`** — rejected: draws S2325 and, once shipped, locks in an ABI
+  that a later "make static" refactor would break.
+- **Plain static `From`** — rejected: breaks the `Create().From()` call shape
+  (CS0176).
+- **A static `EtlPipeline.From(...)` without `Create()`** — rejected: format
+  packages need an *instance* to hang source factories off of, so the surface would
+  be inconsistent (`From` static, `CsvExtractor` instance).
+
+## Consequences
+
+- `From` lives in a separate `EtlPipelineSourceExtensions` class, not on
+  `EtlPipeline` — a reader looking at the `EtlPipeline` class alone won't see it;
+  this ADR is the pointer.
+- The pattern is now the template every format package copies for its own source
+  factories, keeping `Create().Xxx()` uniform across the ecosystem.
+- `Through`/`To`/`AsAsyncEnumerable` remaining instance methods is deliberate and
+  not an inconsistency — they hold state; `From` and the source factories do not.

--- a/docs/adr/0004-etlpipelineprogress-extracted-loaded-elapsed.md
+++ b/docs/adr/0004-etlpipelineprogress-extracted-loaded-elapsed.md
@@ -1,0 +1,48 @@
+# ADR 0004 — `EtlPipelineProgress` reports extracted / loaded / elapsed only
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Deciders:** Chris Wolfgang
+
+## Context
+
+`EtlPipeline.RunAsync` accepts an `IProgress<EtlPipelineProgress>`. An earlier
+draft of the progress record carried richer counters — `RecordsFiltered` and
+`RecordsErrored` alongside extracted/loaded — on the assumption the pipeline could
+report how many records each stage dropped or failed.
+
+Once operators moved out of the core ([ADR-0002](0002-etlpipeline-core-in-abstractions-operators-in-transformers.md)),
+that assumption broke. The core no longer sees per-record operator decisions: a
+`Where` that filters a record is an opaque transformer stage from the pipeline's
+point of view. The only two points the core observes every record are the
+**source** (where it counts what's extracted) and the **sink** (where it counts
+what's loaded). "Filtered" and "errored" are semantics only a specific transformer
+knows, and the core can't populate them honestly.
+
+## Decision
+
+We will make `EtlPipelineProgress` a record of exactly three fields —
+`RecordsExtracted` (counted at the source), `RecordsLoaded` (counted at the sink),
+and `Elapsed` — and nothing the core cannot measure directly. A field the pipeline
+cannot fill accurately is worse than an absent field: it invites callers to trust
+a number that is always zero or wrong.
+
+## Alternatives considered
+
+- **Keep `RecordsFiltered` / `RecordsErrored`** — rejected: after Option B the core
+  cannot populate them; they would report 0 regardless of what transformers did,
+  which is actively misleading.
+- **Have transformers push their own counters up into the progress record** —
+  rejected: requires every transformer to know about `EtlPipelineProgress`,
+  coupling the operator layer to the core's reporting type. Per-stage progress is
+  the fluent `Pipeline`'s job, not the generic `EtlPipeline`'s.
+
+## Consequences
+
+- The progress snapshot is honest and cheap: two counters the core owns end-to-end,
+  plus elapsed time, independent of how many stages sit between source and sink.
+- Callers who need per-stage or per-record diagnostics use the fluent `Pipeline`
+  API (per-stage `IProgress<T>`) or an explicit transformer that reports its own
+  metrics.
+- The counters are currently `int`; widening them to `long` for very large runs is
+  tracked as follow-up #285 and would be a deliberate, separate decision.

--- a/docs/adr/0005-name-etlpipeline-not-pipeline.md
+++ b/docs/adr/0005-name-etlpipeline-not-pipeline.md
@@ -1,0 +1,42 @@
+# ADR 0005 — Name the generic builder `EtlPipeline`, not `Pipeline`
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Deciders:** Chris Wolfgang
+
+## Context
+
+The package already ships a fluent builder named `Pipeline` —
+`Pipeline.Extract(extractor).Transform(t).Load(loader).RunAsync()` — which starts
+from a *typed extractor* and offers per-stage progress and options
+(`.WithProgress`, `.WithName`, `.DisposeStagesOnCompletion`). The new generic,
+format-agnostic builder (#147) starts from *any* source and is designed to be
+extended by other packages. "Pipeline" is the obvious name for it too — but it is
+taken, and both types live in the same namespace (`Wolfgang.Etl.Abstractions`).
+
+## Decision
+
+We will name the generic builder **`EtlPipeline`** and leave `Pipeline` as the
+fluent Extract/Transform/Load builder. The two coexist deliberately: they serve
+different call sites, and the `Etl` prefix distinguishes the generic, extensible
+one without forcing a namespace split or renaming the established `Pipeline`.
+
+## Alternatives considered
+
+- **Rename the existing `Pipeline`** — rejected: it is public, shipped, and used;
+  renaming it is a source-breaking change to save the newer type a prefix.
+- **Put the generic builder in a sub-namespace and call it `Pipeline`** — rejected:
+  two `Pipeline` types resolvable in nearby code is a `using`-ordering foot-gun and
+  a documentation hazard; the prefix is cheaper than the ambiguity.
+- **A more elaborate name (`GenericPipeline`, `EtlFlow`)** — rejected: `EtlPipeline`
+  is the least surprising given the package name and reads well at the call site.
+
+## Consequences
+
+- Two builder types ship side by side; the docs (the getting-started guide carries
+  a "`Pipeline` vs `EtlPipeline`" comparison table) must keep steering readers to
+  the right one — `Pipeline` when you hold discrete typed stages and want per-stage
+  progress, `EtlPipeline` for cross-format flows and the operator/format-package
+  extensions.
+- Related naming stays consistent under the prefix: `EtlPipelineProgress`,
+  `IEtlPipeline<T>`, `IEtlPipelineSink`, `EtlPipelineSourceExtensions`.

--- a/docs/adr/0006-sequential-reverse-order-stage-disposal.md
+++ b/docs/adr/0006-sequential-reverse-order-stage-disposal.md
@@ -1,0 +1,48 @@
+# ADR 0006 — Dispose pipeline stages sequentially, in reverse construction order
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Deciders:** Chris Wolfgang
+
+## Context
+
+`Pipeline.DisposeStagesOnCompletion()` disposes each stage the pipeline owns once
+the run finishes, so short-lived stages the call site created don't each need their
+own `using`. Two questions arise: in what **order** should stages be disposed, and
+should disposal run **concurrently** to shave wall-clock time? A pipeline can hold
+an extractor, several transformers, and a loader — some `IAsyncDisposable`, some
+`IDisposable`, some neither — and a downstream stage may transitively hold a
+resource owned by an upstream stage (e.g. a transformer wrapping the extractor's
+reader).
+
+## Decision
+
+We will dispose stages **sequentially, in reverse construction order** (loader →
+transformers → extractor), matching the LIFO convention of nested
+`using`/`await using` blocks and DI-container scope disposal. A downstream stage is
+torn down before the upstream stage whose resources it may reference. Disposal
+prefers `IAsyncDisposable` over `IDisposable`, skips stages that are neither,
+continues past any failure, and aggregates the failures into an
+`AggregateException`. If the run itself threw, that exception is the primary signal
+and is rethrown unchanged; disposal still runs regardless.
+
+## Alternatives considered
+
+- **Parallel disposal** (`Task.WhenAll` over the stages) — rejected: correctness of
+  shared-resource teardown order outweighs the marginal wall-clock saving. Disposing
+  an upstream stage's resource while a downstream stage still holds it is a
+  use-after-dispose hazard, and it also collides with this project's ban on
+  synchronous parallel primitives (see [ADR-0008](0008-ban-synchronous-parallel-apis.md)).
+- **Forward (construction) order** — rejected: tears down upstream resources first,
+  the opposite of the `using`-nesting guarantee callers expect.
+- **Stop at the first disposal failure** — rejected: would leak the remaining
+  stages' resources; disposing all of them and aggregating is safer.
+
+## Consequences
+
+- Teardown order is predictable and matches `using`-block intuition, which is what
+  a caller reaching for `DisposeStagesOnCompletion()` is implicitly relying on.
+- Disposal is single-threaded and slightly slower than a parallel teardown would
+  be; this is an accepted trade for correctness.
+- A stage that throws on dispose does not prevent its siblings from being disposed;
+  callers see an `AggregateException` unless the run's own exception takes priority.

--- a/docs/adr/0007-pin-assemblyversion.md
+++ b/docs/adr/0007-pin-assemblyversion.md
@@ -1,0 +1,46 @@
+# ADR 0007 — Pin `<AssemblyVersion>` at `1.0.0.0`
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Deciders:** Chris Wolfgang
+
+## Context
+
+The package version moves on every release (`0.13.0`, `0.16.0`, …). On .NET
+Framework, the CLR binds strongly-named references by **assembly version**: if
+`AssemblyVersion` tracked the package version, every release would change it, and
+every consumer would need a `bindingRedirect` in `app.config` to load the new
+build in place of the one they compiled against. That is a notorious source of
+"could not load file or assembly … version mismatch" failures for library
+consumers, especially in the `net462`/`net47x`/`net48` targets this package
+supports.
+
+`AssemblyVersion`, `FileVersion`, and `InformationalVersion` are three separate
+knobs: only `AssemblyVersion` participates in binding; the other two are metadata.
+
+## Decision
+
+We will pin `<AssemblyVersion>` to a fixed `1.0.0.0` binding-stability baseline and
+let the moving version numbers live on the metadata knobs: `FileVersion` is derived
+from `<Version>` (stripped of any pre-release suffix, with a `.0` revision) and
+`InformationalVersion` carries the full `<Version>`. `AssemblyVersion` bumps **only**
+on a deliberate breaking API change — the one situation where forcing consumers to
+recompile/redirect is the *intended* signal.
+
+## Alternatives considered
+
+- **`AssemblyVersion` == package version** — rejected: forces a binding redirect on
+  every release for .NET Framework consumers; maximal friction for no benefit while
+  the API is compatible.
+- **Auto-increment `AssemblyVersion` per build** — rejected: same redirect problem,
+  worse (non-deterministic).
+
+## Consequences
+
+- .NET Framework consumers can drop in a newer patch/minor build without touching
+  `app.config`; the reference keeps binding to `1.0.0.0`.
+- `FileVersion`/`InformationalVersion` remain the source of truth for "which build
+  is this?" in Explorer, logs, and diagnostics.
+- The pin is load-bearing: bumping `AssemblyVersion` casually (e.g. to match the
+  package version) would silently reintroduce the redirect burden. It moves only on
+  an intentional breaking change, and that move is itself a decision worth an ADR.

--- a/docs/adr/0008-ban-synchronous-parallel-apis.md
+++ b/docs/adr/0008-ban-synchronous-parallel-apis.md
@@ -1,0 +1,47 @@
+# ADR 0008 — Ban synchronous `Parallel.For`/`Parallel.ForEach`
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Deciders:** Chris Wolfgang
+
+## Context
+
+This is an **async-first ETL library**: extractors, transformers, and loaders are
+all `IAsyncEnumerable`-based, and every I/O path is `async`. `System.Threading.Tasks.Parallel.For`
+and `Parallel.ForEach` are **synchronous** fan-out primitives — they block the
+calling thread until all iterations complete and offer no natural way to `await`
+async work inside the loop body. Reaching for them in an async pipeline blocks
+threads, defeats the cooperative concurrency model, and tends to produce
+`async void`-style lambdas that swallow exceptions. They are easy to type and look
+harmless in review.
+
+The repository enforces API hygiene via a `BannedSymbols.txt` consumed by the
+`Microsoft.CodeAnalysis.BannedApiAnalyzers` analyzer (warnings-as-errors).
+
+## Decision
+
+We will ban `Parallel.For` and `Parallel.ForEach` (both overload families) in
+`BannedSymbols.txt`, with a diagnostic message pointing to the async-friendly
+alternatives: `Task.WhenAll`, dataflow, and — on .NET 6+ targets —
+`Parallel.ForEachAsync`. The ban makes a synchronous fan-out a **build error**, not
+a review nit, so it can't slip in unnoticed.
+
+## Alternatives considered
+
+- **Rely on code review** — rejected: humans miss it, and the whole point of the
+  banned-API analyzer is to make "we already decided against this" mechanical.
+- **Ban nothing / allow case-by-case** — rejected: there is no place in an
+  async-streaming pipeline where the synchronous `Parallel.*` overloads are the
+  right tool; a blanket ban has no false positives here.
+- **Also ban `Parallel.ForEachAsync`** — rejected: it *is* the async-friendly
+  escape hatch on modern targets, so it stays allowed.
+
+## Consequences
+
+- Synchronous parallel fan-out fails the build with a message that names the
+  replacement, keeping the library consistently async.
+- Contributors on `net462`/`netstandard` (no `Parallel.ForEachAsync`) use
+  `Task.WhenAll` or dataflow instead; the ban steers them there.
+- Reinforces the sequential-disposal decision in
+  [ADR-0006](0006-sequential-reverse-order-stage-disposal.md): parallel teardown
+  would have leaned on exactly these banned primitives.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,35 @@
+# ADR NNNN — <short decision title>
+
+- **Status:** Proposed | Accepted | Superseded by [ADR-XXXX](XXXX-....md) | Deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** <who was involved>
+
+## Context
+
+What is the problem, force, or constraint that makes this decision necessary?
+Describe the situation neutrally — the technical facts, the options on the table,
+and the pressures pulling in different directions. Someone reading this in a year
+should understand *why the question even came up* without archaeology through PRs.
+
+## Decision
+
+The choice that was made, stated in one or two sentences of active voice
+("We will …"). Follow with the reasoning: why this option beat the alternatives.
+
+## Alternatives considered
+
+- **<Option A>** — why it was rejected.
+- **<Option B>** — why it was rejected.
+
+## Consequences
+
+What becomes easier, what becomes harder, and what new obligations this creates.
+Include the *negative* consequences honestly — an ADR that only lists upsides is
+marketing, not a record. Note any follow-up work or constraints this imposes on
+future changes.
+
+---
+
+*This project uses [Michael Nygard's ADR format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
+Copy this file to `NNNN-kebab-case-title.md`, using the next free 4-digit number,
+and add a row to [`index.md`](index.md).*

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,27 @@
+# Architecture Decision Records
+
+This folder records the non-obvious design decisions behind
+`Wolfgang.Etl.Abstractions` — the *why* that the code and type signatures can't
+carry on their own. See [ADR-0001](0001-record-architecture-decisions.md) for the
+practice itself, and [`TEMPLATE.md`](TEMPLATE.md) to add a new one.
+
+Each ADR is immutable once **Accepted**. A decision that gets reversed is recorded
+as a *new* ADR that supersedes the old one; the superseded ADR stays in place with
+its status updated, so the history of the thinking is preserved.
+
+| # | Title | Status |
+|---|-------|--------|
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
+| [0002](0002-etlpipeline-core-in-abstractions-operators-in-transformers.md) | EtlPipeline core in Abstractions; operators in Transformers | Accepted |
+| [0003](0003-from-as-extension-method.md) | `Create().From()` with `From` as an extension method | Accepted |
+| [0004](0004-etlpipelineprogress-extracted-loaded-elapsed.md) | `EtlPipelineProgress` reports extracted / loaded / elapsed only | Accepted |
+| [0005](0005-name-etlpipeline-not-pipeline.md) | Name the generic builder `EtlPipeline`, not `Pipeline` | Accepted |
+| [0006](0006-sequential-reverse-order-stage-disposal.md) | Dispose stages sequentially, in reverse construction order | Accepted |
+| [0007](0007-pin-assemblyversion.md) | Pin `<AssemblyVersion>` at `1.0.0.0` | Accepted |
+| [0008](0008-ban-synchronous-parallel-apis.md) | Ban synchronous `Parallel.For`/`Parallel.ForEach` | Accepted |
+
+## Status legend
+
+- **Accepted** — in force.
+- **Superseded by ADR-XXXX** — replaced by a later decision; kept for history.
+- **Deprecated** — no longer applies, but was not directly replaced.


### PR DESCRIPTION
## Summary

Adds `docs/adr/` — Architecture Decision Records capturing the *why* behind non-obvious design choices that the code and type signatures can't carry on their own (issue #220).

- **`TEMPLATE.md`** — Michael Nygard format (Context / Decision / Alternatives / Consequences).
- **`index.md`** — table of all ADRs with a Status column (Accepted / Superseded / Deprecated) and a status legend.
- **Eight retroactive ADRs** for this cycle's decisions:
  - `0001` Record architecture decisions (the practice itself)
  - `0002` EtlPipeline core in Abstractions, operators in Transformers (Option B)
  - `0003` `Create().From()` with `From` as an extension method
  - `0004` `EtlPipelineProgress` reports extracted/loaded/elapsed only
  - `0005` Name the generic builder `EtlPipeline`, not `Pipeline`
  - `0006` Dispose stages sequentially, in reverse construction order
  - `0007` Pin `<AssemblyVersion>` at `1.0.0.0`
  - `0008` Ban synchronous `Parallel.For`/`Parallel.ForEach`

Every ADR is grounded in the current tree (verified the `AssemblyVersion` pin in the csproj, the `Parallel.*` bans in `BannedSymbols.txt`, and the reverse-order disposal in `StageList.cs`).

Pointers added from **README** (Documentation section) and **CONTRIBUTING** ("new ADRs land alongside the PR that introduces the decision").

## Acceptance criteria (#220)

- [x] `docs/adr/` with a `TEMPLATE.md`
- [x] Existing non-obvious choices documented retroactively (the `AssemblyVersion` pin and `Parallel.*` ban from the AC, plus this repo's EtlPipeline decisions in place of the ChunkAsync/DoCoreAsync examples, which belong to a different repo)
- [x] `index.md` listing all ADRs with status
- [x] CONTRIBUTING notes that new ADRs land alongside their PR

Docs-only; no code or workflow changes.

Closes #220