### PR TITLE
test: globalization / CultureInfo invariance (#215)

### DIFF
--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Globalization/CultureInvarianceTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Globalization/CultureInvarianceTests.cs
@@ -1,0 +1,155 @@
+using System.Globalization;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.Globalization;
+
+/// <summary>
+/// Globalization / CultureInfo invariance (#215). The default PR matrix runs only
+/// <c>en-US</c>; the Turkish dotted-I, German decimal-comma, Chinese collation, and
+/// Arabic digit-shaping bug classes surface only under non-<c>en-US</c> cultures.
+///
+/// <para>
+/// Allowlist of intentionally culture-sensitive public members: <b>none</b>. The
+/// base classes (<see cref="ExtractorBase{TSource, TProgress}"/>,
+/// <see cref="LoaderBase{TDestination, TProgress}"/>,
+/// <see cref="TransformerBase{TSource, TDestination, TProgress}"/>) orchestrate
+/// <see cref="System.Collections.Generic.IAsyncEnumerable{T}"/> flows and integer
+/// counters; <see cref="Report"/> exposes numeric metrics computed by
+/// culture-invariant arithmetic. Field-level parsing/formatting is the format
+/// packages' responsibility, not this one's. Every public member is therefore
+/// culture-invariant by contract, and these tests assert it under six hostile
+/// cultures. (Exception <em>message</em> text may format numbers via the current
+/// culture — that is UI text, not behaviour, and is out of scope.)
+/// </para>
+/// </summary>
+public sealed class CultureInvarianceTests
+{
+    public static IEnumerable<object[]> HostileCultures() =>
+        new[] { "en-US", "tr-TR", "de-DE", "zh-CN", "ar-SA", "ja-JP" }
+            .Select(culture => new object[] { culture });
+
+
+    // Sanity guard: proves the scope actually swaps the culture (so the invariance
+    // theories below are meaningful and not silently running under en-US). tr-TR
+    // upper-cases 'i' to the dotted 'İ'; en-US to plain 'I'.
+    [Theory]
+    [InlineData("tr-TR", "İ")]
+    [InlineData("en-US", "I")]
+    public void CultureScope_swaps_the_current_culture(string culture, string expectedUpperI)
+    {
+        using var scope = new CultureScope(culture);
+
+        Assert.Equal(culture, CultureInfo.CurrentCulture.Name);
+        Assert.Equal(culture, CultureInfo.CurrentUICulture.Name);
+        Assert.Equal(expectedUpperI, "i".ToUpper(CultureInfo.CurrentCulture));
+    }
+
+
+    [Theory]
+    [MemberData(nameof(HostileCultures))]
+    public void Report_metrics_are_culture_invariant(string culture)
+    {
+        using var scope = new CultureScope(culture);
+
+        var report = new Report(50)
+        {
+            TotalItemCount = 100,
+            Elapsed = TimeSpan.FromSeconds(10),
+        };
+
+        // Fixed results in every culture: 50/10 = 5/s, 50/100 = 50%, 50 left / 5 = 10s.
+        Assert.Equal(5d, report.ItemsPerSecond);
+        Assert.Equal(50d, report.PercentComplete);
+        Assert.Equal(TimeSpan.FromSeconds(10), report.EstimatedRemaining);
+    }
+
+
+    [Theory]
+    [MemberData(nameof(HostileCultures))]
+    public async Task Pipeline_output_is_culture_invariant(string culture)
+    {
+        var loader = new CollectingLoader();
+
+        using (new CultureScope(culture))
+        {
+            await Pipeline
+                .Extract(new RangeExtractor(5))
+                .Transform(new DoublingTransformer())
+                .Load(loader)
+                .RunAsync();
+        }
+
+        // Culture-neutral stages: any variance would be the orchestration injecting culture.
+        Assert.Equal(new[] { 2, 4, 6, 8, 10 }, loader.Items);
+    }
+
+
+    // Sets CurrentCulture + CurrentUICulture for the scope's lifetime and restores both
+    // on dispose, so a hostile culture can't leak into the next test (xunit reuses
+    // threads). CurrentCulture flows across await, so it holds for the async pipeline run.
+    private sealed class CultureScope : IDisposable
+    {
+        private readonly CultureInfo _culture;
+        private readonly CultureInfo _uiCulture;
+
+        public CultureScope(string culture)
+        {
+            _culture = CultureInfo.CurrentCulture;
+            _uiCulture = CultureInfo.CurrentUICulture;
+
+            var target = CultureInfo.GetCultureInfo(culture);
+            CultureInfo.CurrentCulture = target;
+            CultureInfo.CurrentUICulture = target;
+        }
+
+        public void Dispose()
+        {
+            CultureInfo.CurrentCulture = _culture;
+            CultureInfo.CurrentUICulture = _uiCulture;
+        }
+    }
+
+
+    private sealed class RangeExtractor : IExtractAsync<int>
+    {
+        private readonly int _count;
+
+        public RangeExtractor(int count) => _count = count;
+
+        public async IAsyncEnumerable<int> ExtractAsync()
+        {
+            for (var i = 1; i <= _count; i++)
+            {
+                yield return i;
+                await Task.Yield();
+            }
+        }
+    }
+
+
+    private sealed class DoublingTransformer : ITransformAsync<int, int>
+    {
+        public async IAsyncEnumerable<int> TransformAsync(IAsyncEnumerable<int> items)
+        {
+            await foreach (var item in items)
+            {
+                yield return item * 2;
+            }
+        }
+    }
+
+
+    private sealed class CollectingLoader : ILoadAsync<int>
+    {
+        private readonly List<int> _items = new();
+
+        public IReadOnlyList<int> Items => _items;
+
+        public async Task LoadAsync(IAsyncEnumerable<int> items)
+        {
+            await foreach (var item in items)
+            {
+                _items.Add(item);
+            }
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Globalization/README.md
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Globalization/README.md
@@ -1,0 +1,34 @@
+# Globalization / CultureInfo invariance (#215)
+
+The default PR test matrix runs under `en-US`. A whole class of bugs — the Turkish
+dotted-I, German decimal-comma, Chinese collation, Arabic right-to-left digit
+shaping, Japanese full-width digits — only surfaces under a non-`en-US` culture.
+[`CultureInvarianceTests`](CultureInvarianceTests.cs) re-exercises the library's
+observable behaviour under six hostile cultures (`en-US`, `tr-TR`, `de-DE`,
+`zh-CN`, `ar-SA`, `ja-JP`), swapping **both** `CultureInfo.CurrentCulture` and
+`CultureInfo.CurrentUICulture` per test and restoring them after (the `CultureScope`
+helper), so a hostile culture can't leak into the next test.
+
+Because these run as ordinary xunit theories, they execute in the existing PR test
+job on **every** target framework — no separate CI matrix required.
+
+## Allowlist of intentionally culture-sensitive public members
+
+**None.** `Wolfgang.Etl.Abstractions` is orchestration and contracts:
+
+- The base classes (`ExtractorBase`, `LoaderBase`, `TransformerBase`) pull items
+  through `IAsyncEnumerable<T>` and track **integer** counters — no formatting or
+  parsing.
+- `Report` exposes numeric metrics (`ItemsPerSecond`, `PercentComplete`,
+  `EstimatedRemaining`) computed with culture-invariant arithmetic.
+- Field-level parsing/formatting (decimal separators, date formats, digit shaping)
+  is the **format packages'** responsibility (`Wolfgang.Etl.Csv`, `.FixedWidth`, …),
+  and is verified in those repos.
+
+Every public member is therefore culture-invariant **by contract**, and the tests
+assert it. If a future change makes a member intentionally culture-sensitive, add
+it to this list with the rationale and give it its own culture-specific test rather
+than an invariance assertion.
+
+> Exception *message* text can format numbers via the current culture — that is UI
+> text, not behaviour, and is deliberately not asserted here.


### PR DESCRIPTION
## Summary

Adds `tests/…Tests.Unit/Globalization/` (issue #215). The default PR matrix runs only `en-US`; the Turkish dotted-I, German decimal-comma, Chinese collation, Arabic digit-shaping, and Japanese full-width classes of bug surface only under non-`en-US` cultures.

`CultureInvarianceTests` re-exercises the library's observable behaviour under **six hostile cultures** (`en-US`, `tr-TR`, `de-DE`, `zh-CN`, `ar-SA`, `ja-JP`):
- **Both** `CultureInfo.CurrentCulture` *and* `CurrentUICulture` are swapped per test and **restored after** (the `CultureScope` `IDisposable`), so a hostile culture can't leak into the next test.
- Because Abstractions is orchestration + integer counters (field parsing/formatting is the format packages' job), every public member is culture-invariant **by contract** — so the tests **assert invariance**:
  - `Report` metrics (`ItemsPerSecond`=5, `PercentComplete`=50, `EstimatedRemaining`=10s) compute to fixed values in every culture.
  - a small int pipeline (`extract → double → collect`) produces identical output in every culture (culture-neutral stages, so any variance would be the orchestration injecting culture).
- A **`CultureScope_swaps_the_current_culture` guard** proves the cultures are actually applied (`tr-TR` upper-cases `i` → `İ`) — so the invariance theories aren't silently running under `en-US`.

They run as ordinary xunit theories, so they execute in the **existing PR test job on every TFM** — no separate CI matrix needed. `Globalization/README.md` documents the allowlist of intentionally culture-sensitive members (**none**, with rationale).

## Verification
`dotnet test -c Release` (net10.0, warnings-as-errors): **14/14 green** (2 guard + 6 Report + 6 pipeline).

## Acceptance criteria (#215)
- [x] A `tests/.../Globalization/` set runs the suite under the six cultures.
- [x] Both `CurrentCulture` and `CurrentUICulture` swapped per test.
- [x] Culture restored after each test (scope helper).
- [x] Documented allowlist of intentionally culture-sensitive members (none) — everything else asserted invariant.

Additive test-only change.

Closes #215