### PR TITLE
ci: workflow / CI-infrastructure bundle for 0.16.1 (admin-bypass)

### DIFF
--- a/.github/license/allowed-licenses.json
+++ b/.github/license/allowed-licenses.json
@@ -1,0 +1,7 @@
+[
+  "MIT",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "MS-PL"
+]

--- a/.github/license/license-url-mappings.json
+++ b/.github/license/license-url-mappings.json
@@ -1,0 +1,4 @@
+{
+  "http://go.microsoft.com/fwlink/?LinkId=329770": "MIT",
+  "https://github.com/dotnet/standard/blob/master/LICENSE.TXT": "MIT"
+}

--- a/.github/workflows/aot.yaml
+++ b/.github/workflows/aot.yaml
@@ -1,0 +1,71 @@
+name: AOT / Trim Smoke
+
+# Native-AOT + trim compatibility gate (#213). The library advertises net8.0 /
+# net10.0 targets, but nothing verified it survives the trimmer / ILC: reflection
+# on type names the trimmer can't see, dynamic generic instantiation, or runtime
+# codegen break silently under AOT. This publishes a tiny consumer with
+# PublishAot + PublishTrimmed and RUNS the native binary — so an AOT regression
+# fails here, on the PR, instead of in a consumer's published app.
+#
+# The build-time trim/AOT analyzers (IsAotCompatible in the smoke csproj) already
+# run in the normal build; this job adds the real linux-x64 native link + run,
+# which can only be done on Linux.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+    paths:
+      - 'src/**/*.cs'
+      - 'src/**/*.csproj'
+      - 'tests/Wolfgang.Etl.Abstractions.AotSmoke/**'
+      - '.github/workflows/aot.yaml'
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  aot-smoke:
+    name: PublishAot linux-x64 + run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Install Native AOT prerequisites
+        # ILC links native code with clang against zlib; ubuntu-latest ships clang
+        # but the zlib dev headers must be installed.
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang zlib1g-dev
+
+      - name: Publish (Native AOT + trimmed)
+        # A trim/AOT incompatibility in the library's reachable surface fails the
+        # publish (analyzer warning -> error, or an ILC error) before the run.
+        run: >
+          dotnet publish
+          tests/Wolfgang.Etl.Abstractions.AotSmoke/Wolfgang.Etl.Abstractions.AotSmoke.csproj
+          -c Release -r linux-x64
+
+      - name: Run the published native binary
+        # No managed runtime here — the binary is fully native. A reflection path
+        # that silently no-ops or throws NotSupportedException under AOT makes the
+        # smoke exit non-zero and fails the job.
+        run: |
+          set -euo pipefail
+          BIN="tests/Wolfgang.Etl.Abstractions.AotSmoke/bin/Release/net10.0/linux-x64/publish/Wolfgang.Etl.Abstractions.AotSmoke"
+          "$BIN"

--- a/.github/workflows/build-all-versions.yaml
+++ b/.github/workflows/build-all-versions.yaml
@@ -25,13 +25,13 @@ jobs:
 
     steps:
       - name: Checkout repository (full history + all tags)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0 # Full history so all tags are reachable
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             5.0.x

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         persist-credentials: false
 
@@ -77,7 +77,7 @@ jobs:
 
     - name: Initialize CodeQL
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
       with:
         languages: ${{ matrix.language }}
         # security-extended adds the broader security query pack on top of the
@@ -86,7 +86,7 @@ jobs:
 
     - name: Setup .NET
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
       with:
         dotnet-version: '10.0.x'
 
@@ -159,7 +159,7 @@ jobs:
     - name: Perform CodeQL Analysis
       id: perform-codeql-analysis
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
       with:
         category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/cross-platform-differential.yaml
