### PR TITLE
Kill the 10 timer mutation survivors via a deterministic seam (#328)

### DIFF
--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -290,10 +290,18 @@ public abstract class ExtractorBase<TSource, TProgress>
     /// <returns>A started <see cref="IProgressTimer"/> instance.</returns>
     protected virtual IProgressTimer CreateProgressTimer(IProgress<TProgress> progress)
     {
-        var timer = new SystemProgressTimer(ReportProgress, progress);
+        var timer = TimerCoreFactory is null
+            ? new SystemProgressTimer(ReportProgress, progress)
+            : new SystemProgressTimer(ReportProgress, progress, TimerCoreFactory);
         timer.Start(ReportingInterval);
         return timer;
     }
+
+
+    // Test seam: when set, CreateProgressTimer builds its SystemProgressTimer over this timer core
+    // (a deterministic fake) instead of a real System.Threading.Timer.
+    internal Func<System.Threading.TimerCallback, ITimerCore>? TimerCoreFactory;
+
 
 
 

--- a/src/Wolfgang.Etl.Abstractions/ITimerCore.cs
+++ b/src/Wolfgang.Etl.Abstractions/ITimerCore.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Wolfgang.Etl.Abstractions;
+
+/// <summary>
+/// The minimal periodic-timer primitive that <see cref="SystemProgressTimer"/> drives. Production
+/// code uses a wrapper over <see cref="System.Threading.Timer"/>; tests inject a deterministic fake
+/// (one whose ticks fire on demand and that records <see cref="Change"/> / <see cref="IDisposable.Dispose"/>
+/// calls), which makes the timer's Start / StopTimer / Dispose contract observable without relying on
+/// real wall-clock ticks.
+/// </summary>
+internal interface ITimerCore : IDisposable
+{
+    /// <summary>
+    /// Arms or disarms the timer. <see cref="System.Threading.Timeout.Infinite"/> for both arguments
+    /// disarms it; a positive period arms it to fire repeatedly at that interval.
+    /// </summary>
+    void Change(int dueTime, int period);
+}

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -291,10 +291,18 @@ public abstract class LoaderBase<TDestination, TProgress>
     /// <returns>A started <see cref="IProgressTimer"/> instance.</returns>
     protected virtual IProgressTimer CreateProgressTimer(IProgress<TProgress> progress)
     {
-        var timer = new SystemProgressTimer(ReportProgress, progress);
+        var timer = TimerCoreFactory is null
+            ? new SystemProgressTimer(ReportProgress, progress)
+            : new SystemProgressTimer(ReportProgress, progress, TimerCoreFactory);
         timer.Start(ReportingInterval);
         return timer;
     }
+
+
+    // Test seam: when set, CreateProgressTimer builds its SystemProgressTimer over this timer core
+    // (a deterministic fake) instead of a real System.Threading.Timer.
+    internal Func<System.Threading.TimerCallback, ITimerCore>? TimerCoreFactory;
+
 
 
 

--- a/src/Wolfgang.Etl.Abstractions/SystemProgressTimer.cs
+++ b/src/Wolfgang.Etl.Abstractions/SystemProgressTimer.cs
@@ -6,22 +6,18 @@ namespace Wolfgang.Etl.Abstractions;
 
 /// <summary>
 /// The default <see cref="IProgressTimer"/> implementation that wraps
-/// <see cref="System.Threading.Timer"/> to drive progress callbacks on a
-/// background thread-pool thread at a regular interval.
+/// <see cref="System.Threading.Timer"/> (via <see cref="ITimerCore"/>) to drive progress callbacks on
+/// a background thread-pool thread at a regular interval.
 /// </summary>
 /// <remarks>
-/// This class is used internally by the ETL base classes. In production code
-/// it is created automatically by
-/// <c>ExtractorBase.CreateProgressTimer</c>,
-/// <c>TransformerBase.CreateProgressTimer</c>, and
-/// <c>LoaderBase.CreateProgressTimer</c>.
-/// In unit tests, override <c>CreateProgressTimer</c> to return a custom
-/// <see cref="IProgressTimer"/> implementation (for example, a manually
-/// controlled fake whose ticks the test fires on demand).
+/// This class is used internally by the ETL base classes. In production code it is created
+/// automatically by <c>ExtractorBase.CreateProgressTimer</c>, <c>TransformerBase.CreateProgressTimer</c>,
+/// and <c>LoaderBase.CreateProgressTimer</c>. In unit tests, inject a fake <see cref="ITimerCore"/> via
+/// the test constructor so the Start / StopTimer / Dispose contract can be verified deterministically.
 /// </remarks>
 internal sealed class SystemProgressTimer : IProgressTimer
 {
-    private readonly Timer _timer;
+    private readonly ITimerCore _timer;
     private bool _disposed;
 
 
@@ -32,25 +28,24 @@ internal sealed class SystemProgressTimer : IProgressTimer
 
 
     /// <summary>
-    /// Initialises a new <see cref="SystemProgressTimer"/> and immediately
-    /// wires the supplied <paramref name="callback"/> to fire on each tick.
+    /// Initialises a new <see cref="SystemProgressTimer"/> backed by a real
+    /// <see cref="System.Threading.Timer"/>, wiring <paramref name="callback"/> to fire on each tick.
     /// </summary>
-    internal SystemProgressTimer
-    (
-        TimerCallback callback,
-        object? state
-    )
+    internal SystemProgressTimer(TimerCallback callback, object? state)
+        : this(callback, state, onTick => new SystemTimerCore(onTick))
     {
-        // Timer is created stopped (Timeout.Infinite) — Start() arms it.
-#pragma warning disable MA0042 // Timer does not implement IAsyncDisposable
-        _timer = new Timer
-        (
-            _ => OnTick(callback, state),
-            state: null,
-            Timeout.Infinite,
-            Timeout.Infinite
-        );
-#pragma warning restore MA0042
+    }
+
+
+
+    /// <summary>
+    /// Test seam: initialises a new <see cref="SystemProgressTimer"/> whose underlying timer is produced
+    /// by <paramref name="coreFactory"/> (the factory receives the per-tick callback to invoke).
+    /// </summary>
+    internal SystemProgressTimer(TimerCallback callback, object? state, Func<TimerCallback, ITimerCore> coreFactory)
+    {
+        // The core is created stopped; Start() arms it.
+        _timer = coreFactory(_ => OnTick(callback, state));
     }
 
 
@@ -106,8 +101,31 @@ internal sealed class SystemProgressTimer : IProgressTimer
         }
         _disposed = true;
         Elapsed = null;
-#pragma warning disable CA1849, VSTHRD103 // Timer.Dispose() is correct here
         _timer.Dispose();
+    }
+
+
+
+    /// <summary>The production <see cref="ITimerCore"/> — a thin wrapper over <see cref="Timer"/>.</summary>
+    private sealed class SystemTimerCore : ITimerCore
+    {
+        private readonly Timer _timer;
+
+        internal SystemTimerCore(TimerCallback onTick)
+        {
+#pragma warning disable MA0042 // Timer does not implement IAsyncDisposable
+            _timer = new Timer(onTick, state: null, Timeout.Infinite, Timeout.Infinite);
+#pragma warning restore MA0042
+        }
+
+        public void Change(int dueTime, int period) => _timer.Change(dueTime, period);
+
+        [ExcludeFromCodeCoverage] // thin BCL delegation
+        public void Dispose()
+        {
+#pragma warning disable CA1849, VSTHRD103 // Timer.Dispose() is correct here
+            _timer.Dispose();
 #pragma warning restore CA1849, VSTHRD103
+        }
     }
 }

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -297,10 +297,18 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
     /// <returns>A started <see cref="IProgressTimer"/> instance.</returns>
     protected virtual IProgressTimer CreateProgressTimer(IProgress<TProgress> progress)
     {
-        var timer = new SystemProgressTimer(ReportProgress, progress);
+        var timer = TimerCoreFactory is null
+            ? new SystemProgressTimer(ReportProgress, progress)
+            : new SystemProgressTimer(ReportProgress, progress, TimerCoreFactory);
         timer.Start(ReportingInterval);
         return timer;
     }
