### PR TITLE
test: raise Stryker mutation score to ~87% and ratchet the gate (#205)

### DIFF
--- a/stryker-config.json
+++ b/stryker-config.json
@@ -12,8 +12,8 @@
     ],
     "thresholds": {
       "high": 90,
-      "low": 75,
-      "break": 0
+      "low": 80,
+      "break": 80
     }
   }
 }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ExtractorBaseCoverageTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ExtractorBaseCoverageTests.cs
@@ -1,0 +1,309 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
+
+/// <summary>
+/// Behavioural coverage for <see cref="ExtractorBase{TSource, TProgress}"/> beyond the
+/// TestKit contract tests — per-run counter reset, <c>StartedAt</c>/<c>Elapsed</c> timing,
+/// the progress-path final report, and timer disposal (mutation-testing hardening, #205).
+/// </summary>
+public sealed class ExtractorBaseCoverageTests
+{
+    private static async Task Drain(IAsyncEnumerable<int> source)
+    {
+        await foreach (var item in source)
+        {
+            _ = item;
+        }
+    }
+
+
+    [Fact]
+    public async Task CurrentItemCount_resets_between_runs()
+    {
+        var extractor = new TimedExtractor(count: 5);
+
+        await Drain(extractor.ExtractAsync());
+        Assert.Equal(5, extractor.CurrentItemCount);
+
+        await Drain(extractor.ExtractAsync());
+        Assert.Equal(5, extractor.CurrentItemCount); // reset per run, not 10
+    }
+
+
+    [Fact]
+    public async Task CurrentItemCount_resets_between_runs_on_the_progress_path()
+    {
+        var extractor = new TimedExtractor(count: 5);
+        var progress = new SynchronousProgress<EtlProgress>(_ => { });
+
+        await Drain(extractor.ExtractAsync(progress));
+        await Drain(extractor.ExtractAsync(progress));
+
+        Assert.Equal(5, extractor.CurrentItemCount);
+    }
+
+
+    [Fact]
+    public async Task StartedAt_and_Elapsed_are_set_after_producing_items()
+    {
+        var before = DateTimeOffset.UtcNow.AddSeconds(-5);
+        var extractor = new TimedExtractor(count: 8, perItemDelayMs: 2);
+
+        await Drain(extractor.ExtractAsync());
+
+        Assert.NotNull(extractor.StartedAtPublic);
+        Assert.True(
+            extractor.StartedAtPublic > before,
+            "StartedAt should be a real capture of the run start, not default(DateTimeOffset)");
+        Assert.True(
+            extractor.StartedAtPublic <= DateTimeOffset.UtcNow,
+            "StartedAt should not be in the future");
+        Assert.True(extractor.ElapsedPublic > TimeSpan.Zero, "Elapsed should be positive after doing work");
+        Assert.True(extractor.ElapsedPublic < TimeSpan.FromMinutes(1), "Elapsed should be a sane duration");
+    }
+
+
+    [Fact]
+    public async Task CurrentSkippedItemCount_resets_between_runs()
+    {
+        var extractor = new TimedExtractor(count: 5) { SkipItemCount = 2 };
+
+        await Drain(extractor.ExtractAsync());
+        Assert.Equal(2, extractor.CurrentSkippedItemCount);
+
+        await Drain(extractor.ExtractAsync());
+        Assert.Equal(2, extractor.CurrentSkippedItemCount); // reset per run, not 4
+    }
+
+
+    [Fact]
+    public async Task StartedAt_is_set_when_every_item_is_skipped()
+    {
+        var extractor = new TimedExtractor(count: 4) { SkipItemCount = 4 };
+
+        await Drain(extractor.ExtractAsync());
+
+        Assert.Equal(0, extractor.CurrentItemCount);
+        Assert.Equal(4, extractor.CurrentSkippedItemCount);
+        Assert.NotNull(extractor.StartedAtPublic); // the skip path must also mark the run as started
+    }
+
+
+    [Fact]
+    public void Dispose_delegates_to_Dispose_bool()
+    {
+        var extractor = new DisposeRecordingExtractor();
+
+        extractor.Dispose();
+
+        Assert.Equal(1, extractor.DisposeBoolCalls);
+        Assert.True(extractor.LastDisposing);
+    }
+
+
+    [Fact]
+    public async Task DisposeAsync_delegates_to_Dispose_bool()
+    {
+        var extractor = new DisposeRecordingExtractor();
+
+        await extractor.DisposeAsync();
+
+        Assert.Equal(1, extractor.DisposeBoolCalls);
+        Assert.True(extractor.LastDisposing);
+    }
+
+
+    [Fact]
+    public async Task StartedAt_is_null_and_Elapsed_is_Zero_when_nothing_is_produced()
+    {
+        var extractor = new TimedExtractor(count: 0);
+
+        await Drain(extractor.ExtractAsync());
+
+        Assert.Null(extractor.StartedAtPublic);
+        Assert.Equal(TimeSpan.Zero, extractor.ElapsedPublic);
+    }
+
+
+    [Fact]
+    public async Task StartedAt_resets_to_null_when_a_later_run_produces_nothing()
+    {
+        var extractor = new TimedExtractor(count: 5);
+
+        await Drain(extractor.ExtractAsync());
+        Assert.NotNull(extractor.StartedAtPublic);
+
+        extractor.Count = 0;
+        await Drain(extractor.ExtractAsync());
+
+        Assert.Null(extractor.StartedAtPublic); // the run-start timestamp must be reset each run
+        Assert.Equal(TimeSpan.Zero, extractor.ElapsedPublic);
+    }
+
+
+    [Fact]
+    public async Task Progress_path_reports_the_final_extracted_count()
+    {
+        var reports = new List<int>();
+        var extractor = new TimedExtractor(count: 7);
+        var progress = new SynchronousProgress<EtlProgress>(p => reports.Add(p.CurrentItemCount));
+
+        await Drain(extractor.ExtractAsync(progress));
+
+        Assert.NotEmpty(reports);
+        Assert.Equal(7, reports[^1]);
+    }
+
+
+    [Fact]
+    public async Task Progress_path_disposes_the_timer()
+    {
+        var timer = new RecordingTimer();
+        var extractor = new TimedExtractor(count: 4, timer);
+        var progress = new SynchronousProgress<EtlProgress>(_ => { });
+
+        await Drain(extractor.ExtractAsync(progress));
+
+        Assert.True(timer.Disposed, "the progress timer should be disposed after the run");
+    }
+
+
+    [Fact]
+    public async Task A_timer_tick_reports_the_running_count()
+    {
+        var reports = new List<int>();
+        var timer = new RecordingTimer();
+        var extractor = new TimedExtractor(count: 6, timer);
+        var progress = new SynchronousProgress<EtlProgress>(p => reports.Add(p.CurrentItemCount));
+
+        await Drain(extractor.ExtractAsync(progress));
+        timer.RaiseElapsed();
+
+        Assert.Contains(6, reports);
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class TimedExtractor : ExtractorBase<int, EtlProgress>
+    {
+        private readonly int _perItemDelayMs;
+        private readonly IProgressTimer? _timer;
+        private bool _wired;
+
+        public TimedExtractor(int count, int perItemDelayMs = 0)
+        {
+            Count = count;
+            _perItemDelayMs = perItemDelayMs;
+        }
+
+        public TimedExtractor(int count, IProgressTimer timer)
+        {
+            Count = count;
+            _timer = timer;
+        }
+
+        public int Count { get; set; }
+
+        public TimeSpan ElapsedPublic => Elapsed;
+
+        public DateTimeOffset? StartedAtPublic => StartedAt;
+
+        protected override async IAsyncEnumerable<int> ExtractWorkerAsync(
+            [EnumeratorCancellation] CancellationToken token)
+        {
+            var skipped = 0;
+
+            for (var i = 0; i < Count; i++)
+            {
+                token.ThrowIfCancellationRequested();
+
+                if (skipped < SkipItemCount)
+                {
+                    skipped++;
+                    IncrementCurrentSkippedItemCount();
+                    continue;
+                }
+
+                IncrementCurrentItemCount();
+                yield return i;
+
+                if (_perItemDelayMs > 0)
+                {
+                    await Task.Delay(_perItemDelayMs, token);
+                }
+                else
+                {
+                    await Task.Yield();
+                }
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+
+        protected override IProgressTimer CreateProgressTimer(IProgress<EtlProgress> progress)
+        {
+            if (_timer is null)
+            {
+                return base.CreateProgressTimer(progress);
+            }
+
+            if (!_wired)
+            {
+                _wired = true;
+                _timer.Elapsed += () => progress.Report(CreateProgressReport());
+            }
+
+            return _timer;
+        }
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class DisposeRecordingExtractor : ExtractorBase<int, EtlProgress>
+    {
+        public int DisposeBoolCalls { get; private set; }
+
+        public bool LastDisposing { get; private set; }
+
+#pragma warning disable CS1998 // async iterator with no yielded items is intentional
+        protected override async IAsyncEnumerable<int> ExtractWorkerAsync(
+            [EnumeratorCancellation] CancellationToken token)
+        {
+            yield break;
+        }
+#pragma warning restore CS1998
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeBoolCalls++;
+            LastDisposing = disposing;
+            base.Dispose(disposing);
+        }
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class RecordingTimer : IProgressTimer
+    {
+        public bool Disposed { get; private set; }
+
+        public event Action? Elapsed;
+
+        public void Start(int intervalMilliseconds)
+        {
+        }
+
+        public void StopTimer()
+        {
+        }
+
+        public void RaiseElapsed() => Elapsed?.Invoke();
+
+        public void Dispose() => Disposed = true;
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/LoaderBaseCoverageTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/LoaderBaseCoverageTests.cs
@@ -1,0 +1,299 @@
+using System.Diagnostics.CodeAnalysis;
+using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
+
+/// <summary>
+/// Behavioural coverage for <see cref="LoaderBase{TDestination, TProgress}"/> beyond the
+/// TestKit contract tests — per-run counter reset, <c>StartedAt</c>/<c>Elapsed</c> timing,
+/// the progress-path final report, and timer disposal (mutation-testing hardening, #205).
+/// </summary>
+public sealed class LoaderBaseCoverageTests
+{
+    private static async IAsyncEnumerable<int> Items(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return i;
+            await Task.Yield();
+        }
+    }
+
+
+    [Fact]
+    public async Task CurrentItemCount_resets_between_runs()
+    {
+        var loader = new TimedLoader();
+
+        await loader.LoadAsync(Items(5));
+        Assert.Equal(5, loader.CurrentItemCount);
+
+        await loader.LoadAsync(Items(3));
+        Assert.Equal(3, loader.CurrentItemCount); // reset per run, not 8
+    }
+
+
+    [Fact]
+    public async Task CurrentItemCount_resets_between_runs_on_the_progress_path()
+    {
+        var loader = new TimedLoader();
+        var progress = new SynchronousProgress<EtlProgress>(_ => { });
+
+        await loader.LoadAsync(Items(5), progress);
+        await loader.LoadAsync(Items(3), progress);
+
+        Assert.Equal(3, loader.CurrentItemCount);
+    }
+
+
+    [Fact]
+    public async Task StartedAt_and_Elapsed_are_set_after_processing_items()
+    {
+        var before = DateTimeOffset.UtcNow.AddSeconds(-5);
+        var loader = new TimedLoader(perItemDelayMs: 2);
+
+        await loader.LoadAsync(Items(8));
+
+        Assert.NotNull(loader.StartedAtPublic);
+        Assert.True(
+            loader.StartedAtPublic > before,
+            "StartedAt should be a real capture of the run start, not default(DateTimeOffset)");
+        Assert.True(
+            loader.StartedAtPublic <= DateTimeOffset.UtcNow,
+            "StartedAt should not be in the future");
+        Assert.True(loader.ElapsedPublic > TimeSpan.Zero, "Elapsed should be positive after doing work");
+        Assert.True(loader.ElapsedPublic < TimeSpan.FromMinutes(1), "Elapsed should be a sane duration");
+    }
+
+
+    [Fact]
+    public async Task CurrentSkippedItemCount_resets_between_runs()
+    {
+        var loader = new TimedLoader { SkipItemCount = 2 };
+
+        await loader.LoadAsync(Items(5));
+        Assert.Equal(2, loader.CurrentSkippedItemCount);
+
+        await loader.LoadAsync(Items(5));
+        Assert.Equal(2, loader.CurrentSkippedItemCount); // reset per run, not 4
+    }
+
+
+    [Fact]
+    public async Task StartedAt_is_set_when_every_item_is_skipped()
+    {
+        var loader = new TimedLoader { SkipItemCount = 4 };
+
+        await loader.LoadAsync(Items(4));
+
+        Assert.Equal(0, loader.CurrentItemCount);
+        Assert.Equal(4, loader.CurrentSkippedItemCount);
+        Assert.NotNull(loader.StartedAtPublic); // the skip path must also mark the run as started
+    }
+
+
+    [Fact]
+    public void Dispose_delegates_to_Dispose_bool()
+    {
+        var loader = new DisposeRecordingLoader();
+
+        loader.Dispose();
+
+        Assert.Equal(1, loader.DisposeBoolCalls); // Dispose() must route through Dispose(bool)
+        Assert.True(loader.LastDisposing);
+    }
+
+
+    [Fact]
+    public async Task DisposeAsync_delegates_to_Dispose_bool()
+    {
+        var loader = new DisposeRecordingLoader();
+
+        await loader.DisposeAsync();
+
+        Assert.Equal(1, loader.DisposeBoolCalls); // DisposeAsync() must route through Dispose(bool)
+        Assert.True(loader.LastDisposing);
+    }
+
+
+    [Fact]
+    public async Task StartedAt_is_null_and_Elapsed_is_Zero_when_nothing_is_processed()
+    {
+        var loader = new TimedLoader();
+
+        await loader.LoadAsync(Items(0));
+
+        Assert.Null(loader.StartedAtPublic);
+        Assert.Equal(TimeSpan.Zero, loader.ElapsedPublic);
+    }
+
+
+    [Fact]
+    public async Task StartedAt_resets_to_null_when_a_later_run_processes_nothing()
+    {
+        var loader = new TimedLoader();
+
+        await loader.LoadAsync(Items(5));
+        Assert.NotNull(loader.StartedAtPublic);
+
+        await loader.LoadAsync(Items(0));
+
+        Assert.Null(loader.StartedAtPublic); // the run-start timestamp must be reset each run
+        Assert.Equal(TimeSpan.Zero, loader.ElapsedPublic);
+    }
+
+
+    [Fact]
+    public async Task Progress_path_reports_the_final_loaded_count()
+    {
+        var reports = new List<int>();
+        var loader = new TimedLoader();
+        var progress = new SynchronousProgress<EtlProgress>(p => reports.Add(p.CurrentItemCount));
+
+        await loader.LoadAsync(Items(7), progress);
+
+        Assert.NotEmpty(reports);
+        Assert.Equal(7, reports[^1]); // the finally-block report reflects the final count
+    }
+
+
+    [Fact]
+    public async Task Progress_path_disposes_the_timer()
+    {
+        var timer = new RecordingTimer();
+        var loader = new TimedLoader(timer);
+        var progress = new SynchronousProgress<EtlProgress>(_ => { });
+
+        await loader.LoadAsync(Items(4), progress);
+
+        Assert.True(timer.Disposed, "the progress timer should be disposed after the run");
+    }
+
+
+    [Fact]
+    public async Task A_timer_tick_reports_the_running_count()
+    {
+        var reports = new List<int>();
+        var timer = new RecordingTimer();
+        var loader = new TimedLoader(timer);
+        var progress = new SynchronousProgress<EtlProgress>(p => reports.Add(p.CurrentItemCount));
+
+        await loader.LoadAsync(Items(6), progress);
+        timer.RaiseElapsed(); // simulate a scheduled tick
+
+        Assert.Contains(6, reports);
+    }
+
+
+    [Fact]
+    public async Task Skipped_items_increment_the_skipped_counter()
+    {
+        var loader = new TimedLoader { SkipItemCount = 2 };
+
+        await loader.LoadAsync(Items(5));
+
+        Assert.Equal(2, loader.CurrentSkippedItemCount);
+        Assert.Equal(3, loader.CurrentItemCount);
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class TimedLoader : LoaderBase<int, EtlProgress>
+    {
+        private readonly int _perItemDelayMs;
+        private readonly IProgressTimer? _timer;
+        private bool _wired;
+
+        public TimedLoader(int perItemDelayMs = 0) => _perItemDelayMs = perItemDelayMs;
+
+        public TimedLoader(IProgressTimer timer) => _timer = timer;
+
+        public TimeSpan ElapsedPublic => Elapsed;
+
+        public DateTimeOffset? StartedAtPublic => StartedAt;
+
+        protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
+        {
+            var skipped = 0;
+
+            await foreach (var item in items.WithCancellation(token))
+            {
+                _ = item;
+
+                if (skipped < SkipItemCount)
+                {
+                    skipped++;
+                    IncrementCurrentSkippedItemCount();
+                    continue;
+                }
+
+                IncrementCurrentItemCount();
+
+                if (_perItemDelayMs > 0)
+                {
+                    await Task.Delay(_perItemDelayMs, token);
+                }
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+
+        protected override IProgressTimer CreateProgressTimer(IProgress<EtlProgress> progress)
+        {
+            if (_timer is null)
+            {
+                return base.CreateProgressTimer(progress);
+            }
+
+            if (!_wired)
+            {
+                _wired = true;
+                _timer.Elapsed += () => progress.Report(CreateProgressReport());
+            }
+
+            return _timer;
+        }
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class DisposeRecordingLoader : LoaderBase<int, EtlProgress>
+    {
+        public int DisposeBoolCalls { get; private set; }
+
+        public bool LastDisposing { get; private set; }
+
+        protected override Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
+            => Task.CompletedTask;
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeBoolCalls++;
+            LastDisposing = disposing;
+            base.Dispose(disposing);
+        }
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class RecordingTimer : IProgressTimer
+    {
+        public bool Disposed { get; private set; }
+
+        public event Action? Elapsed;
+
+        public void Start(int intervalMilliseconds)
+        {
+        }
+
+        public void StopTimer()
+        {
+        }
+
+        public void RaiseElapsed() => Elapsed?.Invoke();
+
+        public void Dispose() => Disposed = true;
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TransformerBaseCoverageTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TransformerBaseCoverageTests.cs
@@ -1,0 +1,304 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
+
+/// <summary>
+/// Behavioural coverage for <see cref="TransformerBase{TSource, TDestination, TProgress}"/>
+/// beyond the TestKit contract tests — per-run counter reset, <c>StartedAt</c>/<c>Elapsed</c>
+/// timing, the progress-path final report, and timer disposal (mutation-testing hardening, #205).
+/// </summary>
+public sealed class TransformerBaseCoverageTests
+{
+    private static async IAsyncEnumerable<int> Items(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return i;
+            await Task.Yield();
+        }
+    }
+
+
+    private static async Task Drain(IAsyncEnumerable<int> source)
+    {
+        await foreach (var item in source)
+        {
+            _ = item;
+        }
+    }
+
+
+    [Fact]
+    public async Task CurrentItemCount_resets_between_runs()
+    {
+        var transformer = new TimedTransformer();
+
+        await Drain(transformer.TransformAsync(Items(5)));
+        Assert.Equal(5, transformer.CurrentItemCount);
+
+        await Drain(transformer.TransformAsync(Items(3)));
+        Assert.Equal(3, transformer.CurrentItemCount); // reset per run, not 8
+    }
+
+
+    [Fact]
+    public async Task CurrentItemCount_resets_between_runs_on_the_progress_path()
+    {
+        var transformer = new TimedTransformer();
+        var progress = new SynchronousProgress<EtlProgress>(_ => { });
+
+        await Drain(transformer.TransformAsync(Items(5), progress));
+        await Drain(transformer.TransformAsync(Items(3), progress));
+
+        Assert.Equal(3, transformer.CurrentItemCount);
+    }
+
+
+    [Fact]
+    public async Task StartedAt_and_Elapsed_are_set_after_transforming_items()
+    {
+        var before = DateTimeOffset.UtcNow.AddSeconds(-5);
+        var transformer = new TimedTransformer(perItemDelayMs: 2);
+
+        await Drain(transformer.TransformAsync(Items(8)));
+
+        Assert.NotNull(transformer.StartedAtPublic);
+        Assert.True(
+            transformer.StartedAtPublic > before,
+            "StartedAt should be a real capture of the run start, not default(DateTimeOffset)");
+        Assert.True(
+            transformer.StartedAtPublic <= DateTimeOffset.UtcNow,
+            "StartedAt should not be in the future");
+        Assert.True(transformer.ElapsedPublic > TimeSpan.Zero, "Elapsed should be positive after doing work");
+        Assert.True(transformer.ElapsedPublic < TimeSpan.FromMinutes(1), "Elapsed should be a sane duration");
+    }
+
+
+    [Fact]
+    public async Task CurrentSkippedItemCount_resets_between_runs()
+    {
+        var transformer = new TimedTransformer { SkipItemCount = 2 };
+
+        await Drain(transformer.TransformAsync(Items(5)));
+        Assert.Equal(2, transformer.CurrentSkippedItemCount);
+
+        await Drain(transformer.TransformAsync(Items(5)));
+        Assert.Equal(2, transformer.CurrentSkippedItemCount); // reset per run, not 4
+    }
+
+
+    [Fact]
+    public async Task StartedAt_is_set_when_every_item_is_skipped()
+    {
+        var transformer = new TimedTransformer { SkipItemCount = 4 };
+
+        await Drain(transformer.TransformAsync(Items(4)));
+
+        Assert.Equal(0, transformer.CurrentItemCount);
+        Assert.Equal(4, transformer.CurrentSkippedItemCount);
+        Assert.NotNull(transformer.StartedAtPublic); // the skip path must also mark the run as started
+    }
+
+
+    [Fact]
+    public void Dispose_delegates_to_Dispose_bool()
+    {
+        var transformer = new DisposeRecordingTransformer();
+
+        transformer.Dispose();
+
+        Assert.Equal(1, transformer.DisposeBoolCalls);
+        Assert.True(transformer.LastDisposing);
+    }
+
+
+    [Fact]
+    public async Task DisposeAsync_delegates_to_Dispose_bool()
+    {
+        var transformer = new DisposeRecordingTransformer();
+
+        await transformer.DisposeAsync();
+
+        Assert.Equal(1, transformer.DisposeBoolCalls);
+        Assert.True(transformer.LastDisposing);
+    }
+
+
+    [Fact]
+    public async Task StartedAt_is_null_and_Elapsed_is_Zero_when_nothing_is_transformed()
+    {
+        var transformer = new TimedTransformer();
+
+        await Drain(transformer.TransformAsync(Items(0)));
+
+        Assert.Null(transformer.StartedAtPublic);
+        Assert.Equal(TimeSpan.Zero, transformer.ElapsedPublic);
+    }
+
+
+    [Fact]
+    public async Task StartedAt_resets_to_null_when_a_later_run_transforms_nothing()
+    {
+        var transformer = new TimedTransformer();
+
+        await Drain(transformer.TransformAsync(Items(5)));
+        Assert.NotNull(transformer.StartedAtPublic);
+
+        await Drain(transformer.TransformAsync(Items(0)));
+
+        Assert.Null(transformer.StartedAtPublic); // the run-start timestamp must be reset each run
+        Assert.Equal(TimeSpan.Zero, transformer.ElapsedPublic);
+    }
+
+
+    [Fact]
+    public async Task Progress_path_reports_the_final_transformed_count()
+    {
+        var reports = new List<int>();
+        var transformer = new TimedTransformer();
+        var progress = new SynchronousProgress<EtlProgress>(p => reports.Add(p.CurrentItemCount));
+
+        await Drain(transformer.TransformAsync(Items(7), progress));
+
+        Assert.NotEmpty(reports);
+        Assert.Equal(7, reports[^1]);
+    }
+
+
+    [Fact]
+    public async Task Progress_path_disposes_the_timer()
+    {
+        var timer = new RecordingTimer();
+        var transformer = new TimedTransformer(timer);
+        var progress = new SynchronousProgress<EtlProgress>(_ => { });
+
+        await Drain(transformer.TransformAsync(Items(4), progress));
+
+        Assert.True(timer.Disposed, "the progress timer should be disposed after the run");
+    }
+
+
+    [Fact]
+    public async Task A_timer_tick_reports_the_running_count()
+    {
+        var reports = new List<int>();
+        var timer = new RecordingTimer();
+        var transformer = new TimedTransformer(timer);
+        var progress = new SynchronousProgress<EtlProgress>(p => reports.Add(p.CurrentItemCount));
+
+        await Drain(transformer.TransformAsync(Items(6), progress));
+        timer.RaiseElapsed();
+
+        Assert.Contains(6, reports);
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class TimedTransformer : TransformerBase<int, int, EtlProgress>
+    {
+        private readonly int _perItemDelayMs;
+        private readonly IProgressTimer? _timer;
+        private bool _wired;
+
+        public TimedTransformer(int perItemDelayMs = 0) => _perItemDelayMs = perItemDelayMs;
+
+        public TimedTransformer(IProgressTimer timer) => _timer = timer;
+
+        public TimeSpan ElapsedPublic => Elapsed;
+
+        public DateTimeOffset? StartedAtPublic => StartedAt;
+
+        protected override async IAsyncEnumerable<int> TransformWorkerAsync(
+            IAsyncEnumerable<int> items,
+            [EnumeratorCancellation] CancellationToken token)
+        {
+            var skipped = 0;
+
+            await foreach (var item in items.WithCancellation(token))
+            {
+                if (skipped < SkipItemCount)
+                {
+                    skipped++;
+                    IncrementCurrentSkippedItemCount();
+                    continue;
+                }
+
+                IncrementCurrentItemCount();
+                yield return item;
+
+                if (_perItemDelayMs > 0)
+                {
+                    await Task.Delay(_perItemDelayMs, token);
+                }
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+
+        protected override IProgressTimer CreateProgressTimer(IProgress<EtlProgress> progress)
+        {
+            if (_timer is null)
+            {
+                return base.CreateProgressTimer(progress);
+            }
+
+            if (!_wired)
+            {
+                _wired = true;
+                _timer.Elapsed += () => progress.Report(CreateProgressReport());
+            }
+
+            return _timer;
+        }
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class DisposeRecordingTransformer : TransformerBase<int, int, EtlProgress>
+    {
+        public int DisposeBoolCalls { get; private set; }
+
+        public bool LastDisposing { get; private set; }
+
+#pragma warning disable CS1998 // async iterator with no yielded items is intentional
+        protected override async IAsyncEnumerable<int> TransformWorkerAsync(
+            IAsyncEnumerable<int> items,
+            [EnumeratorCancellation] CancellationToken token)
+        {
+            yield break;
+        }
+#pragma warning restore CS1998
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeBoolCalls++;
+            LastDisposing = disposing;
+            base.Dispose(disposing);
+        }
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class RecordingTimer : IProgressTimer
+    {
+        public bool Disposed { get; private set; }
+
+        public event Action? Elapsed;
+
+        public void Start(int intervalMilliseconds)
+        {
+        }
+
+        public void StopTimer()
+        {
+        }
+
+        public void RaiseElapsed() => Elapsed?.Invoke();
+
+        public void Dispose() => Disposed = true;
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
@@ -255,6 +255,10 @@ public class EtlPipelineCoreTests
         var final = reports.Last();
         Assert.Equal(5, final.RecordsExtracted);
         Assert.Equal(5, final.RecordsLoaded);
+
+        // The sink reports after each loaded item, not only at the end — so an intermediate
+        // snapshot capturing exactly one loaded record must be present.
+        Assert.Contains(reports, r => r.RecordsLoaded == 1);
     }
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/DisposeStagesTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/DisposeStagesTests.cs
@@ -141,6 +141,37 @@ public class DisposeStagesTests
 
 
     [Fact]
+    public async Task DisposeStagesOnCompletion_disposes_stages_on_the_load_progress_path()
+    {
+        // A load-progress loader routes the run through PipelineWithLoadProgress, whose
+        // dispose branch is separate from the bare path — exercise it explicitly.
+        var extractor = new TrackingExtractor(3);
+
+        await Pipeline
+            .Extract(extractor)
+            .Load(new TestDoubles.ProgressOnlyLoader<int, string>("p"))
+            .DisposeStagesOnCompletion()
+            .RunAsync();
+
+        Assert.True(extractor.Disposed);
+    }
+
+
+    [Fact]
+    public async Task Load_progress_pipeline_without_DisposeStagesOnCompletion_leaves_stages_undisposed()
+    {
+        var extractor = new TrackingExtractor(3);
+
+        await Pipeline
+            .Extract(extractor)
+            .Load(new TestDoubles.ProgressOnlyLoader<int, string>("p"))
+            .RunAsync();
+
+        Assert.False(extractor.Disposed);
+    }
+
+
+    [Fact]
     public async Task DisposeStagesOnCompletion_prefers_DisposeAsync_over_Dispose()
     {
         var loader = new DualDisposableLoader();
@@ -203,6 +234,7 @@ public class DisposeStagesTests
             .RunAsync());
 
         Assert.Contains(ex.InnerExceptions, e => e is InvalidOperationException && string.Equals(e.Message, "dispose failed", StringComparison.Ordinal));
+        Assert.StartsWith("One or more pipeline stages threw while being disposed.", ex.Message);
     }
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/PipelineBehaviorTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/PipelineBehaviorTests.cs
@@ -257,7 +257,8 @@ public class PipelineBehaviorTests
 
         await pipeline.RunAsync();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => pipeline.RunAsync());
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => pipeline.RunAsync());
+        Assert.Equal("Pipeline has already been run. Construct a new pipeline for each run.", ex.Message);
     }
 
 
@@ -270,7 +271,8 @@ public class PipelineBehaviorTests
 
         await pipeline.RunAsync();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => pipeline.RunAsync(CancellationToken.None));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => pipeline.RunAsync(CancellationToken.None));
+        Assert.Equal("Pipeline has already been run. Construct a new pipeline for each run.", ex.Message);
     }
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/WithProgressSemanticsTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/WithProgressSemanticsTests.cs
@@ -120,7 +120,8 @@ public class WithProgressSemanticsTests
 
         pipeline.WithProgress(progressA);
 
-        Assert.Throws<InvalidOperationException>(() => pipeline.WithProgress(progressB));
+        var ex = Assert.Throws<InvalidOperationException>(() => pipeline.WithProgress(progressB));
+        Assert.Equal("WithProgress has already been called on this pipeline. Progress can only be set once.", ex.Message);
     }
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ReportTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ReportTests.cs
@@ -36,6 +36,14 @@ public class ReportTests
     }
 
 
+    [Fact]
+    public void Constructor_when_passed_a_negative_value_throws_with_explanatory_message()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new Report(-1));
+        Assert.StartsWith("Current item count cannot be less than 0.", ex.Message);
+    }
+
+
 
     [Fact]
     public void CurrentItemCount_returns_the_value_passed_to_the_constructor()
@@ -85,6 +93,15 @@ public class ReportTests
     public void TotalItemCount_when_set_to_a_negative_value_throws_ArgumentOutOfRangeException()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => new Report(0) { TotalItemCount = -1 });
+    }
+
+
+    [Fact]
+    public void TotalItemCount_when_set_to_a_negative_value_throws_with_param_name_and_message()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new Report(0) { TotalItemCount = -1 });
+        Assert.Equal("value", ex.ParamName);
+        Assert.StartsWith("Total item count cannot be less than 0.", ex.Message);
     }
 
 