+++ b/.github/workflows/cross-platform-differential.yaml
@@ -1,0 +1,111 @@
+name: Cross-Platform Differential
+
+# Cross-platform / multi-arch differential (#209).
+#
+# pr.yaml already runs the suite on Linux/Windows/macOS and requires it to *pass*
+# on each. This workflow verifies it passes the SAME WAY on each — including
+# ARM64, which pr.yaml does not cover. Each runner produces a normalized list of
+# "test name -> outcome"; the diff job fails if any platform's list diverges from
+# the linux-x64 reference (catching a test that passes on x64 but behaves
+# differently on arm64: culture sorts, line endings, timing, FS case).
+
+on:
+  schedule:
+    - cron: '30 6 * * 1'   # weekly, Monday 06:30 UTC
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - vNext
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/cross-platform-differential.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-platform-differential-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    name: Test ${{ matrix.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-latest,    label: linux-x64 }
+          - { runner: ubuntu-24.04-arm, label: linux-arm64 }
+          - { runner: macos-latest,     label: macos-arm64 }
+          - { runner: windows-latest,   label: windows-x64 }
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.x'
+
+      - name: Run tests (net10.0)
+        shell: bash
+        # Do not fail here — a failing/diverging test must reach the diff job,
+        # where a *difference* between platforms is the real signal.
+        run: |
+          dotnet test tests/Wolfgang.Etl.Abstractions.Tests.Unit/Wolfgang.Etl.Abstractions.Tests.Unit.csproj \
+            -c Release -f net10.0 \
+            --logger "trx;LogFileName=results.trx" \
+            --results-directory trx || true
+
+      - name: Normalize outcomes
+        shell: bash
+        run: |
+          python scripts/normalize-trx.py trx "outcomes-${{ matrix.label }}.txt"
+
+      - name: Upload outcomes
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: outcomes-${{ matrix.label }}
+          path: outcomes-${{ matrix.label }}.txt
+
+  diff:
+    name: Diff outcomes across platforms
+    needs: run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all outcomes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: outcomes
+
+      - name: Compare against linux-x64
+        run: |
+          ref="outcomes/outcomes-linux-x64/outcomes-linux-x64.txt"
+          if [ ! -f "$ref" ]; then
+            echo "::error::reference outcomes (linux-x64) missing"
+            exit 1
+          fi
+          fail=0
+          for dir in outcomes/outcomes-*/; do
+            file=$(find "$dir" -name 'outcomes-*.txt' | head -n1)
+            label=$(basename "$dir" | sed 's/^outcomes-//')
+            if ! diff -u "$ref" "$file" > "diff-$label.txt"; then
+              echo "::error::Test outcomes on $label diverge from linux-x64:"
+              cat "diff-$label.txt"
+              fail=1
+            else
+              echo "✅ $label matches linux-x64"
+            fi
+          done
+          exit $fail

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0  # Full history needed to enumerate all v* tags
           persist-credentials: false
@@ -127,7 +127,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             5.0.x

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,0 +1,77 @@
+name: Fuzz
+
+# Continuous fuzz sweep (#196). The unit suite runs the same CsCheck properties
+# at ~1000 cases per PR (seconds); this scheduled workflow runs them at a far
+# higher case count to surface rare edge cases, and auto-files an issue if a
+# property is falsified. CsCheck prints a replayable seed on failure, so the
+# reported case can be pinned as a deterministic regression in the unit suite.
+
+on:
+  schedule:
+    - cron: '0 5 * * 0'   # weekly, Sunday 05:00 UTC
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: 'Cases per property'
+        required: false
+        default: '1000000'
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Property fuzz sweep
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write   # auto-file an issue when a property is falsified
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Run fuzz sweep
+        id: fuzz
+        env:
+          FUZZ_ITER: ${{ github.event.inputs.iterations || '1000000' }}
+        run: |
+          set -o pipefail
+          dotnet test tests/Wolfgang.Etl.Abstractions.Tests.Fuzz/Wolfgang.Etl.Abstractions.Tests.Fuzz.csproj \
+            -c Release --logger "console;verbosity=detailed" 2>&1 | tee fuzz-output.txt
+
+      - name: Upload fuzz log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: fuzz-output
+          path: fuzz-output.txt
+          retention-days: 30
+
+      - name: File issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # CsCheck prints a replayable seed in the failure output; the issue body
+          # carries the log tail so the seed can be pinned as a regression.
+          {
+            echo "The scheduled fuzz sweep falsified a property."
+            echo ""
+            echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo ""
+            echo '```'
+            tail -c 4000 fuzz-output.txt || true
+            echo '```'
+          } > issue-body.txt
+          gh issue create \
+            --title "Fuzz sweep falsified a property ($(date -u +%Y-%m-%d))" \
+            --label bug \
+            --body-file issue-body.txt

--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -1,0 +1,57 @@
+name: License Audit
+
+# Transitive-dependency license audit (#218). Dependabot tracks dependency
+# versions and CVEs but not the *licenses* of transitive packages — a new
+# transitive dep under an incompatible license (GPL/AGPL/OSL/source-available)
+# would silently leak into this MIT-licensed package. This job enumerates every
+# transitive package and fails on any license outside the documented allowlist.
+#
+# Allowlist:            .github/license/allowed-licenses.json
+# License-URL mappings: .github/license/license-url-mappings.json
+# Ignored (build-only): SonarAnalyzer.CSharp (SONAR source-available; PrivateAssets=all,
+#                       never distributed to consumers).
+
+on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+  schedule:
+    - cron: '30 7 * * 1'   # weekly, Monday 07:30 UTC
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: License audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+
+      - name: Install nuget-license
+        run: |
+          dotnet tool install --global nuget-license
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Audit transitive licenses
+        run: |
+          nuget-license \
+            -i src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj \
+            -t \
+            -a .github/license/allowed-licenses.json \
+            -mapping .github/license/license-url-mappings.json \
+            -ignore SonarAnalyzer.CSharp \
+            -o Table

--- a/.github/workflows/pr-benchmarks.yaml
+++ b/.github/workflows/pr-benchmarks.yaml
@@ -1,39 +1,43 @@
-name: Benchmarks
+name: PR Benchmarks
 
-# Runs BenchmarkDotNet after a merge to main, then publishes the results to
-# the gh-pages branch under /dev/bench/ where benchmark-action/github-action-benchmark
-# renders an interactive line chart.
+# Forward-looking perf-regression signal (#224). benchmarks.yaml graphs the BDN
+# trend AFTER a merge to main (backward-looking). This workflow runs the suite on
+# a PR and compares it against the gh-pages baseline, posting a delta comment and
+# failing the PR if a metric regresses past the alert threshold — so a PR that
+# balloons allocations or runtime is caught before merge, not after.
 #
-# This workflow is decoupled from PR validation and release: it does NOT gate
-# merging or publishing — it just adds one data point per qualifying push.
+# Scoped to code that can actually move the numbers (src/**, benchmarks/**) so it
+# does not run on docs/test-only PRs, and to main/vNext so it exercises release
+# candidates. Full mutation-style cost is avoided by BDN's --job short.
 
 on:
-  push:
-    branches: [main]
+  pull_request:
+    branches:
+      - main
+      - vNext
     paths:
-      - 'src/**'
-      - 'benchmarks/**'
-      - '.github/workflows/benchmarks.yaml'
+      # Only run on actual code changes — a version/csproj/docs-only PR can't move
+      # the numbers, so it should not spend ~5 min on benchmarks.
+      - 'src/**/*.cs'
+      - 'benchmarks/**/*.cs'
+      - '.github/workflows/pr-benchmarks.yaml'
   workflow_dispatch:
 
 permissions:
   contents: read
 
-# Serialize benchmark publishes so two pushes to main close together can't race
-# on the gh-pages branch. cancel-in-progress: false — every merge represents a
-# meaningful data point, so we queue rather than discard.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: pr-benchmarks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   benchmark:
-    name: Run BenchmarkDotNet & publish chart
+    name: BDN delta vs base
     runs-on: ubuntu-latest
 
     permissions:
-      # Required to push the rendered chart + history to the gh-pages branch.
-      contents: write
+      contents: read
+      pull-requests: write   # post / update the delta comment
 
     steps:
       - name: Checkout repository
@@ -55,9 +59,9 @@ jobs:
 
       - name: Run benchmarks
         working-directory: benchmarks/Wolfgang.Etl.Abstractions.Benchmarks
-        # ShortRun keeps total runtime small (~3-5 min). GitHub-hosted runners
-        # are noisy, so chart trends are reliable for allocations and double-digit
-        # time changes; smaller deltas are not.
+        # ShortRun (~3-5 min). GitHub-hosted runners are noisy, so the delta is
+        # reliable for allocations and double-digit time changes; the alert
+        # threshold below is set accordingly to avoid false alarms.
         run: dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
 
       - name: Merge per-class BDN reports
@@ -67,9 +71,6 @@ jobs:
           # BDN's --exporters json writes one *-report-full-compressed.json per
           # benchmark class. github-action-benchmark consumes a single file, so
           # we combine the .Benchmarks arrays into one synthetic report.
-          # nullglob: empty match expands to nothing (instead of the literal
-          # pattern), so the explicit "no report found" branch can run before
-          # set -e + pipefail aborts the step.
           shopt -s nullglob
           reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
           if [ ${#reports[@]} -eq 0 ]; then
@@ -85,9 +86,10 @@ jobs:
           }' "${reports[@]}" > benchmarks-result.json
           echo "report=benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
 
-      - name: Publish chart to gh-pages
-        # Pinned to v1.22.1 commit per repo convention (third-party actions
-        # publishing to gh-pages are pinned by SHA, not mutable tag).
+      - name: Compare against baseline & comment
+        # Same action + SHA pin as benchmarks.yaml. Compares the PR result against
+        # the gh-pages baseline (latest main data point) WITHOUT pushing:
+        # auto-push:false + save-data-file:false leave gh-pages untouched.
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba  # v1.22.1
         with:
           name: BenchmarkDotNet
@@ -95,9 +97,13 @@ jobs:
           output-file-path: ${{ steps.locate.outputs.report }}
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
-          auto-push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Don't fail the workflow if a metric regresses — this is a tracker,
-          # not a gate. Tighten later if the noise floor settles.
-          alert-threshold: '200%'
-          fail-on-alert: false
+          auto-push: false
+          save-data-file: false
+          summary-always: true
+          comment-always: true
+          comment-on-alert: true
+          # 150% = a metric 1.5x worse than baseline. Deliberately loose because
+          # GitHub-hosted runners are noisy; tighten once the noise floor settles.
+          alert-threshold: '150%'
+          fail-on-alert: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -42,7 +42,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -96,7 +96,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -275,7 +275,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -337,7 +337,7 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           # Install every SDK the test stages install. The solution
           # multi-targets out-of-support TFMs (netcoreapp3.1 / net5.0 /
@@ -395,7 +395,7 @@ jobs:
             --no-build
 
       - name: Upload SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
         with:
           sarif_file: inspect.sarif
 
@@ -431,7 +431,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -518,7 +518,7 @@ jobs:
           sudo rm /etc/apt/sources.list.d/focal-security.list
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             3.1.x
@@ -806,7 +806,7 @@ jobs:
 
       - name: Upload Linux coverage results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-linux
           path: |
@@ -814,7 +814,7 @@ jobs:
             CoverageReport/
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-output
           path: |
@@ -832,7 +832,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -887,7 +887,7 @@ jobs:
           Write-Host "✅ Configuration files secured - using versions from main branch"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             3.1.x
@@ -1125,7 +1125,7 @@ jobs:
 
       - name: Upload Windows coverage results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-windows
           path: |
@@ -1143,7 +1143,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -1215,7 +1215,7 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             6.0.x
@@ -1480,7 +1480,7 @@ jobs:
 
       - name: Upload macOS coverage results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-macos
           path: |
@@ -1530,7 +1530,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -1635,7 +1635,7 @@ jobs:
 
       - name: Upload security scan results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: devskim-results
           path: devskim-results.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -85,7 +85,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             3.1.x
@@ -340,7 +340,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-coverage
           path: CoverageReport/
@@ -354,12 +354,12 @@ jobs:
       has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             3.1.x
@@ -562,7 +562,7 @@ jobs:
 
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nuget-packages
           path: ./nuget-packages/
@@ -581,7 +581,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -598,7 +598,7 @@ jobs:
 
       - name: Setup .NET
         if: steps.check.outputs.found == 'true'
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           # Install the same SDK set as validate-release so dotnet build can
           # compile every TFM the solution targets (some test projects span
@@ -677,7 +677,7 @@ jobs:
       contents: read
     steps:
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             3.1.x
@@ -689,14 +689,14 @@ jobs:
             10.0.x
 
       - name: Download packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-packages
           path: ./packages
 
       - name: NuGet login (OIDC trusted publishing)
         id: nuget-login
-        uses: NuGet/login@v1
+        uses: NuGet/login@ebc737b6fc418a6ca0073cf116ec8dc156d8b81e # v1
         with:
           user: Chris-Wolfgang
 
@@ -755,13 +755,13 @@ jobs:
       contents: write  # Required to upload assets to the GitHub Release
     steps:
       - name: Download NuGet packages artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-packages
           path: ./nuget-packages
 
       - name: Download coverage report artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-coverage
           path: ./release-coverage

--- a/.github/workflows/reproducible-build.yaml
+++ b/.github/workflows/reproducible-build.yaml
@@ -1,0 +1,70 @@
+name: Build Reproducibility
+
+# Deterministic-build verification (#216).
+#
+# The library builds with Deterministic + ContinuousIntegrationBuild + SourceLink,
+# which should make the compiled assembly byte-for-byte reproducible regardless of
+# the checkout path. This job proves it: check the same commit out to two different
+# directories, build each with ContinuousIntegrationBuild=true (which normalises
+# source paths to /_/), and fail if the produced assemblies don't hash identically.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reproducible-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reproducible:
+    name: Reproducible build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      ASM: src/Wolfgang.Etl.Abstractions/bin/Release/net10.0/Wolfgang.Etl.Abstractions.dll
+      PROJ: src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+    steps:
+      - name: Checkout (copy A)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: a
+          persist-credentials: false
+
+      - name: Checkout (copy B)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: b
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build copy A
+        run: dotnet build "a/${{ env.PROJ }}" -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+
+      - name: Build copy B
+        run: dotnet build "b/${{ env.PROJ }}" -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+
+      - name: Compare assembly hashes
+        run: |
+          ha=$(sha256sum "a/${ASM}" | cut -d' ' -f1)
+          hb=$(sha256sum "b/${ASM}" | cut -d' ' -f1)
+          echo "A: $ha"
+          echo "B: $hb"
+          if [ "$ha" != "$hb" ]; then
+            echo "::error::Build is not reproducible — assembly hashes differ."
+            exit 1
+          fi
+          echo "✅ Reproducible: $ha"

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,52 @@
+name: Scorecard supply-chain security
+
+# OSSF Scorecard (#222): scores the repository's security posture (branch
+# protection, pinned dependencies, dangerous-workflow patterns, token
+# permissions, ...) against ~20 best practices and uploads the result to the
+# code-scanning / Security tab. Distinct from CodeQL — Scorecard grades the repo
+# *configuration*, not the source code. publish_results powers the README badge.
+
+on:
+  # Re-score when branch-protection rules change (a common posture regression).
+  branch_protection_rule:
+  schedule:
+    - cron: '20 7 * * 1'   # weekly, Monday 07:20 UTC
+  push:
+    branches:
+      - main
+
+# Top-level least privilege; the analysis job opts into exactly what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload the SARIF result to code-scanning
+      id-token: write          # publish to the OpenSSF API (badge + transparency log)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the OpenSSF transparency log so the README badge resolves.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,69 @@
+name: SAST (Semgrep)
+
+# Security-grade static analysis beyond CodeQL (#198).
+#
+# Semgrep runs a different engine and ruleset from CodeQL (pattern/dataflow rules
+# for C#, a general security-audit pack, and a secrets pack), so it surfaces
+# issues CodeQL's queries don't. Findings upload to Code Scanning (Security tab)
+# as an additional signal; report-only for now (`|| true`) so a noisy new ruleset
+# version can't block merges — the current baseline is clean (0 findings), so this
+# can be promoted to a gate later.
+#
+# Uses the public Semgrep registry packs, which need no account/login. The scan
+# is scoped to src/ (the shipped library) — SAST belongs on shipped code, and
+# scanning test/CI-helper scripts only produces false positives (e.g. stdlib xml
+# use in a CI trx parser that reads trusted, self-generated input). Repo-wide
+# secret scanning is already covered by gitleaks in pr.yaml.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: semgrep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Semgrep
+        run: pip install semgrep
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config p/csharp \
+            --config p/security-audit \
+            --config p/secrets \
+            --sarif --output semgrep.sarif \
+            --error src/ || true
+
+      - name: Upload Semgrep SARIF
+        uses: github/codeql-action/upload-sarif@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
+        with:
+          sarif_file: semgrep.sarif

--- a/.github/workflows/sourcelink.yaml
+++ b/.github/workflows/sourcelink.yaml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -56,7 +56,7 @@ jobs:
 
       - name: Setup .NET
         if: steps.detect.outputs.found == 'true'
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: '10.0.x'
 

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Setup .NET
         if: steps.check.outputs.found == 'true'
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             8.0.x
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload Stryker report
         if: always() && steps.check.outputs.found == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: stryker-report-${{ github.run_id }}
           path: |

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -1,0 +1,62 @@
+name: Workflow Security
+
+# Lints the GitHub Actions workflows themselves (#223):
+#   - actionlint: syntax, shell (shellcheck), and expression errors.
+#   - zizmor:     workflow-level security (template injection, over-broad
+#                 permissions, unpinned actions, dangerous triggers).
+# The zizmor pinning policy lives in .github/zizmor.yml. Both tools fail the PR
+# on a finding, so a workflow change that introduces one is caught before merge
+# rather than on the server after.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Run actionlint
+        # Download + checksum-verify the pinned binary (same pattern as the
+        # gitleaks step in pr.yaml) rather than a floating third-party action.
+        run: |
+          set -euo pipefail
+          ACTIONLINT_VERSION="1.7.12"
+          ACTIONLINT_SHA256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+          TARBALL="actionlint.tar.gz"
+          curl -sSfL -o "$TARBALL" "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  ${TARBALL}" | sha256sum -c -
+          tar -xzf "$TARBALL" actionlint
+          ./actionlint -color
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+
+      - name: Install zizmor
+        run: pip install zizmor==1.26.1
+
+      - name: Run zizmor
+        # --format=github emits inline PR annotations; a high-severity finding
+        # exits non-zero and fails the job.
+        run: zizmor --format=github --min-severity=high --config .github/zizmor.yml .github/workflows/

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,26 @@
+# zizmor configuration (#223).
+#
+# Pinning policy: every action reference must be pinned to a full commit hash.
+# This repo SHA-pinned all of its actions in #298 (first-party actions/* and
+# github/* included, not just third-party), so the strictest policy is the one
+# that matches reality and keeps it that way — a future PR that adds a
+# tag-pinned action is a high-severity finding that fails the check.
+#
+# (Local reusable-workflow calls of the form `uses: ./…` are not registry
+# actions and are not subject to pinning.)
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": hash-pin
+
+  # Accepted-suppression baseline. Each entry is a pre-existing finding that is
+  # intentional; a NEW high-severity finding anywhere else still fails the PR.
+  dangerous-triggers:
+    ignore:
+      # pr.yaml's `pull_request_target` is deliberate: the protected-file guard
+      # ("Detect .NET Projects") must run trusted workflow code from the base
+      # branch, not from the PR branch, so it cannot be spoofed by a fork PR.
+      # It never checks out or executes PR-supplied code, which is what makes
+      # pull_request_target dangerous. Revisiting this is out of scope for #223.
+      - pr.yaml

--- a/scripts/normalize-trx.py
+++ b/scripts/normalize-trx.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Normalize VSTest .trx output to a sorted, platform-independent list of
+"test name<TAB>outcome" lines, for the cross-platform differential (#209).
+
+Usage: python scripts/normalize-trx.py <trx-dir> <output-file>
+
+Only the test name and outcome are emitted — durations, machine names, and
+timestamps are intentionally excluded so the list is identical across platforms
+when behaviour is identical.
+"""
+import glob
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+NS = "{http://microsoft.com/schemas/VisualStudio/TeamTest/2010}"
+
+
+def main(trx_dir: str, out_file: str) -> None:
+    rows = []
+    for path in glob.glob(os.path.join(trx_dir, "**", "*.trx"), recursive=True):
+        tree = ET.parse(path)
+        for result in tree.iter(NS + "UnitTestResult"):
+            rows.append(f"{result.get('testName')}\t{result.get('outcome')}")
+
+    rows.sort()
+    with open(out_file, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write("\n".join(rows))
+        handle.write("\n")
+
+    print(f"wrote {len(rows)} outcomes to {out_file}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: normalize-trx.py <trx-dir> <output-file>", file=sys.stderr)
+        sys.exit(2)
+    main(sys.argv[1], sys.argv[2])

--- a/tests/Wolfgang.Etl.Abstractions.AotSmoke/Program.cs
+++ b/tests/Wolfgang.Etl.Abstractions.AotSmoke/Program.cs
@@ -1,0 +1,87 @@
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.Abstractions.AotSmoke;
+
+// Native-AOT / trim smoke (#213). Exercises the library's public surface — both
+// pipeline builders, all three base classes, progress reporting, and Report — so
+// that a reflection / dynamic-codegen path that breaks under AOT surfaces here as
+// a NotSupportedException / MissingMethodException at run time (or a trim warning
+// at publish) instead of in a consumer's AOT-published app.
+
+Console.WriteLine("AOT smoke: exercising Wolfgang.Etl.Abstractions...");
+
+var extractProgress = new Progress<Report>(_ => { });
+var loadProgress = new Progress<Report>(_ => { });
+
+// Fluent Pipeline: base-class extractor -> transformer -> loader, with per-stage
+// progress, naming, and stage disposal — exercises the base-class machinery.
+var pipelineLoader = new ListLoader();
+await Pipeline
+    .Extract(new NumberExtractor(5))
+    .WithProgress(extractProgress)
+    .Transform(new DoubleTransformer())
+    .Load(pipelineLoader)
+    .WithProgress(loadProgress)
+    .WithName("aot-smoke")
+    .DisposeStagesOnCompletion()
+    .RunAsync(CancellationToken.None);
+
+Require(pipelineLoader.Items.SequenceEqual(new[] { 2, 4, 6, 8, 10 }), "Pipeline output");
+
+// Generic EtlPipeline: From (IAsyncEnumerable) -> Through (transformer) ->
+// To (base-class loader), with pipeline-level progress.
+var sink = new ListLoader();
+var etlProgress = new Progress<EtlPipelineProgress>(_ => { });
+await EtlPipeline
+    .Create()
+    .From(Numbers(3))
+    .Through(new PlusOneTransformer())
+    .To(sink)
+    .RunAsync(etlProgress, CancellationToken.None);
+
+Require(sink.Items.SequenceEqual(new[] { 2, 3, 4 }), "EtlPipeline output");
+
+// Escape hatch.
+var seen = 0;
+await foreach (var _ in EtlPipeline.Create().From(Numbers(4)).AsAsyncEnumerable(CancellationToken.None))
+{
+    seen++;
+}
+
+Require(seen == 4, "AsAsyncEnumerable");
+
+// Report metrics: fixed arithmetic, no reflection.
+var report = new Report(50)
+{
+    TotalItemCount = 100,
+    Elapsed = TimeSpan.FromSeconds(10),
+};
+
+Require(report.CurrentItemCount == 50, "Report.CurrentItemCount");
+Require(report.ItemsPerSecond == 5d, "Report.ItemsPerSecond");
+Require(report.PercentComplete == 50d, "Report.PercentComplete");
+Require(report.EstimatedRemaining == TimeSpan.FromSeconds(10), "Report.EstimatedRemaining");
+
+Console.WriteLine("AOT smoke: OK");
+return 0;
+
+
+static async IAsyncEnumerable<int> Numbers(int count)
+{
+    for (var i = 1; i <= count; i++)
+    {
+        yield return i;
+        await Task.Yield();
+    }
+}
+
+
+static void Require(bool ok, string what)
+{
+    if (ok)
+    {
+        return;
+    }
+
+    Console.Error.WriteLine($"AOT smoke FAILED: {what}");
+    Environment.Exit(1);
+}

--- a/tests/Wolfgang.Etl.Abstractions.AotSmoke/Stages.cs
+++ b/tests/Wolfgang.Etl.Abstractions.AotSmoke/Stages.cs
@@ -1,0 +1,71 @@
+using System.Runtime.CompilerServices;
+
+namespace Wolfgang.Etl.Abstractions.AotSmoke;
+
+internal sealed class NumberExtractor : ExtractorBase<int, Report>
+{
+    private readonly int _count;
+
+    public NumberExtractor(int count) => _count = count;
+
+    protected override async IAsyncEnumerable<int> ExtractWorkerAsync(
+        [EnumeratorCancellation] CancellationToken token)
+    {
+        for (var i = 1; i <= _count; i++)
+        {
+            token.ThrowIfCancellationRequested();
+            IncrementCurrentItemCount();
+            yield return i;
+            await Task.Yield();
+        }
+    }
+
+    protected override Report CreateProgressReport() => new(CurrentItemCount);
+}
+
+
+internal sealed class DoubleTransformer : TransformerBase<int, int, Report>
+{
+    protected override async IAsyncEnumerable<int> TransformWorkerAsync(
+        IAsyncEnumerable<int> items,
+        [EnumeratorCancellation] CancellationToken token)
+    {
+        await foreach (var item in items.WithCancellation(token))
+        {
+            yield return item * 2;
+        }
+    }
+
+    protected override Report CreateProgressReport() => new(CurrentItemCount);
+}
+
+
+internal sealed class PlusOneTransformer : ITransformAsync<int, int>
+{
+    public async IAsyncEnumerable<int> TransformAsync(IAsyncEnumerable<int> items)
+    {
+        await foreach (var item in items)
+        {
+            yield return item + 1;
+        }
+    }
+}
+
+
+internal sealed class ListLoader : LoaderBase<int, Report>
+{
+    private readonly List<int> _items = new();
+
+    public IReadOnlyList<int> Items => _items;
+
+    protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
+    {
+        await foreach (var item in items.WithCancellation(token))
+        {
+            IncrementCurrentItemCount();
+            _items.Add(item);
+        }
+    }
+
+    protected override Report CreateProgressReport() => new(CurrentItemCount);
+}

--- a/tests/Wolfgang.Etl.Abstractions.AotSmoke/Wolfgang.Etl.Abstractions.AotSmoke.csproj
+++ b/tests/Wolfgang.Etl.Abstractions.AotSmoke/Wolfgang.Etl.Abstractions.AotSmoke.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Native-AOT / trim smoke consumer (#213). Publishes the library into an
+       AOT + trimmed console app and runs it, so a reflection/dynamic-codegen
+       regression that breaks AOT consumers fails CI instead of the consumer's
+       publish. IsAotCompatible turns on the trim/AOT analyzers at BUILD time
+       (they run cross-platform), so an incompatibility is flagged as a
+       warning -> error even before the native link; aot.yaml does the actual
+       linux-x64 native publish + run. -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+
+    <PublishAot>true</PublishAot>
+    <PublishTrimmed>true</PublishTrimmed>
+    <IsAotCompatible>true</IsAotCompatible>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <!-- Report every trim warning, not just one per assembly, so nothing hides. -->
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Abstractions\Wolfgang.Etl.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

**Protected-file split for the 0.16.1 release.** The release PR #305 (vNext → main) includes 17 `.github/workflows/*` changes, which trip the `Detect .NET Projects` protected-file guard and require an admin-bypass merge. This PR extracts just the CI-infrastructure so the *rest* of the release (docs, tests, csproj version bump, sln) can go through full CI in #305 without a bypass.

Carries:
- **9 new workflows**: `aot`, `cross-platform-differential`, `fuzz`, `license-audit`, `pr-benchmarks`, `reproducible-build`, `scorecard`, `semgrep`, `workflow-security`.
- **8 SHA-pin-modified workflows**: `pr`, `release`, `benchmarks`, `build-all-versions`, `codeql`, `docfx`, `sourcelink`, `stryker`.
- **Supporting non-protected files** the workflows need so this bundle's own CI is self-sufficient: `.github/zizmor.yml`, `.github/license/*.json`, `scripts/normalize-trx.py`, and the `tests/Wolfgang.Etl.Abstractions.AotSmoke` consumer that `aot.yaml` publishes.

All content is verbatim from `vNext` (already green there).

## Merge

Requires **admin-bypass** (waives the protected-file guard — everything else is green). After this merges, `main` is merged into #305, whose diff then drops to a clean non-protected set that passes the guard and full CI.

Part of the 0.16.1 release; no `Closes` (issues close via #305).