+
+
+    // Test seam: when set, CreateProgressTimer builds its SystemProgressTimer over this timer core
+    // (a deterministic fake) instead of a real System.Threading.Timer.
+    internal Func<System.Threading.TimerCallback, ITimerCore>? TimerCoreFactory;
+
 
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TimerSeamTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TimerSeamTests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
+
+/// <summary>
+/// Deterministic tests for the <see cref="SystemProgressTimer"/> Start / StopTimer / Dispose contract
+/// and the base classes' <c>CreateProgressTimer</c> factory, driven through the <see cref="ITimerCore"/>
+/// seam (#328). A fake core records <c>Change</c>/<c>Dispose</c> calls, so the timer behaviour is
+/// verified without relying on real wall-clock ticks (which made the pre-seam tests flaky and left
+/// mutation survivors).
+/// </summary>
+public class TimerSeamTests
+{
+    // ---- SystemProgressTimer: Start / StopTimer ----
+
+    [Fact]
+    public void Start_arms_the_core_with_the_interval()
+    {
+        var (timer, core) = NewTimer();
+
+        timer.Start(250);
+
+        Assert.Equal(1, core.ChangeCount);
+        Assert.Equal(250, core.LastDueTime);
+        Assert.Equal(250, core.LastPeriod);
+    }
+
+
+    [Fact]
+    public void StopTimer_disarms_the_core()
+    {
+        var (timer, core) = NewTimer();
+
+        timer.Start(250);
+        timer.StopTimer();
+
+        Assert.Equal(2, core.ChangeCount);
+        Assert.Equal(Timeout.Infinite, core.LastDueTime);
+        Assert.Equal(Timeout.Infinite, core.LastPeriod);
+    }
+
+
+    // ---- SystemProgressTimer: Dispose ----
+
+    [Fact]
+    public void Dispose_disposes_the_core()
+    {
+        var (timer, core) = NewTimer();
+
+        timer.Dispose();
+
+        Assert.Equal(1, core.DisposeCount);
+    }
+
+
+    [Fact]
+    public void Dispose_is_idempotent()
+    {
+        var (timer, core) = NewTimer();
+
+        timer.Dispose();
+        timer.Dispose();
+
+        Assert.Equal(1, core.DisposeCount); // the second Dispose short-circuits
+    }
+
+
+    // ---- SystemProgressTimer: operations after Dispose are no-ops ----
+
+    [Fact]
+    public void Start_after_Dispose_does_not_touch_the_core()
+    {
+        var (timer, core) = NewTimer();
+
+        timer.Dispose();
+        timer.Start(250);
+
+        Assert.Equal(0, core.ChangeCount); // Start short-circuited; the disposed timer is not re-armed
+    }
+
+
+    [Fact]
+    public void StopTimer_after_Dispose_does_not_touch_the_core()
+    {
+        var (timer, core) = NewTimer();
+
+        timer.Dispose();
+        timer.StopTimer();
+
+        Assert.Equal(0, core.ChangeCount); // StopTimer short-circuited
+    }
+
+
+    // ---- A tick drives the callback + Elapsed event ----
+
+    [Fact]
+    public void A_tick_invokes_the_callback_and_raises_Elapsed()
+    {
+        var callbackFired = 0;
+        var elapsedFired = 0;
+        FakeTimerCore? core = null;
+        using var timer = new SystemProgressTimer(_ => callbackFired++, state: null, onTick => core = new FakeTimerCore(onTick));
+        timer.Elapsed += () => elapsedFired++;
+        timer.Start(100);
+
+        core!.Tick();
+
+        Assert.Equal(1, callbackFired);
+        Assert.Equal(1, elapsedFired);
+    }
+
+
+    // ---- CreateProgressTimer factory starts the timer (base classes) ----
+
+    [Fact]
+    public void LoaderBase_CreateProgressTimer_returns_a_started_timer()
+    {
+        FakeTimerCore? core = null;
+        using var loader = new TimerSeamLoader { ReportingInterval = 321, TimerCoreFactory = onTick => core = new FakeTimerCore(onTick) };
+
+        using var timer = loader.CallCreateProgressTimer();
+
+        Assert.NotNull(core);
+        Assert.Equal(321, core!.LastDueTime); // CreateProgressTimer called Start(ReportingInterval)
+        Assert.Equal(321, core.LastPeriod);
+    }
+
+
+    [Fact]
+    public void TransformerBase_CreateProgressTimer_returns_a_started_timer()
+    {
+        FakeTimerCore? core = null;
+        using var transformer = new TimerSeamTransformer { ReportingInterval = 654, TimerCoreFactory = onTick => core = new FakeTimerCore(onTick) };
+
+        using var timer = transformer.CallCreateProgressTimer();
+
+        Assert.NotNull(core);
+        Assert.Equal(654, core!.LastDueTime);
+        Assert.Equal(654, core.LastPeriod);
+    }
+
+
+    [Fact]
+    public void ExtractorBase_CreateProgressTimer_returns_a_started_timer()
+    {
+        FakeTimerCore? core = null;
+        using var extractor = new TimerSeamExtractor { ReportingInterval = 111, TimerCoreFactory = onTick => core = new FakeTimerCore(onTick) };
+
+        using var timer = extractor.CallCreateProgressTimer();
+
+        Assert.NotNull(core);
+        Assert.Equal(111, core!.LastDueTime);
+        Assert.Equal(111, core.LastPeriod);
+    }
+
+
+    // ---- helpers / doubles ----
+
+    private static (SystemProgressTimer timer, FakeTimerCore core) NewTimer()
+    {
+        FakeTimerCore? core = null;
+        var timer = new SystemProgressTimer(_ => { }, state: null, onTick => core = new FakeTimerCore(onTick));
+        return (timer, core!);
+    }
+
+
+    // A deterministic ITimerCore that records Change/Dispose calls and fires ticks on demand.
+    [ExcludeFromCodeCoverage]
+    private sealed class FakeTimerCore : ITimerCore
+    {
+        private readonly TimerCallback _onTick;
+
+        public int ChangeCount;
+        public int LastDueTime = int.MinValue;
+        public int LastPeriod = int.MinValue;
+        public int DisposeCount;
+
+        public FakeTimerCore(TimerCallback onTick) => _onTick = onTick;
+
+        public void Change(int dueTime, int period)
+        {
+            ChangeCount++;
+            LastDueTime = dueTime;
+            LastPeriod = period;
+        }
+
+        public void Dispose() => DisposeCount++;
+
+        public void Tick() => _onTick(null);
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class TimerSeamLoader : LoaderBase<int, EtlProgress>
+    {
+        public IProgressTimer CallCreateProgressTimer() =>
+            CreateProgressTimer(new SynchronousProgress<EtlProgress>(_ => { }));
+
+        protected override Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token) => Task.CompletedTask;
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class TimerSeamTransformer : TransformerBase<int, int, EtlProgress>
+    {
+        public IProgressTimer CallCreateProgressTimer() =>
+            CreateProgressTimer(new SynchronousProgress<EtlProgress>(_ => { }));
+
+        protected override async IAsyncEnumerable<int> TransformWorkerAsync(
+            IAsyncEnumerable<int> items, [EnumeratorCancellation] CancellationToken token)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class TimerSeamExtractor : ExtractorBase<int, EtlProgress>
+    {
+        public IProgressTimer CallCreateProgressTimer() =>
+            CreateProgressTimer(new SynchronousProgress<EtlProgress>(_ => { }));
+
+        protected override async IAsyncEnumerable<int> ExtractWorkerAsync([EnumeratorCancellation] CancellationToken token)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+}


### PR DESCRIPTION
## Kill the 10 timer mutation survivors via a deterministic seam (#328)

Second PR of the **0.19.0** stack — **stacked on #329** (base branch `feat/285-widen-counters`; retargets to `main` once #329 merges).

### The problem
The residual Stryker survivors were all in the timer machinery — `SystemProgressTimer` (the Start / StopTimer / Dispose disposed-guards) and each base's `CreateProgressTimer` calling `timer.Start`. They were only reachable by **real-timer timing tests** (flaky — one was already "de-flaked" in #250), and because `System.Threading.Timer` is post-dispose-safe, several guards read as *equivalent* over a real timer.

### The fix — an `ITimerCore` seam (all internal)
- `SystemProgressTimer` now drives an internal `ITimerCore` (production = a thin `System.Threading.Timer` wrapper); an internal test constructor injects a fake core.
- The three base classes gain an internal `TimerCoreFactory` so `CreateProgressTimer` builds its timer over an injectable core.
- `TimerSeamTests` use a **`FakeTimerCore` that _records_ `Change`/`Dispose` calls** — this makes the Start/StopTimer/Dispose contract and each base's `CreateProgressTimer.Start` **deterministically observable, with no wall-clock ticks**. The previously-"equivalent-over-a-real-Timer" guards become killable because the fake records operations the real `Timer` would silently no-op.

### Result
- **Mutation score 97.23% → 100.00% (0 survivors).**
- **No public API change** — `ITimerCore` and `TimerCoreFactory` are `internal`.
- 409 unit tests pass; full solution builds clean; **zero new flaky timing tests**.

Closes #328.