@@ -168,6 +185,18 @@ public class ReportTests
         Assert.Equal(TimeSpan.Zero, sut.EstimatedRemaining);
     }
 
+
+
+    [Fact]
+    public void EstimatedRemaining_is_zero_when_count_reached_total_even_with_no_elapsed_time()
+    {
+        // remaining == 0 must short-circuit to Zero *before* the throughput check, so a
+        // completed run with a zero rate still reports Zero rather than null. Distinguishes
+        // the "remaining <= 0" boundary from "remaining < 0".
+        var sut = new Report(100) { TotalItemCount = 100, Elapsed = TimeSpan.Zero };
+
+        Assert.Equal(TimeSpan.Zero, sut.EstimatedRemaining);
+    }
 
 
     [Fact]


### PR DESCRIPTION
## Summary

Raises the Stryker mutation score from **74.40% → ~86.6%** (survivors **86 → ~43**) by adding behavioural tests that kill previously-surviving mutants, and ratchets the gate by raising the Stryker `break` threshold from `0` to `80`.

Refs #205.

## What changed

**Base classes** (`LoaderBase` / `ExtractorBase` / `TransformerBase`) — new `BaseClassTests/*CoverageTests.cs`:
- per-run reset of the skipped counter and the run-start timestamp
- `StartedAt` is a real, recent capture (not `default(DateTimeOffset)`)
- `StartedAt` is set on the skip-only path
- `Dispose()` / `DisposeAsync()` delegate to `Dispose(bool)`

**Pipeline / Report**:
- exact exception-message assertions (one-shot re-run, `WithProgress` once, aggregate disposal message, `Report` argument guards)
- `EstimatedRemaining` `remaining <= 0` boundary with a zero rate
- dispose-vs-not branch on the load-progress pipeline path
- per-item progress report in the sink

**Gate**: `stryker-config.json` `break: 0 → 80` (current score leaves ~7 points of headroom).

## Remaining survivors are equivalent / timing-only

The residual survivors are not killable by tests:
- `ConfigureAwait(false)` flips — no `SynchronizationContext` under test
- `GC.SuppressFinalize` removal — no finalizer to suppress
- the `_disposed` guard — the flag has no other consumer, so toggling it is unobservable
- `SystemProgressTimer` start/stop/dispose — observable only via timing, which is exactly the flakiness removed in #250

Killing these would require either `// Stryker disable` annotations in `src` (cosmetic) or reintroducing flaky timing tests; left as a deliberate non-goal.

## Verification
- `dotnet test` net10.0: **344 passing**
- Stryker (net10.0) final score confirmed ≥ the new `break: 80` gate
