### PR TITLE
test: Native-AOT / trim smoke consumer (#213)

### DIFF
--- a/.github/workflows/aot.yaml
+++ b/.github/workflows/aot.yaml
@@ -1,0 +1,71 @@
+name: AOT / Trim Smoke
+
+# Native-AOT + trim compatibility gate (#213). The library advertises net8.0 /
+# net10.0 targets, but nothing verified it survives the trimmer / ILC: reflection
+# on type names the trimmer can't see, dynamic generic instantiation, or runtime
+# codegen break silently under AOT. This publishes a tiny consumer with
+# PublishAot + PublishTrimmed and RUNS the native binary — so an AOT regression
+# fails here, on the PR, instead of in a consumer's published app.
+#
+# The build-time trim/AOT analyzers (IsAotCompatible in the smoke csproj) already
+# run in the normal build; this job adds the real linux-x64 native link + run,
+# which can only be done on Linux.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+    paths:
+      - 'src/**/*.cs'
+      - 'src/**/*.csproj'
+      - 'tests/Wolfgang.Etl.Abstractions.AotSmoke/**'
+      - '.github/workflows/aot.yaml'
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  aot-smoke:
+    name: PublishAot linux-x64 + run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Install Native AOT prerequisites
+        # ILC links native code with clang against zlib; ubuntu-latest ships clang
+        # but the zlib dev headers must be installed.
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang zlib1g-dev
+
+      - name: Publish (Native AOT + trimmed)
+        # A trim/AOT incompatibility in the library's reachable surface fails the
+        # publish (analyzer warning -> error, or an ILC error) before the run.
+        run: >
+          dotnet publish
+          tests/Wolfgang.Etl.Abstractions.AotSmoke/Wolfgang.Etl.Abstractions.AotSmoke.csproj
+          -c Release -r linux-x64
+
+      - name: Run the published native binary
+        # No managed runtime here — the binary is fully native. A reflection path
+        # that silently no-ops or throws NotSupportedException under AOT makes the
+        # smoke exit non-zero and fails the job.
+        run: |
+          set -euo pipefail
+          BIN="tests/Wolfgang.Etl.Abstractions.AotSmoke/bin/Release/net10.0/linux-x64/publish/Wolfgang.Etl.Abstractions.AotSmoke"
+          "$BIN"

--- a/tests/Wolfgang.Etl.Abstractions.AotSmoke/Program.cs
+++ b/tests/Wolfgang.Etl.Abstractions.AotSmoke/Program.cs
@@ -1,0 +1,87 @@
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.Abstractions.AotSmoke;
+
+// Native-AOT / trim smoke (#213). Exercises the library's public surface — both
+// pipeline builders, all three base classes, progress reporting, and Report — so
+// that a reflection / dynamic-codegen path that breaks under AOT surfaces here as
+// a NotSupportedException / MissingMethodException at run time (or a trim warning
+// at publish) instead of in a consumer's AOT-published app.
+
+Console.WriteLine("AOT smoke: exercising Wolfgang.Etl.Abstractions...");
+
+var extractProgress = new Progress<Report>(_ => { });
+var loadProgress = new Progress<Report>(_ => { });
+
+// Fluent Pipeline: base-class extractor -> transformer -> loader, with per-stage
+// progress, naming, and stage disposal — exercises the base-class machinery.
+var pipelineLoader = new ListLoader();
+await Pipeline
+    .Extract(new NumberExtractor(5))
+    .WithProgress(extractProgress)
+    .Transform(new DoubleTransformer())
+    .Load(pipelineLoader)
+    .WithProgress(loadProgress)
+    .WithName("aot-smoke")
+    .DisposeStagesOnCompletion()
+    .RunAsync(CancellationToken.None);
+
+Require(pipelineLoader.Items.SequenceEqual(new[] { 2, 4, 6, 8, 10 }), "Pipeline output");
+
+// Generic EtlPipeline: From (IAsyncEnumerable) -> Through (transformer) ->
+// To (base-class loader), with pipeline-level progress.
+var sink = new ListLoader();
+var etlProgress = new Progress<EtlPipelineProgress>(_ => { });
+await EtlPipeline
+    .Create()
+    .From(Numbers(3))
+    .Through(new PlusOneTransformer())
+    .To(sink)
+    .RunAsync(etlProgress, CancellationToken.None);
+
+Require(sink.Items.SequenceEqual(new[] { 2, 3, 4 }), "EtlPipeline output");
+
+// Escape hatch.
+var seen = 0;
+await foreach (var _ in EtlPipeline.Create().From(Numbers(4)).AsAsyncEnumerable(CancellationToken.None))
+{
+    seen++;
+}
+
+Require(seen == 4, "AsAsyncEnumerable");
+
+// Report metrics: fixed arithmetic, no reflection.
+var report = new Report(50)
+{
+    TotalItemCount = 100,
+    Elapsed = TimeSpan.FromSeconds(10),
+};
+
+Require(report.CurrentItemCount == 50, "Report.CurrentItemCount");
+Require(report.ItemsPerSecond == 5d, "Report.ItemsPerSecond");
+Require(report.PercentComplete == 50d, "Report.PercentComplete");
+Require(report.EstimatedRemaining == TimeSpan.FromSeconds(10), "Report.EstimatedRemaining");
+
+Console.WriteLine("AOT smoke: OK");
+return 0;
+
+
+static async IAsyncEnumerable<int> Numbers(int count)
+{
+    for (var i = 1; i <= count; i++)
+    {
+        yield return i;
+        await Task.Yield();
+    }
+}
+
+
+static void Require(bool ok, string what)
+{
+    if (ok)
+    {
+        return;
+    }
+
+    Console.Error.WriteLine($"AOT smoke FAILED: {what}");
+    Environment.Exit(1);
+}

--- a/tests/Wolfgang.Etl.Abstractions.AotSmoke/Stages.cs
+++ b/tests/Wolfgang.Etl.Abstractions.AotSmoke/Stages.cs
@@ -1,0 +1,71 @@
+using System.Runtime.CompilerServices;
+
+namespace Wolfgang.Etl.Abstractions.AotSmoke;
+
+internal sealed class NumberExtractor : ExtractorBase<int, Report>
+{
+    private readonly int _count;
+
+    public NumberExtractor(int count) => _count = count;
+
+    protected override async IAsyncEnumerable<int> ExtractWorkerAsync(
+        [EnumeratorCancellation] CancellationToken token)
+    {
+        for (var i = 1; i <= _count; i++)
+        {
+            token.ThrowIfCancellationRequested();
+            IncrementCurrentItemCount();
+            yield return i;
+            await Task.Yield();
+        }
+    }
+
+    protected override Report CreateProgressReport() => new(CurrentItemCount);
+}
+
+
+internal sealed class DoubleTransformer : TransformerBase<int, int, Report>
+{
+    protected override async IAsyncEnumerable<int> TransformWorkerAsync(
+        IAsyncEnumerable<int> items,
+        [EnumeratorCancellation] CancellationToken token)
+    {
+        await foreach (var item in items.WithCancellation(token))
+        {
+            yield return item * 2;
+        }
+    }
+
+    protected override Report CreateProgressReport() => new(CurrentItemCount);
+}
+
+
+internal sealed class PlusOneTransformer : ITransformAsync<int, int>
+{
+    public async IAsyncEnumerable<int> TransformAsync(IAsyncEnumerable<int> items)
+    {
+        await foreach (var item in items)
+        {
+            yield return item + 1;
+        }
+    }
+}
+
+
+internal sealed class ListLoader : LoaderBase<int, Report>
+{
+    private readonly List<int> _items = new();
+
+    public IReadOnlyList<int> Items => _items;
+
+    protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
+    {
+        await foreach (var item in items.WithCancellation(token))
+        {
+            IncrementCurrentItemCount();
+            _items.Add(item);
+        }
+    }
+
+    protected override Report CreateProgressReport() => new(CurrentItemCount);
+}

--- a/tests/Wolfgang.Etl.Abstractions.AotSmoke/Wolfgang.Etl.Abstractions.AotSmoke.csproj
+++ b/tests/Wolfgang.Etl.Abstractions.AotSmoke/Wolfgang.Etl.Abstractions.AotSmoke.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Native-AOT / trim smoke consumer (#213). Publishes the library into an
+       AOT + trimmed console app and runs it, so a reflection/dynamic-codegen
+       regression that breaks AOT consumers fails CI instead of the consumer's
+       publish. IsAotCompatible turns on the trim/AOT analyzers at BUILD time
+       (they run cross-platform), so an incompatibility is flagged as a
+       warning -> error even before the native link; aot.yaml does the actual
+       linux-x64 native publish + run. -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+
+    <PublishAot>true</PublishAot>
+    <PublishTrimmed>true</PublishTrimmed>
+    <IsAotCompatible>true</IsAotCompatible>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <!-- Report every trim warning, not just one per assembly, so nothing hides. -->
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Abstractions\Wolfgang.Etl.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds a Native-AOT / trim compatibility gate (issue #213). The library advertises `net8.0`/`net10.0`, but nothing verified it survives the trimmer/ILC — reflection on type names the trimmer can't see, dynamic generic instantiation, or runtime codegen break **silently** under AOT, and a consumer only finds out at *their* publish time.

Two parts:
- **`tests/Wolfgang.Etl.Abstractions.AotSmoke`** — a tiny console consumer (`ProjectReference`) with `<PublishAot>` + `<PublishTrimmed>` + `<IsAotCompatible>`. It exercises the public surface end to end: the fluent **`Pipeline`** (base-class extractor → transformer → loader, per-stage progress, `WithName`, `DisposeStagesOnCompletion`), the generic **`EtlPipeline`** (`From`/`Through`/`To`/`RunAsync` + `AsAsyncEnumerable`), all three **base classes**, `IProgress<Report>` / `EtlPipelineProgress`, and every **`Report`** metric — asserting results and exiting non-zero on any failure.
- **`.github/workflows/aot.yaml`** — on every PR (path-scoped to `src`/the smoke project), installs the ILC prerequisites (`clang`, `zlib1g-dev`), `dotnet publish -r linux-x64` with AOT, and **runs the native binary**. A reflection path that no-ops or throws `NotSupportedException` under AOT fails the job.

`IsAotCompatible` runs the trim/AOT analyzers at **build** time (cross-platform, warning→error under Release), so incompatibilities are caught in the normal build too; `aot.yaml` adds the real linux-x64 **native link + run**, which can only be done on Linux.

## Verification

- Local `dotnet build -c Release`: **0 IL/trim warnings** — the library's reachable surface is AOT-analyzer-clean.
- Managed run passes (`AOT smoke: OK`, exit 0).
- **actionlint + zizmor** clean on the new workflow (SHA-pinned actions per #298/#223).
- The real native `linux-x64` publish + run executes in this PR's own `aot.yaml` job.

## Acceptance criteria (#213)

- [x] A workflow publishes a console consumer with `PublishAot` + `PublishTrimmed` referencing the library.
- [x] The consumer exercises the public surface and the published binary runs without `NotSupportedException`/silent no-ops.
- [x] Trim-warning suppressions documented if required (**none needed** — surface is clean).
- [x] Runs on PRs so AOT regressions block before merge.

Additive; new project + workflow only.

Closes #213