### PR TITLE
docs: SECURITY.md release-path appendix (#221) + migration-guide convention (#219)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,3 +21,13 @@ We will acknowledge your report within 48 hours and provide an estimated timelin
 
 Your help is greatly appreciated!
 Responsible disclosure of security vulnerabilities helps protect our entire community.
+
+## Release path & compromise scope
+
+Facts a maintainer would need at 2am if the release identity is compromised. Generic incident-response steps (rotating credentials, revoking OAuth apps, publishing advisories, unlisting NuGet packages) are not duplicated here — GitHub's and NuGet's own docs update faster than a checked-in runbook.
+
+- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` in `.github/workflows/release.yaml`. The workflow mints an ephemeral push token per run via OIDC — the release path does not depend on a long-lived API key stored in GitHub secrets or on the NuGet account. During an incident, check the NuGet account for any long-lived API keys anyway (they can be created outside of CI) and delete anything you don't recognize.
+- **Fallback**: none. If Trusted Publishing is compromised, the incident is at the GitHub-account level (the OIDC identity is `Chris-Wolfgang/ETL-Abstractions`).
+- **Owner**: @Chris-Wolfgang.
+- **Downstream consumers**: this is the framework's foundational package — every `Wolfgang.Etl.*` library depends on it, including `Wolfgang.Etl.TestKit`, `Wolfgang.Etl.Transformers`, and the format packages (`Wolfgang.Etl.Csv`, `.Json`, `.Xml`, `.FixedWidth`, `.SqlBulkCopy`, `.DbClient`). A compromise cascades to all of them. Unknown external consumers may also exist on nuget.org.
+- **Package coordinates for unlisting**: `Wolfgang.Etl.Abstractions` — https://www.nuget.org/packages/Wolfgang.Etl.Abstractions/ (single package; symbols publish as the matching `.snupkg`).

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,10 @@
+# Migration guides
+
+Per-major-version upgrade guides live here, named `vX-to-vY.md`, created during
+release prep for any major bump (0.x → 1.0 with breaking changes, or 1.0 → 2.0)
+and linked from the corresponding GitHub Release notes.
+
+No major version has shipped yet — ETL-Abstractions is in its `0.x` line — so only
+the [template](TEMPLATE-major-version-migration.md) exists. The convention is
+established now so the first major release can use it without inventing structure
+under time pressure.

--- a/docs/migrations/TEMPLATE-major-version-migration.md
+++ b/docs/migrations/TEMPLATE-major-version-migration.md
@@ -1,0 +1,47 @@
+# Migrating from vX to vY
+
+> Copy this template to `vX-to-vY.md` during release prep for a major version
+> bump, fill in each section, and link it from the GitHub Release notes. Delete
+> any section that does not apply (but prefer "None" over deletion so readers know
+> it was considered).
+
+## Summary
+
+One paragraph: who is affected, roughly how much work the upgrade is, and whether
+a compatibility shim exists.
+
+## Breaking-change inventory
+
+| API | Change | Replacement |
+| --- | --- | --- |
+| `OldType.OldMember` | removed / renamed / behaviour change | `NewType.NewMember` |
+
+## Before / after
+
+```csharp
+// Before (vX)
+```
+
+```csharp
+// After (vY)
+```
+
+Repeat per breaking change that needs a code edit.
+
+## Behavioural changes (no signature change)
+
+Changes that compile unchanged but behave differently at runtime (default-value
+changes, nullability flips, parsing-tolerance changes). These are the dangerous
+ones — call each out explicitly.
+
+## Deprecation timeline
+
+- **vX**: member marked `[Obsolete]` (warning).
+- **vY**: member removed.
+
+State when deprecated members were first warned about and when they were removed.
+
+## Verifying the upgrade
+
+How a consumer confirms the migration succeeded (build clean, tests green, ABI
+check via the release `api-compat` gate).


### PR DESCRIPTION
Two small docs-only follow-ups from the thorough-review backlog.

## #221 — SECURITY.md "Release path & compromise scope" appendix
Appends the load-bearing per-repo incident facts (canonical shape from Etl-DbClient #240) after the existing sections:
- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` — no long-lived key in the release path (true since #287).
- **Fallback**: none; OIDC identity is `Chris-Wolfgang/ETL-Abstractions`.
- **Owner**, **downstream consumers** (this is the framework's base package — a compromise cascades to every `Wolfgang.Etl.*` dependent), and **package coordinates** for unlisting.

Generic incident-response steps (rotating creds, advisories, unlisting) are deliberately *not* duplicated — GitHub's/NuGet's own docs update faster than a checked-in runbook.

## #219 — Migration-guide convention
No major has shipped (repo is `0.x`), so this just establishes the convention now so the first major release isn't inventing structure under time pressure:
- `docs/migrations/README.md` — names the `vX-to-vY.md` convention, created at release prep, linked from Release notes.
- `docs/migrations/TEMPLATE-major-version-migration.md` — sections: summary, breaking-change inventory, before/after, behavioural changes, deprecation timeline, verification.

## Acceptance criteria
- #221: appendix present with the per-repo facts filled in ✅
- #219: `docs/migrations/` with a template documenting the expected sections ✅

Docs only — no code, no workflows, no build impact.

Closes #221
Closes #219