### PR TITLE
fix: cross-assembly-safe Report timing constructor (0.18.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ Patch release. Purely additive — no breaking change.
 - `Report(int currentItemCount, DateTimeOffset? startedAt, TimeSpan elapsed, int? totalItemCount = null)`
   constructor, a cross-assembly-safe way to build a `Report` with its timing/total snapshot values.
 
+### Changed
+
+- The `Report.StartedAt` / `Elapsed` / `TotalItemCount` documentation now steers cross-assembly
+  callers to the new constructor instead of the object-initializer (`init`) form, and the AOT
+  smoke test builds its report through the constructor.
+
 ### Fixed
 
 - A `netstandard2.0`-compiled consumer that set `Report`'s `StartedAt` / `Elapsed` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.18.1] - 2026-07-27
+
+Patch release. Purely additive — no breaking change.
+
+### Added
+
+- `Report(int currentItemCount, DateTimeOffset? startedAt, TimeSpan elapsed, int? totalItemCount = null)`
+  constructor, a cross-assembly-safe way to build a `Report` with its timing/total snapshot values.
+
+### Fixed
+
+- A `netstandard2.0`-compiled consumer that set `Report`'s `StartedAt` / `Elapsed` /
+  `TotalItemCount` via the object-initializer (`init`) form and then ran on **.NET 6 or .NET 7**
+  (which resolve this package's modern assembly) hit a `MissingMethodException`: an `init`
+  setter carries an `IsExternalInit` modreq whose identity differs between the `netstandard2.0`
+  polyfill and the built-in `net5.0+` type, so the compiled call did not match the runtime
+  method. The new constructor takes the values as plain parameters — its signature is identical
+  on every target framework — so consumers can set them without tripping the mismatch. The
+  `init` setters are unchanged and remain safe within a single target framework.
+
 ## [0.18.0] - 2026-07-25
 
 Minor release: adds an **opt-in per-item error-handling mechanism** (#84) to the

--- a/src/Wolfgang.Etl.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Wolfgang.Etl.Abstractions.Report.Report(int currentItemCount, System.DateTimeOffset? startedAt, System.TimeSpan elapsed, int? totalItemCount = null) -> void

--- a/src/Wolfgang.Etl.Abstractions/Report.cs
+++ b/src/Wolfgang.Etl.Abstractions/Report.cs
@@ -41,6 +41,32 @@ public record Report
 
 
     /// <summary>
+    /// Constructs a new <see cref="Report"/> with the timing and total snapshot values set.
+    /// Prefer this over the object-initializer (<c>init</c>) form when constructing a report
+    /// from a <em>different</em> assembly: an <c>init</c>-only setter carries an
+    /// <c>IsExternalInit</c> modreq whose identity differs between this library's
+    /// <c>netstandard2.0</c> assembly and its <c>net5.0+</c> assemblies, so a
+    /// <c>netstandard2.0</c>-compiled caller running on .NET 6/7 (which resolves the modern
+    /// assembly) would fail with a <see cref="MissingMethodException"/>. This constructor takes
+    /// the values as plain parameters, so its signature is identical across every target
+    /// framework.
+    /// </summary>
+    /// <param name="currentItemCount">The number of items processed so far. Must be greater than or equal to 0.</param>
+    /// <param name="startedAt">The wall-clock time (UTC) at which processing started, or <see langword="null"/>.</param>
+    /// <param name="elapsed">The wall-clock time elapsed since processing started.</param>
+    /// <param name="totalItemCount">The total number of items expected, when known; otherwise <see langword="null"/>. Must be greater than or equal to 0 when set.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="currentItemCount"/> is less than 0, or <paramref name="totalItemCount"/> is less than 0.</exception>
+    public Report(int currentItemCount, DateTimeOffset? startedAt, TimeSpan elapsed, int? totalItemCount = null)
+        : this(currentItemCount)
+    {
+        StartedAt = startedAt;
+        Elapsed = elapsed;
+        TotalItemCount = totalItemCount;
+    }
+
+
+
+    /// <summary>
     /// The number of items that have been processed so far in the ETL process.
     /// </summary>
     public int CurrentItemCount { get; }

--- a/src/Wolfgang.Etl.Abstractions/Report.cs
+++ b/src/Wolfgang.Etl.Abstractions/Report.cs
@@ -77,6 +77,13 @@ public record Report
     /// The wall-clock time (UTC) at which processing started, or <c>null</c> if it
     /// has not started yet (no items processed) or the producer does not track it.
     /// </summary>
+    /// <remarks>
+    /// When constructing a report from a <em>different</em> assembly, set this through the timing
+    /// constructor (<c>Report(int, DateTimeOffset?, TimeSpan, int?)</c>) rather than the
+    /// object-initializer (<see langword="init"/>) form: an <c>init</c> setter is not safe across a
+    /// <c>netstandard2.0</c> / <c>net5.0+</c> assembly boundary (a <c>MissingMethodException</c> on
+    /// .NET 6/7). Same-assembly or matched-framework use is unaffected.
+    /// </remarks>
     public DateTimeOffset? StartedAt { get; init; }
 
 
@@ -86,6 +93,11 @@ public record Report
     /// moment this report was constructed. <see cref="TimeSpan.Zero"/> when timing is
     /// not tracked or processing has not started.
     /// </summary>
+    /// <remarks>
+    /// When constructing a report from a <em>different</em> assembly, set this through the timing
+    /// constructor (<c>Report(int, DateTimeOffset?, TimeSpan, int?)</c>) rather than the
+    /// object-initializer (<see langword="init"/>) form — see <see cref="StartedAt"/>.
+    /// </remarks>
     public TimeSpan Elapsed { get; init; }
 
 
@@ -95,6 +107,11 @@ public record Report
     /// file line count or a SQL <c>COUNT(*)</c>). <c>null</c> for unknown-size or
     /// infinite sources. Must be greater than or equal to 0 when set.
     /// </summary>
+    /// <remarks>
+    /// When constructing a report from a <em>different</em> assembly, set this through the timing
+    /// constructor (<c>Report(int, DateTimeOffset?, TimeSpan, int?)</c>) rather than the
+    /// object-initializer (<see langword="init"/>) form — see <see cref="StartedAt"/>.
+    /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">The specified value is less than 0.</exception>
     public int? TotalItemCount
     {

--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<TargetFrameworks>net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
-	<Version>0.18.0</Version>
+	<Version>0.18.1</Version>
 	<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 	     do not need to recompile / add binding redirects on every minor/patch
 	     bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/tests/Wolfgang.Etl.Abstractions.AotSmoke/Program.cs
+++ b/tests/Wolfgang.Etl.Abstractions.AotSmoke/Program.cs
@@ -49,12 +49,9 @@ await foreach (var _ in EtlPipeline.Create().From(Numbers(4)).AsAsyncEnumerable(
 
 Require(seen == 4, "AsAsyncEnumerable");
 
-// Report metrics: fixed arithmetic, no reflection.
-var report = new Report(50)
-{
-    TotalItemCount = 100,
-    Elapsed = TimeSpan.FromSeconds(10),
-};
+// Report metrics: fixed arithmetic, no reflection. Built via the timing constructor
+// (cross-assembly-safe on every target framework) rather than the init form.
+var report = new Report(50, startedAt: null, elapsed: TimeSpan.FromSeconds(10), totalItemCount: 100);
 
 Require(report.CurrentItemCount == 50, "Report.CurrentItemCount");
 Require(report.ItemsPerSecond == 5d, "Report.ItemsPerSecond");

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ReportTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ReportTests.cs
@@ -240,4 +240,44 @@ public class ReportTests
         Assert.Equal(started, sut.StartedAt);
         Assert.Equal(TimeSpan.FromSeconds(3), sut.Elapsed);
     }
+
+
+
+    [Fact]
+    public void Timing_constructor_stores_all_snapshot_values()
+    {
+        var started = DateTimeOffset.UtcNow;
+        var sut = new Report(7, started, TimeSpan.FromSeconds(2), 20);
+
+        Assert.Equal(7, sut.CurrentItemCount);
+        Assert.Equal(started, sut.StartedAt);
+        Assert.Equal(TimeSpan.FromSeconds(2), sut.Elapsed);
+        Assert.Equal(20, sut.TotalItemCount);
+    }
+
+
+
+    [Fact]
+    public void Timing_constructor_defaults_TotalItemCount_to_null()
+    {
+        var sut = new Report(3, DateTimeOffset.UtcNow, TimeSpan.FromSeconds(1));
+
+        Assert.Null(sut.TotalItemCount);
+    }
+
+
+
+    [Fact]
+    public void Timing_constructor_when_currentItemCount_is_negative_throws_ArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Report(-1, null, TimeSpan.Zero));
+    }
+
+
+
+    [Fact]
+    public void Timing_constructor_when_totalItemCount_is_negative_throws_ArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Report(0, null, TimeSpan.Zero, -1));
+    }
 }


