### PR TITLE
Widen EtlPipelineProgress counters int -> long (#285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking (#285):** `EtlPipelineProgress`'s counters — `ExtractedItemCount`, `LoadedItemCount`, and
+  `ErrorItemCount` — are now `long` instead of `int`, so a long-running pipeline can report more than
+  `int.MaxValue` (~2.1 billion) records without overflow. This changes the record's getters, positional
+  constructor, and `Deconstruct` from `int` to `long`; Package Validation against the 0.18.0 baseline
+  waives the change via `CompatibilitySuppressions.xml`. `AssemblyVersion` stays pinned at `1.0.0.0`.
+  Pre-1.0.
+
 ### Deprecated
 
 ### Removed

--- a/src/Wolfgang.Etl.Abstractions/CompatibilitySuppressions.xml
+++ b/src/Wolfgang.Etl.Abstractions/CompatibilitySuppressions.xml
@@ -1,316 +1,393 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <!--
-  0.18.0 renamed EtlPipelineProgress.RecordsExtracted -> ExtractedItemCount and
-  RecordsLoaded -> LoadedItemCount for a consistent ...ItemCount naming (alongside the
-  new ErrorItemCount). These CP0002 baseline suppressions waive the intentional removal of
-  the old 0.17.0 accessors — a deliberate pre-1.0 breaking change. See CHANGELOG [0.18.0].
+  0.19.0 widened the EtlPipelineProgress counters from int to long (#285) so a long-running
+  pipeline can report more than int.MaxValue records without overflow. These CP0002 baseline
+  suppressions waive the intentional int->long change of the record's getters, constructor, and
+  Deconstruct against the 0.18.0 baseline — a deliberate pre-1.0 breaking change. See CHANGELOG [0.19.0].
 -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net462/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net462/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net462/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net462/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net462/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net462/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net462/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net462/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net462/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net462/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net472/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net472/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net472/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net472/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net472/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net472/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net472/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net472/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net472/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net472/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net48/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net48/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net48/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net48/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net48/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net48/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net48/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net48/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net48/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net48/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net481/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net481/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net481/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net481/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net481/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net481/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net481/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net481/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net481/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net481/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
+    <Left>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
     <Left>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipelineProgress.cs
+++ b/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipelineProgress.cs
@@ -21,8 +21,8 @@ namespace Wolfgang.Etl.Abstractions;
 /// <param name="Elapsed">The wall-clock time elapsed since the run started.</param>
 public sealed record EtlPipelineProgress
 (
-    int ExtractedItemCount,
-    int LoadedItemCount,
+    long ExtractedItemCount,
+    long LoadedItemCount,
     TimeSpan Elapsed
 )
 {
@@ -35,5 +35,5 @@ public sealed record EtlPipelineProgress
     /// successfully flowed into the pipeline, so a failed record is never silent. Distinct from
     /// intentional skips (an extractor's <c>SkipItemCount</c> budget), which are not surfaced here.
     /// </summary>
-    public int ErrorItemCount { get; init; }
+    public long ErrorItemCount { get; init; }
 }

--- a/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlRunState.cs
+++ b/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlRunState.cs
@@ -14,9 +14,9 @@ internal sealed class EtlRunState
 {
     private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
 
-    public int ExtractedItemCount;
+    public long ExtractedItemCount;
 
-    public int LoadedItemCount;
+    public long LoadedItemCount;
 
     // Optional reader that surfaces an error-reporting source's error-item count into the snapshot.
     // Left null for sources that don't report errors (e.g. a raw IAsyncEnumerable), which reads as 0.

--- a/src/Wolfgang.Etl.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.Abstractions/PublicAPI.Shipped.txt
@@ -3,12 +3,12 @@ Wolfgang.Etl.Abstractions.EtlPipeline
 Wolfgang.Etl.Abstractions.EtlPipelineProgress
 Wolfgang.Etl.Abstractions.EtlPipelineProgress.Elapsed.get -> System.TimeSpan
 Wolfgang.Etl.Abstractions.EtlPipelineProgress.Elapsed.init -> void
-Wolfgang.Etl.Abstractions.EtlPipelineProgress.ErrorItemCount.get -> int
+Wolfgang.Etl.Abstractions.EtlPipelineProgress.ErrorItemCount.get -> long
 Wolfgang.Etl.Abstractions.EtlPipelineProgress.ErrorItemCount.init -> void
-Wolfgang.Etl.Abstractions.EtlPipelineProgress.EtlPipelineProgress(int ExtractedItemCount, int LoadedItemCount, System.TimeSpan Elapsed) -> void
-Wolfgang.Etl.Abstractions.EtlPipelineProgress.ExtractedItemCount.get -> int
+Wolfgang.Etl.Abstractions.EtlPipelineProgress.EtlPipelineProgress(long ExtractedItemCount, long LoadedItemCount, System.TimeSpan Elapsed) -> void
+Wolfgang.Etl.Abstractions.EtlPipelineProgress.ExtractedItemCount.get -> long
 Wolfgang.Etl.Abstractions.EtlPipelineProgress.ExtractedItemCount.init -> void
-Wolfgang.Etl.Abstractions.EtlPipelineProgress.LoadedItemCount.get -> int
+Wolfgang.Etl.Abstractions.EtlPipelineProgress.LoadedItemCount.get -> long
 Wolfgang.Etl.Abstractions.EtlPipelineProgress.LoadedItemCount.init -> void
 Wolfgang.Etl.Abstractions.EtlPipelineSinkExtensions
 Wolfgang.Etl.Abstractions.EtlPipelineSourceExtensions

--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<TargetFrameworks>net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
-	<Version>0.18.0</Version>
+	<Version>0.19.0</Version>
 	<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 	     do not need to recompile / add binding redirects on every minor/patch
 	     bump. Bump only on a deliberate breaking API change. FileVersion +
@@ -20,7 +20,7 @@
          recorded in CompatibilitySuppressions.xml, regenerated with
          `dotnet pack /p:GenerateCompatibilitySuppressionFile=true`. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.17.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.18.0</PackageValidationBaselineVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Contains interfaces and base classes used to build ETL applications</Description>

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
@@ -393,4 +393,19 @@ public class EtlPipelineCoreTests
         // ToString surfaces the members.
         Assert.Contains("ExtractedItemCount", a.ToString());
     }
+
+
+    [Fact]
+    public void EtlPipelineProgress_counters_hold_values_beyond_int_MaxValue()
+    {
+        // #285: the counters are long so a long-running pipeline can report more than
+        // int.MaxValue (~2.1B) records without overflow.
+        var big = (long)int.MaxValue + 1;
+
+        var p = new EtlPipelineProgress(big, big, TimeSpan.Zero) { ErrorItemCount = big };
+
+        Assert.Equal(big, p.ExtractedItemCount);
+        Assert.Equal(big, p.LoadedItemCount);
+        Assert.Equal(big, p.ErrorItemCount);
+    }
 }


### PR DESCRIPTION
## Widen `EtlPipelineProgress` counters `int → long` (#285)

First PR of the **0.19.0** cycle (headline). Makes the pipeline progress counters overflow-safe.

### Change
- `EtlPipelineProgress.ExtractedItemCount`, `LoadedItemCount`, and `ErrorItemCount` are now **`long`** instead of `int`, so a long-running pipeline can report more than `int.MaxValue` (~2.1 billion) records without overflow.
- Internal `EtlRunState` tracking fields widened to `long`; the `++` increment sites and the `ErrorCountReader` assignment widen implicitly.

### Breaking-change handling (pre-1.0)
- The record's getters, positional constructor, and generated `Deconstruct` change from `int` to `long`.
- `PublicAPI.Shipped.txt` updated; **`CompatibilitySuppressions.xml`** regenerated against the new **0.18.0** baseline (55 CP0002 waivers for the 5 changed members × 11 TFMs) with a justification comment.
- Version `0.18.0 → 0.19.0`, `PackageValidationBaselineVersion 0.17.0 → 0.18.0`; `AssemblyVersion` stays pinned `1.0.0.0`.

### Verification
- Full-solution build clean (0 warnings), pack passes Package Validation.
- **399 unit tests** pass, including a new overflow-safety test asserting the counters hold `> int.MaxValue`.
- CHANGELOG entry under `[Unreleased]` (promoted to `[0.19.0]` at release-prep).

### Stack
This is the base of the 0.19.0 stack; **#328** (clear the 10 Stryker survivors) is stacked on top of this branch.

Closes #285.
