### PR TITLE
ci: SLSA build-provenance attestation at release (#208, partial)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -752,13 +752,27 @@ jobs:
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Required to upload assets to the GitHub Release
+      contents: write       # Required to upload assets to the GitHub Release
+      id-token: write       # OIDC token for the SLSA build-provenance attestation (#208)
+      attestations: write   # Write the provenance to the repo's attestation store (#208)
     steps:
       - name: Download NuGet packages artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-packages
           path: ./nuget-packages
+
+      - name: Generate SLSA build-provenance attestation
+        # Attests each packed .nupkg — records a signed, verifiable statement that
+        # this artifact was built by THIS workflow from THIS repo/commit. Stored in
+        # the repo's attestation store; consumers verify with
+        # `gh attestation verify <pkg> --repo Chris-Wolfgang/ETL-Abstractions`.
+        # (Complements the CycloneDX SBOM already attached below. Package signing —
+        # `nuget verify`-able signatures — is separate and needs a code-signing
+        # certificate; still tracked on #208.)
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: './nuget-packages/*.nupkg'
 
       - name: Download coverage report artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,3 +31,28 @@ Facts a maintainer would need at 2am if the release identity is compromised. Gen
 - **Owner**: @Chris-Wolfgang.
 - **Downstream consumers**: this is the framework's foundational package — every `Wolfgang.Etl.*` library depends on it, including `Wolfgang.Etl.TestKit`, `Wolfgang.Etl.Transformers`, and the format packages (`Wolfgang.Etl.Csv`, `.Json`, `.Xml`, `.FixedWidth`, `.SqlBulkCopy`, `.DbClient`). A compromise cascades to all of them. Unknown external consumers may also exist on nuget.org.
 - **Package coordinates for unlisting**: `Wolfgang.Etl.Abstractions` — https://www.nuget.org/packages/Wolfgang.Etl.Abstractions/ (single package; symbols publish as the matching `.snupkg`).
+
+## Verifying the supply chain
+
+Each release ships provenance so consumers can verify what they downloaded:
+
+- **SBOM** — a CycloneDX SBOM (`Wolfgang.Etl.Abstractions.bom.json`) is generated at
+  release time and attached to the GitHub Release, listing the package's transitive
+  dependency set.
+- **SLSA build provenance** — each `.nupkg` is attested with
+  [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance),
+  recording a signed statement that the artifact was built by this repo's
+  `release.yaml` from a specific commit. Verify a downloaded package with:
+
+  ```bash
+  gh attestation verify Wolfgang.Etl.Abstractions.<version>.nupkg \
+    --repo Chris-Wolfgang/ETL-Abstractions
+  ```
+
+  A pass confirms the package's digest matches an attestation produced by this
+  repository's release workflow.
+
+> **Not yet enabled — Authenticode/NuGet package signing.** The `.nupkg` is not yet
+> signed with a code-signing certificate, so `nuget verify --signatures` will report
+> it as unsigned. That is tracked on issue #208 and requires a code-signing
+> certificate; the SBOM + SLSA attestation above are the current verification path.


### PR DESCRIPTION
## Summary

Adds **SLSA build provenance** to the release (issue #208). The `update-release-artifacts` job now runs [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance) on each packed `.nupkg` — recording a signed, verifiable statement that the artifact was built by *this* repo's `release.yaml` from a specific commit, stored in the repo's attestation store. The job gains `id-token: write` + `attestations: write` for it (action SHA-pinned per the zizmor `hash-pin` policy).

`SECURITY.md` gains a **"Verifying the supply chain"** section documenting how a consumer verifies the artifacts:
```bash
gh attestation verify Wolfgang.Etl.Abstractions.<version>.nupkg \
  --repo Chris-Wolfgang/ETL-Abstractions
```
and explicitly notes what's *not* yet done.

## Scope vs #208 — partial (intentionally not `Closes`)

| AC item | Status |
|---|---|
| SBOM attached to release | ✅ already shipping (CycloneDX `bom.json`) |
| **SLSA attestation** | ✅ **this PR** |
| NuGet package **signing** (`nuget verify`) | ⛔ **blocked — needs a code-signing certificate** |
| `SECURITY.md` verification procedure | ✅ this PR (for SBOM + attestation) |

So #208 stays open for the signing half. If you have (or want to provision) a code-signing cert + secret, I can add the `dotnet nuget sign` step as a follow-up.

## Validation
- **zizmor** (`hash-pin`) + **actionlint** clean on the modified `release.yaml`.
- The attestation itself only runs on an actual release (can't be exercised on a PR); the step is the standard first-party action used as documented.

Relates to #208 (does not close it).