### PR TITLE
test: XML-doc example rot detection (#211)

### DIFF
--- a/ETL-Abstractions.sln
+++ b/ETL-Abstractions.sln
@@ -91,6 +91,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example8-EtlPipeline", "exa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example8-EtlPipeline", "examples\Net4.8\Example8-EtlPipeline\Example8-EtlPipeline.csproj", "{B59B4926-9CDD-41C2-A367-42F030DFAF54}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wolfgang.Etl.Abstractions.Tests.DocExamples", "tests\Wolfgang.Etl.Abstractions.Tests.DocExamples\Wolfgang.Etl.Abstractions.Tests.DocExamples.csproj", "{6A9827C6-EFCA-4040-A561-45D2E21FF012}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -377,6 +379,18 @@ Global
 		{B59B4926-9CDD-41C2-A367-42F030DFAF54}.Release|x64.Build.0 = Release|Any CPU
 		{B59B4926-9CDD-41C2-A367-42F030DFAF54}.Release|x86.ActiveCfg = Release|Any CPU
 		{B59B4926-9CDD-41C2-A367-42F030DFAF54}.Release|x86.Build.0 = Release|Any CPU
+		{6A9827C6-EFCA-4040-A561-45D2E21FF012}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A9827C6-EFCA-4040-A561-45D2E21FF012}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A9827C6-EFCA-4040-A561-45D2E21FF012}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6A9827C6-EFCA-4040-A561-45D2E21FF012}.Debug|x64.Build.0 = Debug|Any CPU
+		{6A9827C6-EFCA-4040-A561-45D2E21FF012}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6A9827C6-EFCA-4040-A561-45D2E21FF012}.Debug|x86.Build.0 = Debug|Any CPU
+		{6A9827C6-EFCA-4040-A561-45D2E21FF012}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A9827C6-EFCA-4040-A561-45D2E21FF012}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A9827C6-EFCA-4040-A561-45D2E21FF012}.Release|x64.ActiveCfg = Release|Any CPU
+		{6A9827C6-EFCA-4040-A561-45D2E21FF012}.Release|x64.Build.0 = Release|Any CPU
+		{6A9827C6-EFCA-4040-A561-45D2E21FF012}.Release|x86.ActiveCfg = Release|Any CPU
+		{6A9827C6-EFCA-4040-A561-45D2E21FF012}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -409,6 +423,7 @@ Global
 		{F26156B5-9FDC-46CA-9152-F888932238E1} = {336D72A1-8E5E-49DE-83D9-DF6BE458BA24}
 		{F97582DD-F8D7-4BA0-B46E-20B7200ADC74} = {3C48157B-5E90-489E-9444-E01F51D59F86}
 		{B59B4926-9CDD-41C2-A367-42F030DFAF54} = {336D72A1-8E5E-49DE-83D9-DF6BE458BA24}
