### PR TITLE
test: narrow the EnsureStarted disable so its condition stays tested (#205)

### DIFF
--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -413,14 +413,16 @@ public abstract class ExtractorBase<TSource, TProgress>
     // win the CompareExchange records the start; later calls are a cheap volatile read.
     private void EnsureStarted()
     {
-        // Stryker disable all: equivalent mutant — the CompareExchange below is the real guard, so
-        // whether this fast-path early-out (or its whole block) executes, a re-entrant caller that
-        // has already started changes nothing: the assignment only happens on the winning exchange.
         if (Volatile.Read(ref _startTimestamp) != 0)
+        // Stryker disable once all: equivalent — dropping this fast-path block only skips a cheap
+        // early-out. The CompareExchange below is the real guard and assigns only on the winning
+        // exchange, so a re-entrant caller changes nothing either way. (The CONDITION itself is not
+        // disabled — flipping it returns before the first timestamp is recorded, which the
+        // StartedAt/Elapsed tests catch.)
         {
+            // Stryker disable once all: equivalent — same reasoning as the block above.
             return;
         }
-        // Stryker restore all
 
         var now = DateTimeOffset.UtcNow;
         var timestamp = Stopwatch.GetTimestamp();

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -411,14 +411,16 @@ public abstract class LoaderBase<TDestination, TProgress>
     // win the CompareExchange records the start; later calls are a cheap volatile read.
     private void EnsureStarted()
     {
-        // Stryker disable all: equivalent mutant — the CompareExchange below is the real guard, so
-        // whether this fast-path early-out (or its whole block) executes, a re-entrant caller that
-        // has already started changes nothing: the assignment only happens on the winning exchange.
         if (Volatile.Read(ref _startTimestamp) != 0)
+        // Stryker disable once all: equivalent — dropping this fast-path block only skips a cheap
+        // early-out. The CompareExchange below is the real guard and assigns only on the winning
+        // exchange, so a re-entrant caller changes nothing either way. (The CONDITION itself is not
+        // disabled — flipping it returns before the first timestamp is recorded, which the
+        // StartedAt/Elapsed tests catch.)
         {
+            // Stryker disable once all: equivalent — same reasoning as the block above.
             return;
         }
-        // Stryker restore all
 
         var now = DateTimeOffset.UtcNow;
         var timestamp = Stopwatch.GetTimestamp();

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -421,14 +421,16 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
     // win the CompareExchange records the start; later calls are a cheap volatile read.
     private void EnsureStarted()
     {
-        // Stryker disable all: equivalent mutant — the CompareExchange below is the real guard, so
-        // whether this fast-path early-out (or its whole block) executes, a re-entrant caller that
-        // has already started changes nothing: the assignment only happens on the winning exchange.
         if (Volatile.Read(ref _startTimestamp) != 0)
+        // Stryker disable once all: equivalent — dropping this fast-path block only skips a cheap
+        // early-out. The CompareExchange below is the real guard and assigns only on the winning
+        // exchange, so a re-entrant caller changes nothing either way. (The CONDITION itself is not
+        // disabled — flipping it returns before the first timestamp is recorded, which the
+        // StartedAt/Elapsed tests catch.)
         {
+            // Stryker disable once all: equivalent — same reasoning as the block above.
             return;
         }
-        // Stryker restore all
 
         var now = DateTimeOffset.UtcNow;
         var timestamp = Stopwatch.GetTimestamp();


### PR DESCRIPTION
## Summary

Follow-up to #318 (merged). An audit of the remaining `// Stryker disable` comments found one that was **too broad and was hiding real coverage**. Narrowed it; the rest are confirmed genuinely unkillable.

Refs #205.

## The fix
The `EnsureStarted` annotation wrapped the whole `if`, so it also disabled the **condition's** Equality mutant — and that one *is* killable. Flipping `Volatile.Read(ref _startTimestamp) != 0` to `== 0` makes the very first call return early, so the start timestamp is never recorded and `StartedAt` stays null; the existing `StartedAt`/`Elapsed` tests catch it.

Narrowed the annotation to cover only the fast-path **block and its return**, which remain equivalent (the `CompareExchange` below assigns only on the winning exchange, so a re-entrant caller changes nothing either way). Stryker confirms the condition mutants are now **Killed** rather than Ignored.

## Re-audit of the remaining disables — all genuinely unkillable
- **`Dispose(bool)` redundant early-return** — the negate, the `_disposed = true` assignment, and the whole-method-body removal are all killed by `DisposedGuardTests`; skipping the early return just re-runs the idempotent assignment.
- **Sink cancellation check** — `To()` always wraps the `CountExtracted` head, so the head guard is always upstream of `CountLoaded`; no public path reaches it without one.
- **`Report` overflow boundary** — `>=` vs `>` differ only at an exact-equality point that isn't constructible through a division-of-a-division with int-bounded inputs.

## State
- **97.08%**, **370 tests** passing.
- 9 survivors, all `SystemProgressTimer` / `timer.Start` timing — deliberately unmasked.