### PR DESCRIPTION
**PATCH hotfix to `main`** (not `vNext` — that's the separate 0.19.0 breaking line).

## Problem
A `netstandard2.0`-compiled consumer (e.g. ETL-Test-Kit's `netstandard2.0` assembly, loaded on **.NET 6/7**) that set `Report`'s `StartedAt`/`Elapsed`/`TotalItemCount` via the object-initializer (`init`) form fails at runtime with `MissingMethodException: Report.set_StartedAt`. An `init` setter carries an `IsExternalInit` modreq whose *type identity* differs between this package's `netstandard2.0` polyfill (`internal`) and the built-in `net5.0+` type — so a call compiled against the netstandard2.0 assembly does not match the net6.0 assembly resolved at runtime. (net462/net8/net10 match compile-and-runtime, so they were unaffected — which is why it was latent until a consumer set these from netstandard2.0.)

## Fix
Add a plain constructor `Report(int currentItemCount, DateTimeOffset? startedAt, TimeSpan elapsed, int? totalItemCount = null)`. A constructor has **no `IsExternalInit` modreq**, so its signature is byte-identical on every TFM. Consumers set the snapshot values through it instead of the `init` initializer. The `init` setters are unchanged and remain safe within a single TFM.

Purely additive, non-breaking → **0.18.1**. Unblocks ETL-Test-Kit 0.11.0 (which surfaces `Report` timing from its doubles).

Tests: 4 new `ReportTests` cases; 28 pass.