### PR TITLE
build: ABI-compatibility gate via Package Validation (#206)

### DIFF
--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -10,6 +10,17 @@
 	     the actual release version. -->
 	<AssemblyVersion>1.0.0.0</AssemblyVersion>
 	<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
+    <!-- API/ABI compatibility gate (#206). Package Validation compares the packed
+         package against the last published version on NuGet and fails the pack if a
+         non-major change breaks binary/API compatibility (default-value changes,
+         nullability flips, removed members, layout shifts) — the behavioural breaks
+         PublicApiAnalyzers (A1) can't see. Keep the baseline at the last PUBLISHED
+         version and bump it after each release (see reference: keep baseline at
+         last-published during release). Intentional breaks in a MAJOR release are
+         recorded in CompatibilitySuppressions.xml, regenerated with
+         `dotnet pack /p:GenerateCompatibilitySuppressionFile=true`. -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.16.0</PackageValidationBaselineVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Contains interfaces and base classes used to build ETL applications</Description>


### PR DESCRIPTION
## Summary

Adds an **ABI-compatibility release gate** (issue #206) so a non-major bump can't silently ship a binary break. PublicApiAnalyzers (A1) catches added/removed *signatures* via `PublicAPI.Shipped.txt`; it does **not** catch behavioural/binary breaks — default-value changes, nullability annotation flips, removed members, layout shifts — that a consumer's already-compiled assembly trips over at runtime.

**Approach — .NET SDK Package Validation** (the fleet-standard mechanism; ETL-FixedWidth ships the identical `<EnablePackageValidation>` + `<PackageValidationBaselineVersion>` pair). This is the idiomatic realization of the AC's "download the previous NuGet version and run ApiCompat": at pack time the SDK downloads the last published package and runs ApiCompat under the hood, across **every** target framework, failing the pack on an incompatibility.

```xml
<EnablePackageValidation>true</EnablePackageValidation>
<PackageValidationBaselineVersion>0.16.0</PackageValidationBaselineVersion>
```

- **Gates both paths**: `dotnet pack` runs `RunPackageValidation` in the PR pack check *and* in `release.yaml`'s pack step — so a break fails before publish (stronger than release-only).
- **Intentional MAJOR breaks** are recorded in `CompatibilitySuppressions.xml` (regenerate with `dotnet pack /p:GenerateCompatibilitySuppressionFile=true`) — the SemVer "MAJOR allows breaks" escape hatch.
- **Baseline discipline**: keep it at the last *published* version; bump after each release.
- The pinned `<AssemblyVersion>1.0.0.0</AssemblyVersion>` means baseline and current share assembly identity, so validation compares real surface rather than tripping on a version-identity mismatch.

## Verification

Local `dotnet pack -c Release`:
- Downloads the `0.16.0` baseline from NuGet into the package cache.
- Runs the `RunPackageValidation` target across all 11 TFMs (net462 → net10.0).
- **Passes** (vNext's public surface is identical to shipped 0.16.0), package created.

## Acceptance criteria (#206)

- [x] Release validates ABI compat against the previous published NuGet version (via Package Validation at pack time).
- [x] Fails a non-major bump that introduces an ABI break.
- [x] Intentional breaks recorded in a suppressions file (`CompatibilitySuppressions.xml`).

> Note: implemented as csproj Package Validation rather than a bespoke `apicompat` CLI step in `release.yaml` — same tool (ApiCompat) and same effect (gate vs previous NuGet version), but MSBuild-native, multi-TFM, and consistent with the rest of the fleet.

Closes #206