+		{6A9827C6-EFCA-4040-A561-45D2E21FF012} = {8220BC33-6632-4D4C-9A50-B7978141A4E3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F673635D-58CE-48A5-9AE4-31F4484BED9E}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.DocExamples/DocExampleCompilationTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.DocExamples/DocExampleCompilationTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.CodeAnalysis;
+
+namespace Wolfgang.Etl.Abstractions.Tests.DocExamples;
+
+/// <summary>
+/// Guards against XML-doc example rot (#211): every <c>&lt;example&gt;&lt;code&gt;</c>
+/// block in the library's documentation comments must still compile against the
+/// current public API. A snippet that references a renamed or removed member becomes
+/// a failing test instead of silently outliving the API it documents.
+/// </summary>
+public sealed class DocExampleCompilationTests
+{
+    public static IEnumerable<object[]> Examples()
+        => DocExampleSource.DiscoverAll().Select(example => new object[] { example });
+
+
+    [Fact]
+    public void Source_scan_finds_the_documented_examples()
+    {
+        var examples = DocExampleSource.DiscoverAll();
+
+        // Floor guard: if extraction (or source-tree location) ever silently breaks, the
+        // theory below would pass vacuously with zero cases. This fails loudly instead.
+        Assert.True(
+            examples.Count >= 5,
+            $"Expected to find the documented <example><code> blocks in the library source, "
+            + $"but found {examples.Count}. Doc-example extraction or source-tree discovery is broken.");
+    }
+
+
+    [Theory]
+    [MemberData(nameof(Examples))]
+    public void Documented_example_still_compiles(DocExample example)
+    {
+        ArgumentNullException.ThrowIfNull(example);
+        var errors = DocExampleCompiler.Compile(example);
+
+        Assert.True(
+            errors.Count == 0,
+            BuildFailureMessage(example, errors));
+    }
+
+
+    private static string BuildFailureMessage(DocExample example, IReadOnlyList<Diagnostic> errors)
+    {
+        var rendered = string.Join(Environment.NewLine, errors.Select(e => "    " + e));
+
+        return $"The XML-doc <example> at {example.File}:{example.Line} no longer compiles "
+            + $"against the current public API:{Environment.NewLine}{rendered}"
+            + $"{Environment.NewLine}--- snippet ---{Environment.NewLine}{example.Code}";
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.DocExamples/DocExampleCompiler.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.DocExamples/DocExampleCompiler.cs
@@ -1,0 +1,179 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Wolfgang.Etl.Abstractions.Tests.DocExamples;
+
+/// <summary>
+/// Compiles an extracted doc <see cref="DocExample"/> against the real
+/// <c>Wolfgang.Etl.Abstractions</c> assembly. The snippet is wrapped in a synthetic
+/// harness that supplies the imports and the placeholder identifiers the illustrative
+/// snippets reference (<c>records</c>, <c>sqlLoader</c>, <c>filePath</c>, …) while the
+/// actual API calls (<c>From</c>/<c>Through</c>/<c>To</c>/<c>Extract</c>/<c>Transform</c>/
+/// <c>Load</c>/<c>RunAsync</c>/…) bind against the shipped types — so a renamed or removed
+/// member turns a stale example into a compile error.
+/// </summary>
+public static class DocExampleCompiler
+{
+    /// <summary>
+    /// Wraps and compiles <paramref name="example"/>, returning only the
+    /// error-severity diagnostics (an empty list means the snippet is valid).
+    /// </summary>
+    public static IReadOnlyList<Diagnostic> Compile(DocExample example)
+    {
+        ArgumentNullException.ThrowIfNull(example);
+        var source = BuildSource(example);
+
+        var tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest));
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "DocExampleScratch",
+            syntaxTrees: [tree],
+            references: ReferenceAssemblies(),
+            options: new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Disable));
+
+        return compilation
+            .GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+    }
+
+
+    private static string BuildSource(DocExample example)
+    {
+        var (signature, closer) = WrapperSignature(example.Code);
+
+        // #line remaps compiler diagnostics onto the real doc-comment location.
+        var location = example.File; // repository-relative, already forward-slashed
+
+        return $$"""
+            using System;
+            using System.IO;
+            using System.Linq;
+            using System.Threading;
+            using System.Threading.Tasks;
+            using System.Collections.Generic;
+            using Wolfgang.Etl.Abstractions;
+
+            namespace DocExamples.Generated
+            {
+                // A sample record type the fluent examples project over.
+                internal sealed class Order { public decimal Amount { get; set; } }
+
+                // The only stub the examples instantiate directly; the real operator lives in
+                // Wolfgang.Etl.Transformers, which Abstractions cannot reference (see ADR-0002).
+                internal sealed class WhereTransformer<T> : ITransformAsync<T, T>
+                    where T : notnull
+                {
+                    public WhereTransformer(Func<T, bool> predicate) { _ = predicate; }
+
+                    public IAsyncEnumerable<T> TransformAsync(IAsyncEnumerable<T> items)
+                        => throw new NotSupportedException();
+                }
+
+                // Supplies the placeholder identifiers the illustrative snippets reference. These
+                // are scaffolding, not the API under test: they are never executed (the snippets are
+                // compiled, not run), so their values are irrelevant. Their TYPES are chosen so the
+                // real API calls in the snippets resolve exactly as a consumer's would.
+                internal abstract class DocExampleContext
+                {
+                    protected int MaximumItemCount;
+                    protected int SkipItemCount;
+                    protected string filePath;
+                    protected IEnumerable<Order> items;
+                    protected IAsyncEnumerable<Order> records;
+                    protected LoaderBase<Order, Report> sqlLoader;
+                    protected IProgress<EtlPipelineProgress> progress;
+                    protected CancellationToken token;
+                    protected IExtractWithProgressAndCancellationAsync<Order, Report> csvExtractor;
+                    protected IProgress<Report> extractProgress;
+                    protected ITransformAsync<Order, Order> enrich;
+                    protected IProgress<Report> loadProgress;
+                }
+
+                internal sealed class Example : DocExampleContext
+                {
+                    public {{signature}}
+                    {
+            #line {{example.Line}} "{{location}}"
+            {{example.Code}}
+            #line default
+                    }{{closer}}
+                }
+            }
+            """;
+    }
+
+
+    // Chooses the wrapper method shape that lets the snippet compile:
+    //   - a `yield` snippet must sit in an async-iterator method;
+    //   - an `await` snippet needs `async Task`;
+    //   - anything else (e.g. a plain `foreach`) is a synchronous `void` body,
+    //     which avoids a spurious CS1998 "async method lacks await" on those.
+    private static (string Signature, string Closer) WrapperSignature(string code)
+    {
+        if (ContainsWord(code, "yield"))
+        {
+            return ("async IAsyncEnumerable<string> Run()", string.Empty);
+        }
+
+        if (ContainsWord(code, "await"))
+        {
+            return ("async Task Run()", string.Empty);
+        }
+
+        return ("void Run()", string.Empty);
+    }
+
+
+    private static bool ContainsWord(string code, string word)
+    {
+        var index = code.IndexOf(word, StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            var before = index == 0 || !char.IsLetterOrDigit(code[index - 1]);
+            var afterIndex = index + word.Length;
+            var after = afterIndex >= code.Length || !char.IsLetterOrDigit(code[afterIndex]);
+            if (before && after)
+            {
+                return true;
+            }
+
+            index = code.IndexOf(word, index + 1, StringComparison.Ordinal);
+        }
+
+        return false;
+    }
+
+
+    // The compiler needs the full framework reference set plus the library under test. The
+    // trusted-platform-assemblies list is the reference closure of the running test host
+    // (net10.0), which already includes the project-referenced Abstractions assembly.
+    private static IReadOnlyList<MetadataReference> ReferenceAssemblies()
+    {
+        var references = new List<MetadataReference>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var trusted = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? string.Empty;
+        foreach (var path in trusted.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && seen.Add(path))
+            {
+                references.Add(MetadataReference.CreateFromFile(path));
+            }
+        }
+
+        // Belt-and-braces: guarantee the library under test is referenced even if it is
+        // ever loaded from outside the TPA closure.
+        var abstractionsPath = typeof(EtlPipeline).Assembly.Location;
+        if (!string.IsNullOrEmpty(abstractionsPath) && seen.Add(abstractionsPath))
+        {
+            references.Add(MetadataReference.CreateFromFile(abstractionsPath));
+        }
+
+        return references;
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.DocExamples/DocExampleSource.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.DocExamples/DocExampleSource.cs
@@ -1,0 +1,200 @@
+using System.Net;
+using Xunit.Abstractions;
+
+namespace Wolfgang.Etl.Abstractions.Tests.DocExamples;
+
+/// <summary>
+/// A single <c>&lt;example&gt;&lt;code&gt;</c> block extracted from the library's
+/// XML-doc comments, together with the source location it came from so a failure
+/// can point back at the exact doc comment to fix.
+/// </summary>
+public sealed class DocExample : IXunitSerializable
+{
+    // Parameterless ctor + settable members are required by IXunitSerializable so
+    // xunit can round-trip the case through the test runner.
+    public DocExample()
+    {
+    }
+
+
+    public DocExample(string file, int line, string code)
+    {
+        File = file;
+        Line = line;
+        Code = code;
+    }
+
+
+    /// <summary>Repository-relative path (forward-slashed) of the file the example lives in.</summary>
+    public string File { get; set; } = string.Empty;
+
+
+    /// <summary>1-based line number of the first line of the <c>&lt;code&gt;</c> block.</summary>
+    public int Line { get; set; }
+
+
+    /// <summary>The decoded snippet text (XML entities resolved, <c>///</c> prefixes stripped).</summary>
+    public string Code { get; set; } = string.Empty;
+
+
+    public void Deserialize(IXunitSerializationInfo info)
+    {
+        ArgumentNullException.ThrowIfNull(info);
+        File = info.GetValue<string>("file");
+        Line = info.GetValue<int>("line");
+        Code = info.GetValue<string>("code");
+    }
+
+
+    public void Serialize(IXunitSerializationInfo info)
+    {
+        ArgumentNullException.ThrowIfNull(info);
+        info.AddValue("file", File);
+        info.AddValue("line", Line);
+        info.AddValue("code", Code);
+    }
+
+
+    // Drives the theory's per-case display name.
+    public override string ToString() => $"{File}:{Line}";
+}
+
+
+/// <summary>
+/// Locates the library source tree and scans it for <c>&lt;example&gt;&lt;code&gt;</c>
+/// blocks in <c>///</c> documentation comments.
+/// </summary>
+public static class DocExampleSource
+{
+    /// <summary>
+    /// Finds every <c>&lt;example&gt;&lt;code&gt;</c> block in the library's source files.
+    /// </summary>
+    public static IReadOnlyList<DocExample> DiscoverAll()
+    {
+        var sourceDirectory = LocateSourceDirectory();
+        var examples = new List<DocExample>();
+
+        foreach (var file in Directory.EnumerateFiles(sourceDirectory, "*.cs", SearchOption.AllDirectories))
+        {
+            if (IsGeneratedPath(file))
+            {
+                continue;
+            }
+
+            var relative = Path.GetRelativePath(sourceDirectory, file).Replace('\\', '/');
+            examples.AddRange(ExtractFromFile(file, relative));
+        }
+
+        return examples;
+    }
+
+
+    private static IEnumerable<DocExample> ExtractFromFile(string file, string relative)
+    {
+        var lines = System.IO.File.ReadAllLines(file);
+
+        var inExample = false;
+        var inCode = false;
+        var codeStartLine = 0;
+        var buffer = new List<string>();
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var content = StripDocPrefix(lines[i]);
+            if (content is null)
+            {
+                // A non-doc line cannot appear inside a well-formed doc block; reset defensively.
+                inExample = false;
+                inCode = false;
+                continue;
+            }
+
+            var tag = content.Trim();
+            switch (tag)
+            {
+                case "<example>":
+                    inExample = true;
+                    break;
+
+                case "</example>":
+                    inExample = false;
+                    inCode = false;
+                    break;
+
+                case "<code>" when inExample:
+                    inCode = true;
+                    buffer.Clear();
+                    codeStartLine = i + 2; // first code line, 1-based
+                    break;
+
+                case "</code>" when inCode:
+                    inCode = false;
+                    yield return new DocExample(relative, codeStartLine, Decode(string.Join("\n", buffer)));
+                    break;
+
+                default:
+                    if (inCode)
+                    {
+                        buffer.Add(content);
+                    }
+
+                    break;
+            }
+        }
+    }
+
+
+    // Strips a leading `///` (and the single conventional space after it) while preserving
+    // the snippet's own indentation. Returns null for lines that are not doc comments.
+    private static string? StripDocPrefix(string line)
+    {
+        var trimmed = line.TrimStart();
+        if (!trimmed.StartsWith("///", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var rest = trimmed.Substring(3);
+        if (rest.StartsWith(" ", StringComparison.Ordinal))
+        {
+            rest = rest.Substring(1);
+        }
+
+        return rest;
+    }
+
+
+    // XML doc comments escape `<`, `>` and `&` as entities; decode them back to real C#.
+    private static string Decode(string code) => WebUtility.HtmlDecode(code);
+
+
+    private static bool IsGeneratedPath(string file)
+    {
+        var sep = Path.DirectorySeparatorChar;
+        return file.Contains($"{sep}bin{sep}", StringComparison.Ordinal)
+            || file.Contains($"{sep}obj{sep}", StringComparison.Ordinal);
+    }
+
+
+    // Walks up from the test assembly's base directory to the checked-out tree. Deliberately
+    // avoids [CallerFilePath], which bakes in the build-machine path and resolves to a
+    // non-existent '/_/...' location under CI's deterministic-build settings.
+    private static string LocateSourceDirectory()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, "src", "Wolfgang.Etl.Abstractions");
+            if (Directory.Exists(candidate)
+                && System.IO.File.Exists(Path.Combine(candidate, "Wolfgang.Etl.Abstractions.csproj")))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate 'src/Wolfgang.Etl.Abstractions' above '{AppContext.BaseDirectory}'.");
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.DocExamples/Wolfgang.Etl.Abstractions.Tests.DocExamples.csproj
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.DocExamples/Wolfgang.Etl.Abstractions.Tests.DocExamples.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Doc-example rot detection (#211). This is a tooling test that hosts the
+       Roslyn C# compiler to build every <example><code> block found in the
+       library's XML-doc comments, so it targets a single modern TFM rather than
+       the library's full matrix. -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Copyright>Copyright 2025 Chris Wolfgang</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <!-- Hosts the C# compiler used to build the extracted doc snippets. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Abstractions\Wolfgang.Etl.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds `tests/Wolfgang.Etl.Abstractions.Tests.DocExamples` — a test that hosts the Roslyn C# compiler to build **every `<example><code>` block** in the library's XML-doc comments against the shipped `Wolfgang.Etl.Abstractions` assembly (issue #211). Stale examples that reference a renamed or removed member now fail a test instead of silently outliving the API they document.

## How it works

- **`DocExampleSource`** — locates the source tree by walking up from `AppContext.BaseDirectory` (deliberately *not* `[CallerFilePath]`, which bakes in a build-machine path that resolves to a non-existent `/_/…` location under CI deterministic builds) and scans `src/**/*.cs` for `<example><code>` blocks, stripping `///` prefixes and decoding XML entities.
- **`DocExampleCompiler`** — wraps each snippet in a synthetic harness that supplies the imports and the illustrative placeholder identifiers (`records`, `sqlLoader`, `filePath`, `items`, …) as scaffolding, while the **real API calls** (`From`/`Through`/`To`/`Extract`/`Transform`/`Load`/`RunAsync`/`WithProgress`/…) bind against the actual shipped types — so a renamed member turns a stale example into a compile error. Placeholder *types* are pinned to the real API so overloads resolve exactly as a consumer's would. A `#line` directive maps compiler diagnostics back to the real doc-comment location. References come from the test host's trusted-platform-assemblies closure plus the library under test.
- **`DocExampleCompilationTests`** — one `[Theory]` case per discovered example (named by its source location, e.g. `EtlPipeline/EtlPipeline.cs:37`), plus a floor-guard `[Fact]` so a broken extractor / source-tree miss fails loudly rather than passing vacuously with zero cases.

## Verification

- All **8** currently-documented `<example>` blocks compile; `dotnet test -c Release` (warnings-as-errors) is green (9/9).
- **Guard confirmed to fire:** renaming `.Through` → `.ThroughXYZ` in an example produced `CS1061` pointing at the exact doc line (`EtlPipeline.cs:39`), then reverted.

## Acceptance criteria (#211)

- [x] A `tests/<Repo>.Tests.DocExamples/` project scans source for `<example><code>` blocks, extracts each, and compiles them (via Roslyn).
- [x] Compilation failures fail the test.
- [x] Snippets that need imports are wrapped in a synthetic harness with the necessary `using` directives (and the placeholder identifiers the illustrative snippets reference).

Net-new `net10.0` test project + solution entry; no changes to `src/` or `.github/`.

Closes #211