### PR TITLE
docs: correct the 0.17.0 CHANGELOG date to 2026-07-24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.17.0] - 2026-07-23
+## [0.17.0] - 2026-07-24
 
 Minor release: a new **use-after-dispose contract** plus a substantial testing-depth
 pass. The only behavioural change is the dispose guard described under *Changed* —


### PR DESCRIPTION
One-line fix: the `## [0.17.0]` heading said **2026-07-23** (when the entry was written); the release actually merged to `main` on **2026-07-24** 01:39 UTC.

Corrected to `2026-07-24` so the changelog date matches the tag.

**Please merge this before tagging `v0.17.0`** — the tag captures `main`, so fixing it now avoids a changelog whose date disagrees with its own release.

Docs only; no source, no version change.