### PR TITLE
ci: protected workflow/Directory.Build files for the 0.17.0 release

### DIFF
--- a/.github/sourcelink/consumer/Directory.Build.props
+++ b/.github/sourcelink/consumer/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Isolate the SourceLink step-into fixture from the repo analyzers/props. -->
+</Project>

--- a/.github/sourcelink/consumer/Directory.Build.targets
+++ b/.github/sourcelink/consumer/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Isolate the SourceLink step-into fixture from the repo targets. -->
+</Project>

--- a/.github/workflows/coyote.yaml
+++ b/.github/workflows/coyote.yaml
@@ -1,0 +1,87 @@
+name: Concurrency (Coyote)
+
+# Systematic concurrency / race-condition testing (#207) with Microsoft Coyote.
+# Coyote rewrites the assemblies to control the task scheduler, then replays each
+# test under thousands of distinct interleavings — surfacing races/deadlocks that a
+# normal single-schedule run never hits. `coyote test` exits non-zero on a found
+# bug, so this is an enforced gate.
+#
+# The Coyote project targets net8.0: the Coyote 1.7.x CLI cannot load net10.0
+# assemblies (it predates that runtime), and the concurrency being explored is
+# runtime-agnostic. Triggers:
+#   - pull_request touching src/** or the concurrency project — a lighter run
+#     (1000 iterations/test) gates races before merge.
+#   - schedule (weekly) + workflow_dispatch — the deep run (10000 iterations/test).
+#
+# NOT implemented: the optional 24h soak (handle/thread/memory-leak hunting via
+# dotnet-counters). It requires a persistent self-hosted runner, which this project
+# does not have; add it here behind a `runs-on: [self-hosted]` job when one exists.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+    paths:
+      - 'src/**/*.cs'
+      - 'tests/Wolfgang.Etl.Abstractions.Tests.Concurrency/**'
+      - '.github/workflows/coyote.yaml'
+  schedule:
+    - cron: '0 5 * * 1' # weekly Monday 05:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coyote:
+    name: Coyote systematic exploration
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      PROJECT: tests/Wolfgang.Etl.Abstractions.Tests.Concurrency
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Build the concurrency project (Release)
+        run: dotnet build "$PROJECT/Wolfgang.Etl.Abstractions.Tests.Concurrency.csproj" -c Release
+
+      - name: Install Coyote CLI
+        run: |
+          dotnet tool install --global Microsoft.Coyote.CLI --version 1.7.11
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Rewrite assemblies for the controlled scheduler
+        working-directory: ${{ env.PROJECT }}
+        run: coyote rewrite coyote.json
+
+      - name: Run Coyote systematic tests
+        working-directory: ${{ env.PROJECT }}
+        run: |
+          set -euo pipefail
+          # Deep run on schedule/dispatch; a lighter gate on PRs to keep them fast.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            iterations=1000
+          else
+            iterations=10000
+          fi
+          dll="bin/Release/net8.0/Wolfgang.Etl.Abstractions.Tests.Concurrency.dll"
+          methods=(
+            Concurrent_item_count_increments_never_lose_an_update
+            Dispose_racing_enumeration_never_deadlocks
+          )
+          for m in "${methods[@]}"; do
+            echo "::group::coyote test $m ($iterations iterations)"
+            coyote test "$dll" --method "$m" --iterations "$iterations"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/gc-profile.yaml
+++ b/.github/workflows/gc-profile.yaml
@@ -1,0 +1,144 @@
+# Sustained-load GC / allocation profiling (#212).
+#
+# Runs the library through a 10-minute in-memory extract -> transform -> load loop
+# under `dotnet-counters`, so we can measure gen0/1/2 promotion, LOH pressure,
+# finalizer-queue depth, and thread-pool starvation under a real streaming ETL
+# pattern rather than the micro-scale BDN benchmarks.
+#
+# Gate mode: INFORMATIONAL. Reports upload as artifacts and get summarised in the
+# Step Summary; no regression gate yet — that requires a stable baseline the first
+# several runs need to establish (same "land the tool informational, harden later"
+# pattern as reproducible-build / semgrep / stryker). See docs/GC-PROFILE.md.
+
+name: GC / allocation profile
+
+on:
+  workflow_dispatch:
+    inputs:
+      duration_seconds:
+        description: "Wall-clock seconds to run the workload"
+        required: false
+        default: "600"
+        type: string
+  schedule:
+    # Weekly Sunday 07:00 UTC — after the Stryker run at 06:00, so they don't fight
+    # for the same GitHub-hosted runner pool.
+    - cron: '0 7 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  profile:
+    name: Profile ETL workload (Linux x64)
+    runs-on: ubuntu-latest
+    # 10 min workload + slack for build / trace processing + safety margin.
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      # Guard so the scheduled run no-ops when the workload project isn't on the
+      # checked-out ref (it lands via vNext before it reaches main).
+      - name: Detect GcProfileWorkload
+        id: check
+        shell: bash
+        run: |
+          if [ -f tools/GcProfileWorkload/GcProfileWorkload.csproj ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::GcProfileWorkload project not present on this ref — skipping GC profile. Merge vNext to main to enable."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install dotnet-counters + dotnet-trace
+        if: steps.check.outputs.found == 'true'
+        run: |
+          dotnet tool install --global dotnet-counters
+          dotnet tool install --global dotnet-trace
+
+      - name: Restore + Build workload (Release)
+        if: steps.check.outputs.found == 'true'
+        run: |
+          dotnet restore tools/GcProfileWorkload/GcProfileWorkload.csproj
+          dotnet build tools/GcProfileWorkload/GcProfileWorkload.csproj \
+            --no-restore \
+            --configuration Release
+
+      - name: Run workload + capture counters
+        id: profile
+        if: steps.check.outputs.found == 'true'
+        env:
+          GC_WORKLOAD_SECONDS: ${{ inputs.duration_seconds || '600' }}
+        run: |
+          set -uo pipefail
+          mkdir -p reports
+
+          # Launch the workload in the background so dotnet-counters can attach by
+          # PID; its stdout goes to reports/workload.log for offline inspection.
+          dotnet run --no-build --project tools/GcProfileWorkload \
+            --configuration Release \
+            > reports/workload.log 2>&1 &
+          workload_pid=$!
+          echo "Workload PID: $workload_pid"
+
+          # Give it a moment to spin up.
+          sleep 5
+
+          # Capture CLR runtime counters continuously to a CSV; kill it explicitly
+          # at the end so the CSV is finalised.
+          dotnet-counters collect \
+            --process-id "$workload_pid" \
+            --refresh-interval 5 \
+            --format csv \
+            --output reports/counters.csv \
+            --counters System.Runtime &
+          counters_pid=$!
+
+          wait "$workload_pid" || echo "Workload exit code: $?"
+          echo "Workload done, stopping counters"
+          kill "$counters_pid" 2>/dev/null || true
+          wait "$counters_pid" 2>/dev/null || true
+
+      - name: Summarise into Step Summary
+        if: always() && steps.check.outputs.found == 'true'
+        # Pass the duration through env (not inline expansion) so a dispatch input
+        # can't inject into this script.
+        env:
+          DURATION_SECONDS: ${{ inputs.duration_seconds || '600' }}
+        run: |
+          {
+            echo "## GC / allocation profile"
+            echo ""
+            echo "Duration: **${DURATION_SECONDS}s**"
+            echo ""
+            echo "### Workload progress (last 20 lines)"
+            echo ""
+            echo '```'
+            tail -n 20 reports/workload.log 2>/dev/null || echo "(no workload log)"
+            echo '```'
+            echo ""
+            echo "### Runtime counter head (System.Runtime)"
+            echo ""
+            echo '```'
+            head -n 30 reports/counters.csv 2>/dev/null || echo "(no counter CSV)"
+            echo '```'
+            echo ""
+            echo "Gate mode: informational. See docs/GC-PROFILE.md for how to read the full report."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload reports
+        if: always() && steps.check.outputs.found == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: gc-profile-reports
+          path: reports/
+          retention-days: 30

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -752,13 +752,27 @@ jobs:
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Required to upload assets to the GitHub Release
+      contents: write       # Required to upload assets to the GitHub Release
+      id-token: write       # OIDC token for the SLSA build-provenance attestation (#208)
+      attestations: write   # Write the provenance to the repo's attestation store (#208)
     steps:
       - name: Download NuGet packages artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-packages
           path: ./nuget-packages
+
+      - name: Generate SLSA build-provenance attestation
+        # Attests each packed .nupkg — records a signed, verifiable statement that
+        # this artifact was built by THIS workflow from THIS repo/commit. Stored in
+        # the repo's attestation store; consumers verify with
+        # `gh attestation verify <pkg> --repo Chris-Wolfgang/ETL-Abstractions`.
+        # (Complements the CycloneDX SBOM already attached below. Package signing —
+        # `nuget verify`-able signatures — is separate and needs a code-signing
+        # certificate; still tracked on #208.)
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: './nuget-packages/*.nupkg'
 
       - name: Download coverage report artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -769,6 +783,48 @@ jobs:
       - name: Zip coverage report
         run: zip -r release-coverage.zip ./release-coverage
 
+      - name: Generate reproducible-build manifest
+        # Publishes the expected sha256 of each SHIPPED assembly (the deterministic
+        # artifact) so a third party can rebuild from the tag and verify byte-for-byte
+        # (#225). Hashes the .dll inside the .nupkg, not the .nupkg itself — the zip
+        # envelope carries non-deterministic timestamps; the assembly does not. See
+        # docs/REPRODUCIBLE-BUILD.md for the verification procedure.
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Pick the first non-symbols .nupkg via a glob loop (SC2010: avoid ls | grep).
+          pkg=""
+          for candidate in ./nuget-packages/*.nupkg; do
+            case "$candidate" in
+              *.symbols.nupkg) continue ;;
+            esac
+            pkg="$candidate"
+            break
+          done
+          if [ -z "$pkg" ]; then
+            echo "No non-symbols .nupkg found in ./nuget-packages" >&2
+            exit 1
+          fi
+          version=$(basename "$pkg" .nupkg | sed 's/^Wolfgang\.Etl\.Abstractions\.//')
+          workdir=$(mktemp -d)
+          unzip -q "$pkg" 'lib/*/*.dll' -d "$workdir"
+          {
+            printf '{\n  "package": "Wolfgang.Etl.Abstractions",\n  "version": "%s",\n' "$version"
+            printf '  "algorithm": "sha256",\n  "assemblies": {\n'
+            first=1
+            while IFS= read -r dll; do
+              rel=${dll#"$workdir"/}
+              hash=$(sha256sum "$dll" | cut -d' ' -f1)
+              [ $first -eq 1 ] || printf ',\n'
+              printf '    "%s": "%s"' "$rel" "$hash"
+              first=0
+            done < <(find "$workdir/lib" -name '*.dll' | sort)
+            printf '\n  }\n}\n'
+          } > reproducible-build-manifest.json
+          echo "::group::reproducible-build-manifest.json"
+          cat reproducible-build-manifest.json
+          echo "::endgroup::"
+
       - name: Attach artifacts to release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
         with:
@@ -777,5 +833,6 @@ jobs:
             ./nuget-packages/*.nupkg
             ./nuget-packages/*.snupkg
             ./nuget-packages/*.bom.json
+            reproducible-build-manifest.json
             release-coverage.zip
 

--- a/.github/workflows/sourcelink-stepinto.yaml
+++ b/.github/workflows/sourcelink-stepinto.yaml
@@ -1,0 +1,64 @@
+name: SourceLink Step-Into
+
+# Proves the DEBUGGER half of SourceLink end-to-end (#214): that pressing F11 in a
+# consumer steps into the library's real source (resolved via the SourceLink map in
+# the PDB), not a decompiled placeholder. sourcelink.yaml already proves every PDB
+# document resolves to real GitHub content; this drives an actual debugger step-into.
+#
+# See .github/sourcelink/README.md. Scheduled + manual, NOT a PR gate — debugger
+# automation is heavier/less deterministic than a unit test, and SourceLink's raw
+# URLs resolve only against a pushed commit.
+
+on:
+  schedule:
+    - cron: '0 4 * * 2' # weekly Tuesday 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NETCOREDBG_VERSION: '3.1.2-1054'
+  CONSUMER: .github/sourcelink/consumer
+  EXPECTED_SRC: Report.cs
+
+jobs:
+  step-into:
+    name: F11 step-into resolves library source
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install netcoredbg
+        run: |
+          set -euo pipefail
+          url="https://github.com/Samsung/netcoredbg/releases/download/${NETCOREDBG_VERSION}/netcoredbg-linux-amd64.tar.gz"
+          curl -sSfL -o netcoredbg.tar.gz "$url"
+          tar -xzf netcoredbg.tar.gz
+          echo "NETCOREDBG=$PWD/netcoredbg/netcoredbg" >> "$GITHUB_ENV"
+
+      - name: Build the step-into fixture (Debug, deterministic SourceLink PDB)
+        # Debug + ContinuousIntegrationBuild=true: the referenced library compiles
+        # with the same SourceLink map a released package ships, non-optimized so the
+        # step-into target is not reordered/inlined.
+        run: >
+          dotnet build "$CONSUMER/StepIntoConsumer.csproj"
+          -c Debug -p:ContinuousIntegrationBuild=true
+
+      - name: Drive netcoredbg step-into
+        run: |
+          set -euo pipefail
+          bpline=$(grep -n STEP_INTO_TARGET "$CONSUMER/Program.cs" | head -1 | cut -d: -f1)
+          dll="$CONSUMER/bin/Debug/net10.0/StepIntoConsumer.dll"
+          echo "Breakpoint at Program.cs:$bpline — expecting step-into to land in $EXPECTED_SRC"
+          python3 -u .github/sourcelink/verify_stepinto.py \
+            "$NETCOREDBG" "$dll" "Program.cs:$bpline" "$EXPECTED_SRC"

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -1,15 +1,30 @@
-# Stryker mutation testing
+# Stryker mutation testing (#205 — release-gate quality bar)
 #
-# Runs the Stryker.NET mutation tester against the repo's test projects to
-# measure mutation score. Mutation runs are slow — triggered manually
-# (workflow_dispatch) and on a weekly schedule, not on every PR.
+# Runs the Stryker.NET mutation tester to measure mutation score. The
+# stryker-config.json `break` threshold is the documented floor: `dotnet stryker`
+# exits non-zero (failing the job) if the score drops below it, so this is an
+# enforced gate, not just a report. Ratchet the floor UP over time; never down.
+#
+# Triggers:
+#   - pull_request touching src/** — gates a PR that would drop the score below
+#     the floor, BEFORE merge. Mutation runs are slow (tens of minutes), so this
+#     is scoped to source changes only; docs/test-only/workflow PRs skip it.
+#   - schedule (weekly) + workflow_dispatch — full-project trend / on-demand runs.
 #
 # The workflow looks for a stryker-config.json at the repo root or under
-# tests/**/. If none is present the run is a no-op (Stryker setup is a
-# per-repo follow-up; this file is the canonical infrastructure).
+# tests/**/. If none is present the run is a no-op.
 name: Stryker (mutation testing)
 
 on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+    paths:
+      - 'src/**/*.cs'
+      - 'tests/**/*.cs'
+      - 'stryker-config.json'
+      - '.github/workflows/stryker.yaml'
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 0' # weekly Sunday 06:00 UTC
@@ -22,6 +37,9 @@ jobs:
     name: Run Stryker
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: write   # publish the score-history chart to gh-pages (non-PR runs only)
+      issues: write     # upsert the single survivors tracking issue (non-PR runs only)
     steps:
       - name: Check out repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -65,13 +83,18 @@ jobs:
 
       - name: Install dotnet-stryker
         if: steps.check.outputs.found == 'true'
-        run: dotnet tool update -g dotnet-stryker || dotnet tool install -g dotnet-stryker
+        # Pinned: mutation score / the gate must be reproducible, and a floating
+        # Stryker can change instrumentation or break on an analyzer/Roslyn bump.
+        run: dotnet tool update -g dotnet-stryker --version 4.16.0 || dotnet tool install -g dotnet-stryker --version 4.16.0
 
       - name: Run Stryker
         if: steps.check.outputs.found == 'true'
         shell: bash
         run: |
-          set -e
+          # pipefail so the gate is preserved: `dotnet stryker` exits non-zero when
+          # the score is below the config's `break` floor, and `| tee` must NOT mask
+          # that. The tee'd log is parsed by the next step for the score.
+          set -eo pipefail
           shopt -s globstar nullglob
           # Run BOTH a root stryker-config.json (if present) AND any
           # tests/**/stryker-config.json suites. The Detect step collects
@@ -80,20 +103,102 @@ jobs:
           ran=0
           if [ -f stryker-config.json ]; then
             echo "::group::Stryker with root stryker-config.json"
-            dotnet stryker --config-file stryker-config.json
+            dotnet stryker --config-file stryker-config.json 2>&1 | tee -a "$GITHUB_WORKSPACE/stryker.log"
             echo "::endgroup::"
             ran=1
           fi
           for cfg in tests/**/stryker-config.json; do
             dir=$(dirname "$cfg")
             echo "::group::Stryker in $dir"
-            (cd "$dir" && dotnet stryker)
+            (cd "$dir" && dotnet stryker 2>&1 | tee -a "$GITHUB_WORKSPACE/stryker.log")
             echo "::endgroup::"
             ran=1
           done
           if [ "$ran" -eq 0 ]; then
             echo "::error::Detect step said stryker-config.json was present, but Run found neither root nor tests/**/stryker-config.json. Bailing."
             exit 1
+          fi
+
+      - name: Extract mutation score
+        id: score
+        # always(): publish/track even when the gate FAILED (a low score is exactly
+        # when the trend + survivor list matter most).
+        if: always() && steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          # Stryker prints e.g. "The final mutation score is 74.40 %".
+          score=$(grep -oE 'final mutation score is [0-9]+(\.[0-9]+)?' "$GITHUB_WORKSPACE/stryker.log" 2>/dev/null \
+                    | grep -oE '[0-9]+(\.[0-9]+)?' | tail -1)
+          if [ -z "$score" ]; then
+            echo "::warning::Could not parse a mutation score from the Stryker output."
+            score=0
+          fi
+          echo "score=$score" >> "$GITHUB_OUTPUT"
+          printf '[{"name":"Mutation score","unit":"%%","value":%s}]\n' "$score" > mutation-score.json
+          echo "Mutation score: ${score} %"
+
+      - name: Publish mutation-score history to gh-pages
+        # Trend chart under gh-pages /dev/stryker (same action + pin as the BDN
+        # benchmark charts). Non-PR only — one data point per scheduled/manual run.
+        if: always() && steps.check.outputs.found == 'true' && github.event_name != 'pull_request'
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba  # v1.22.1
+        with:
+          name: Mutation score
+          tool: 'customBiggerIsBetter'
+          output-file-path: mutation-score.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/stryker
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          summary-always: true
+          # The `break` floor is the enforced gate; this chart is trend visibility,
+          # so it must not double-fail the run.
+          fail-on-alert: false
+
+      - name: Track surviving mutants
+        # Writes the survivor worklist to the run summary and keeps ONE rolling
+        # kind:mutation-survives issue up to date (deliberately not one issue per
+        # survivor — there are dozens). Best-effort: never fails the run.
+        if: always() && steps.check.outputs.found == 'true' && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          shopt -s globstar nullglob
+          reports=(**/StrykerOutput/**/reports/mutation-report.json)
+          if (( ${#reports[@]} == 0 )); then
+            echo "::warning::No mutation-report.json found; skipping survivor tracking."
+            exit 0
+          fi
+          report="${reports[-1]}"
+          survivors=$(jq -r '.files | to_entries[] | .key as $f | .value.mutants[]?
+                              | select(.status=="Survived")
+                              | "- `\($f):\(.location.start.line)` — \(.mutatorName)"' "$report" | sort)
+          count=$(printf '%s\n' "$survivors" | grep -c '^- ' || true)
+          score='${{ steps.score.outputs.score }}'
+
+          {
+            echo "## Surviving mutants: ${count}"
+            echo ""
+            echo "Mutation score **${score} %** (floor 70). Kill these to raise it:"
+            echo ""
+            printf '%s\n' "$survivors"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Ensure the label exists, then upsert a single rolling tracking issue.
+          gh label create "kind:mutation-survives" --repo "$GITHUB_REPOSITORY" \
+            --color BFD4F2 --description "A mutant survived — a test gap to close" 2>/dev/null || true
+          title="Mutation survivors (${count}) — kill these to raise the score"
+          body=$(printf '_Auto-updated by the Stryker workflow (run %s). Mutation score **%s %%** (floor 70)._\n\n%s\n' \
+                   "$GITHUB_RUN_ID" "$score" "$survivors")
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "kind:mutation-survives" \
+                       --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body" || true
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body" \
+              --label "kind:mutation-survives" || true
           fi
 
       - name: Upload Stryker report


### PR DESCRIPTION
## Protected-file split for the 0.17.0 release

Companion to the release PR **#320**. Contains **only** the files that trip the `Detect .NET Projects` guard — nothing else. Admin bypass waives *every* ruleset rule, so anything in here lands without review or CI; this diff is kept to exactly what has to.

### Contents (7 files, all protected)
- `.github/workflows/` — `coyote.yaml`, `gc-profile.yaml`, `release.yaml`, `sourcelink-stepinto.yaml`, `stryker.yaml`
- `.github/sourcelink/consumer/Directory.Build.props` / `Directory.Build.targets`

No source, no test code, no configs.

### Deliberately excluded
- **`tests/…Tests.Concurrency/**`** — test code goes through review and CI in #320, not through a bypass.
- **`stryker-config.json`** — it carries the `break` threshold **0 → 80**. Merging that ahead of #320's test improvements would point an 80% gate at `main`'s ~74% codebase and fail every subsequent PR until the release lands. It belongs with the tests that earn the number.
- `tools/GcProfileWorkload/**` and the `.github/sourcelink/` consumer sources — their workflows are `schedule`/`workflow_dispatch` only, so nothing needs them here.

### Known, deliberate consequence
`coyote.yaml` is `pull_request`-triggered on its own YAML, so it fires on this PR — and fails, because the Concurrency project isn't on `main` yet. That's waived by the bypass. It will also fail on any *other* src-touching PR to `main` until #320 merges; **#320's own run passes**, because it carries the project. Merging #320 promptly closes that window.

### Sequence
1. **Admin-bypass merge this PR** into `main`.
2. Merge `main` back into `release/prep-0.17.0` — #320's guard clears.
3. #320 runs full CI, then merge it.
4. Tag `v0.17.0` and publish the release.
