### PR TITLE
fix: guard allocation-free tests for net462/net472 (#217 regression)

### DIFF
--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Performance/AllocationFreeTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Performance/AllocationFreeTests.cs
@@ -1,3 +1,7 @@
+// GC.GetAllocatedBytesForCurrentThread was added to .NET Framework in 4.8, so this
+// suite compiles on net48+ / netcoreapp3.1+ / net5.0+ but not net462/net472. The
+// allocation behaviour under test is TFM-agnostic, so the modern targets cover it.
+#if !NET462 && !NET472
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -127,3 +131,4 @@ public sealed class AllocationFreeTests
         protected override Report CreateProgressReport() => new(CurrentItemCount);
     }
 }
+#endif


### PR DESCRIPTION
## Summary

The allocation-free tests added in #308 (issue #217) **fail to compile on `net462`/`net472`** — `GC.GetAllocatedBytesForCurrentThread` was added to .NET Framework in **4.8**, not 4.6.2 as the original PR assumed. This breaks the **Debug solution build** on those targets (`CS0117`), which surfaced when running Stryker (its initial `dotnet build` of the solution failed).

Root cause: the original PR validated only `net10.0` and `net48` and missed `net462`/`net472`.

**Fix:** guard the suite with `#if !NET462 && !NET472`. It still runs on `net48+` / `netcoreapp3.1+` / `net5.0+`; the allocation behaviour under test is TFM-agnostic, so the modern targets cover it.

## Validation
`dotnet build -c Debug` now succeeds on **net462, net472, net48, and net10.0** (previously net462/net472 errored).

Refs #217 (fixes a regression from #308).