### PR TITLE
ci: workflow security audit — zizmor + actionlint (#223)

### DIFF
--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -1,0 +1,62 @@
+name: Workflow Security
+
+# Lints the GitHub Actions workflows themselves (#223):
+#   - actionlint: syntax, shell (shellcheck), and expression errors.
+#   - zizmor:     workflow-level security (template injection, over-broad
+#                 permissions, unpinned actions, dangerous triggers).
+# The zizmor pinning policy lives in .github/zizmor.yml. Both tools fail the PR
+# on a finding, so a workflow change that introduces one is caught before merge
+# rather than on the server after.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Run actionlint
+        # Download + checksum-verify the pinned binary (same pattern as the
+        # gitleaks step in pr.yaml) rather than a floating third-party action.
+        run: |
+          set -euo pipefail
+          ACTIONLINT_VERSION="1.7.12"
+          ACTIONLINT_SHA256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+          TARBALL="actionlint.tar.gz"
+          curl -sSfL -o "$TARBALL" "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  ${TARBALL}" | sha256sum -c -
+          tar -xzf "$TARBALL" actionlint
+          ./actionlint -color
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+
+      - name: Install zizmor
+        run: pip install zizmor==1.26.1
+
+      - name: Run zizmor
+        # --format=github emits inline PR annotations; a high-severity finding
+        # exits non-zero and fails the job.
+        run: zizmor --format=github --min-severity=high --config .github/zizmor.yml .github/workflows/

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,26 @@
+# zizmor configuration (#223).
+#
+# Pinning policy: every action reference must be pinned to a full commit hash.
+# This repo SHA-pinned all of its actions in #298 (first-party actions/* and
+# github/* included, not just third-party), so the strictest policy is the one
+# that matches reality and keeps it that way — a future PR that adds a
+# tag-pinned action is a high-severity finding that fails the check.
+#
+# (Local reusable-workflow calls of the form `uses: ./…` are not registry
+# actions and are not subject to pinning.)
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": hash-pin
+
+  # Accepted-suppression baseline. Each entry is a pre-existing finding that is
+  # intentional; a NEW high-severity finding anywhere else still fails the PR.
+  dangerous-triggers:
+    ignore:
+      # pr.yaml's `pull_request_target` is deliberate: the protected-file guard
+      # ("Detect .NET Projects") must run trusted workflow code from the base
+      # branch, not from the PR branch, so it cannot be spoofed by a fork PR.
+      # It never checks out or executes PR-supplied code, which is what makes
+      # pull_request_target dangerous. Revisiting this is out of scope for #223.
+      - pr.yaml


### PR DESCRIPTION
## Summary

Adds `.github/workflows/workflow-security.yaml` — lints the GitHub Actions workflows *themselves* on every PR (and push to `main`), covering what CodeQL (#S1) and the SAST tools don't: the Actions YAML (template injection, over-broad `permissions:`, dangerous triggers, unpinned actions, shell bugs in `run:` blocks). Issue #223.

**Two linters, different rule sets:**
- **actionlint** — workflow syntax, expression errors, and shell (**shellcheck**) issues in `run:` blocks. Uses a **checksum-pinned binary** (v1.7.12, sha256-verified — same pattern as the gitleaks step), not a floating third-party action.
- **zizmor** — workflow-level security, run at `--min-severity=high` so a **new** high-severity finding fails the PR. Emits inline PR annotations (`--format=github`).

## Policy + baseline (`.github/zizmor.yml`)

- **`unpinned-uses` policy is `"*": hash-pin`** — stricter than the fleet template's `actions/*: ref-pin`, because this repo **fully SHA-pinned its actions in #298**. A future tag-pinned action is now a failing finding — this workflow *enforces* what #298 established.
- **One documented suppression:** `pr.yaml`'s `pull_request_target` (a pre-existing high-severity `dangerous-triggers` finding). It's deliberate — the `Detect .NET Projects` protected-file guard must run trusted **base-branch** workflow code (not PR-supplied code, which it never checks out or executes), so a fork PR can't spoof it. Revisiting it is out of scope for #223; the reason is documented in the config.

The new workflow's own actions (`checkout`, `setup-python`) are SHA-pinned to match.

## Validation

Ran both tools locally against all 15 workflows:
- **zizmor** (online audits, `--min-severity=high`): *No findings to report.*
- **actionlint + shellcheck** (0.10.0): 0 findings.

## Acceptance criteria (#223)

- [x] A dedicated `workflow-security.yaml` runs `zizmor` and `actionlint` on every PR.
- [x] Findings reported as PR annotations (`zizmor --format=github`; actionlint via job log).
- [x] Documented baseline of accepted suppressions with a reason, in `.github/zizmor.yml`.
- [x] Fails the PR on a new high-severity finding (`--min-severity=high`; actionlint non-zero exit).

Additive; touches only `.github/`. Complements #298 (which did the pinning) — this enforces it going forward.

Closes #223