### PR TITLE
Dependency-free WrapWorkerExecution retry seam on the base classes (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Retry seam (#94):** `ExtractorBase`, `LoaderBase`, and `TransformerBase` gained a
+  `protected virtual WrapWorkerExecution(...)` hook wrapped around every worker invocation. The
+  default implementation is a no-op, so behaviour is unchanged; override it to run the worker through
+  a retry / resilience strategy. The override receives a re-invocable worker factory (call it again to
+  retry) and stream-level semantics are documented on the method. Kept dependency-free — a ready-made
+  Polly integration will ship as a separate opt-in `Wolfgang.Etl.Polly` package (#332).
+
 ### Changed
 
 - **Breaking (#285):** `EtlPipelineProgress`'s counters — `ExtractedItemCount`, `LoadedItemCount`, and

--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -312,7 +312,7 @@ public abstract class ExtractorBase<TSource, TProgress>
     {
         ResetRunState();
 
-        await foreach (var item in ExtractWorkerAsync(token))
+        await foreach (var item in WrapWorkerExecution(ExtractWorkerAsync, token))
         {
             yield return item;
         }
@@ -330,7 +330,7 @@ public abstract class ExtractorBase<TSource, TProgress>
 
         try
         {
-            await foreach (var item in ExtractWorkerAsync(token))
+            await foreach (var item in WrapWorkerExecution(ExtractWorkerAsync, token))
             {
                 yield return item;
             }
@@ -369,6 +369,43 @@ public abstract class ExtractorBase<TSource, TProgress>
     /// The result may be an empty sequence if no data is available or if the extraction fails.
     /// </returns>
     protected abstract IAsyncEnumerable<TSource> ExtractWorkerAsync(CancellationToken token);
+
+
+
+    /// <summary>
+    /// A resilience seam wrapped around every invocation of <see cref="ExtractWorkerAsync"/>. The
+    /// default implementation simply invokes <paramref name="workerFactory"/> once, so extraction
+    /// behaves exactly as if the seam were absent. Override it to run the worker through a retry /
+    /// resilience strategy (for example a Polly <c>ResiliencePipeline</c>): the strategy can invoke
+    /// <paramref name="workerFactory"/> more than once, each call producing a fresh stream, to retry
+    /// a transient failure.
+    /// </summary>
+    /// <remarks>
+    /// This is <b>stream-level</b> resilience: a retry re-runs the whole worker from the start, so a
+    /// failure part-way through re-yields items already seen. The per-run counters
+    /// (<see cref="CurrentItemCount"/>, <see cref="CurrentSkippedItemCount"/>,
+    /// <see cref="CurrentErrorItemCount"/>) are reset once at the start of the run, <b>not</b> on each
+    /// retry, so they accumulate across attempts unless the override resets them. Any delay the
+    /// override introduces must observe <paramref name="token"/>. Kept dependency-free by design — a
+    /// concrete Polly integration lives in a separate opt-in package rather than in this library.
+    /// </remarks>
+    /// <param name="workerFactory">A factory that produces a fresh worker stream for the supplied token. Re-invocable — call it again to retry.</param>
+    /// <param name="token">A <see cref="CancellationToken"/> to observe, including during any retry delay.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="workerFactory"/> is <see langword="null"/>.</exception>
+    /// <returns>The (possibly resilience-wrapped) stream of extracted items.</returns>
+    protected virtual IAsyncEnumerable<TSource> WrapWorkerExecution
+    (
+        Func<CancellationToken, IAsyncEnumerable<TSource>> workerFactory,
+        CancellationToken token
+    )
+    {
+        if (workerFactory is null)
+        {
+            throw new ArgumentNullException(nameof(workerFactory));
+        }
+
+        return workerFactory(token);
+    }
 
 
 

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -313,7 +313,7 @@ public abstract class LoaderBase<TDestination, TProgress>
     )
     {
         ResetRunState();
-        return LoadWorkerAsync(items, token);
+        return WrapWorkerExecution(ct => LoadWorkerAsync(items, ct), token);
     }
 
 
@@ -329,7 +329,7 @@ public abstract class LoaderBase<TDestination, TProgress>
 
         try
         {
-            await LoadWorkerAsync(items, token).ConfigureAwait(false);
+            await WrapWorkerExecution(ct => LoadWorkerAsync(items, ct), token).ConfigureAwait(false);
         }
         finally
         {
@@ -367,6 +367,43 @@ public abstract class LoaderBase<TDestination, TProgress>
     /// </remarks>
     /// <exception cref="ArgumentNullException">Argument items is null</exception>
     protected abstract Task LoadWorkerAsync(IAsyncEnumerable<TDestination> items, CancellationToken token);
+
+
+
+    /// <summary>
+    /// A resilience seam wrapped around every invocation of <see cref="LoadWorkerAsync"/>. The
+    /// default implementation simply invokes <paramref name="workerFactory"/> once, so loading
+    /// behaves exactly as if the seam were absent. Override it to run the worker through a retry /
+    /// resilience strategy (for example a Polly <c>ResiliencePipeline</c>): the strategy can invoke
+    /// <paramref name="workerFactory"/> more than once to retry a transient failure.
+    /// </summary>
+    /// <remarks>
+    /// This is <b>stream-level</b> resilience: a retry re-runs the whole worker, which re-enumerates
+    /// the source <c>items</c> from the start — so retry is only safe when that source can be
+    /// enumerated more than once. The per-run counters (<see cref="CurrentItemCount"/>,
+    /// <see cref="CurrentSkippedItemCount"/>, <see cref="CurrentErrorItemCount"/>) are reset once at
+    /// the start of the run, <b>not</b> on each retry, so they accumulate across attempts unless the
+    /// override resets them. Any delay the override introduces must observe <paramref name="token"/>.
+    /// Kept dependency-free by design — a concrete Polly integration lives in a separate opt-in
+    /// package rather than in this library.
+    /// </remarks>
+    /// <param name="workerFactory">A factory that runs the worker for the supplied token. Re-invocable — call it again to retry.</param>
+    /// <param name="token">A <see cref="CancellationToken"/> to observe, including during any retry delay.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="workerFactory"/> is <see langword="null"/>.</exception>
+    /// <returns>A task representing the (possibly resilience-wrapped) load operation.</returns>
+    protected virtual Task WrapWorkerExecution
+    (
+        Func<CancellationToken, Task> workerFactory,
+        CancellationToken token
+    )
+    {
+        if (workerFactory is null)
+        {
+            throw new ArgumentNullException(nameof(workerFactory));
+        }
+
+        return workerFactory(token);
+    }
 
 
 

--- a/src/Wolfgang.Etl.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Abstractions/PublicAPI.Unshipped.txt
@@ -1,2 +1,5 @@
 #nullable enable
+virtual Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.WrapWorkerExecution(System.Func<System.Threading.CancellationToken, System.Collections.Generic.IAsyncEnumerable<TSource>!>! workerFactory, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<TSource>!
+virtual Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.WrapWorkerExecution(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! workerFactory, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+virtual Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.WrapWorkerExecution(System.Func<System.Threading.CancellationToken, System.Collections.Generic.IAsyncEnumerable<TDestination>!>! workerFactory, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<TDestination>!
 Wolfgang.Etl.Abstractions.Report.Report(int currentItemCount, System.DateTimeOffset? startedAt, System.TimeSpan elapsed, int? totalItemCount = null) -> void

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -320,7 +320,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
     {
         ResetRunState();
 
-        await foreach (var item in TransformWorkerAsync(items, token))
+        await foreach (var item in WrapWorkerExecution(ct => TransformWorkerAsync(items, ct), token))
         {
             yield return item;
         }
@@ -338,7 +338,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
 
         try
         {
-            await foreach (var item in TransformWorkerAsync(items, token))
+            await foreach (var item in WrapWorkerExecution(ct => TransformWorkerAsync(items, ct), token))
             {
                 yield return item;
             }
@@ -376,6 +376,44 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
     /// IAsyncEnumerable&lt;TDestination&gt; - The result may be an empty sequence if no data is available or if the transformation fails.
     /// </returns>
     protected abstract IAsyncEnumerable<TDestination> TransformWorkerAsync(IAsyncEnumerable<TSource> items, CancellationToken token);
+
+
+
+    /// <summary>
+    /// A resilience seam wrapped around every invocation of <see cref="TransformWorkerAsync"/>. The
+    /// default implementation simply invokes <paramref name="workerFactory"/> once, so transformation
+    /// behaves exactly as if the seam were absent. Override it to run the worker through a retry /
+    /// resilience strategy (for example a Polly <c>ResiliencePipeline</c>): the strategy can invoke
+    /// <paramref name="workerFactory"/> more than once, each call producing a fresh stream, to retry
+    /// a transient failure.
+    /// </summary>
+    /// <remarks>
+    /// This is <b>stream-level</b> resilience: a retry re-runs the whole worker, which re-enumerates
+    /// the source <c>items</c> from the start — so retry is only safe when that source can be
+    /// enumerated more than once, and a failure part-way through re-yields items already seen. The
+    /// per-run counters (<see cref="CurrentItemCount"/>, <see cref="CurrentSkippedItemCount"/>,
+    /// <see cref="CurrentErrorItemCount"/>) are reset once at the start of the run, <b>not</b> on each
+    /// retry, so they accumulate across attempts unless the override resets them. Any delay the
+    /// override introduces must observe <paramref name="token"/>. Kept dependency-free by design — a
+    /// concrete Polly integration lives in a separate opt-in package rather than in this library.
+    /// </remarks>
+    /// <param name="workerFactory">A factory that produces a fresh worker stream for the supplied token. Re-invocable — call it again to retry.</param>
+    /// <param name="token">A <see cref="CancellationToken"/> to observe, including during any retry delay.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="workerFactory"/> is <see langword="null"/>.</exception>
+    /// <returns>The (possibly resilience-wrapped) stream of transformed items.</returns>
+    protected virtual IAsyncEnumerable<TDestination> WrapWorkerExecution
+    (
+        Func<CancellationToken, IAsyncEnumerable<TDestination>> workerFactory,
+        CancellationToken token
+    )
+    {
+        if (workerFactory is null)
+        {
+            throw new ArgumentNullException(nameof(workerFactory));
+        }
+
+        return workerFactory(token);
+    }
 
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/RetrySeamTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/RetrySeamTests.cs
@@ -1,0 +1,460 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
+using Xunit;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
+
+/// <summary>
+/// Covers the #94 retry seam: the <c>WrapWorkerExecution</c> hook on each base class. The default
+/// implementation is a no-op (behaviour is unchanged), and an override receives a <em>re-invocable</em>
+/// worker factory — calling it again produces a fresh worker run, which is what lets a resilience
+/// strategy retry a transient failure. The seam is exercised on both the no-progress and the
+/// with-progress worker paths of all three base classes.
+/// </summary>
+public class RetrySeamTests
+{
+    // ---------- Extractor ----------
+
+    [Fact]
+    public async Task Extractor_default_seam_yields_all_items_and_runs_the_worker_once()
+    {
+        var sut = new SeamExtractor(new[] { 1, 2, 3 });
+
+        var items = await Drain(sut.ExtractAsync(CancellationToken.None));
+
+        Assert.Equal(new[] { 1, 2, 3 }, items);
+        Assert.Equal(1, sut.WorkerStartCount);   // default no-op invokes the factory exactly once
+        Assert.Equal(1, sut.SeamCallCount);
+    }
+
+
+    [Fact]
+    public async Task Extractor_override_re_invokes_the_factory_producing_a_fresh_run_each_time()
+    {
+        var sut = new SeamExtractor(new[] { 1, 2, 3 }) { WorkerRuns = 3 };
+
+        var items = await Drain(sut.ExtractAsync(CancellationToken.None));
+
+        Assert.Equal(new[] { 1, 2, 3 }, items);  // only the final run is yielded
+        Assert.Equal(3, sut.WorkerStartCount);    // factory re-invoked -> worker restarted 3 times
+        Assert.Equal(1, sut.SeamCallCount);       // seam wraps the run once
+    }
+
+
+    [Fact]
+    public async Task Extractor_seam_wraps_the_with_progress_path_too()
+    {
+        var sut = new SeamExtractor(new[] { 7, 8 }) { WorkerRuns = 2 };
+        var progress = new SynchronousProgress<EtlProgress>(_ => { });
+
+        var items = await Drain(sut.ExtractAsync(progress, CancellationToken.None));
+
+        Assert.Equal(new[] { 7, 8 }, items);
+        Assert.Equal(2, sut.WorkerStartCount);
+        Assert.Equal(1, sut.SeamCallCount);
+    }
+
+
+    [Fact]
+    public async Task Extractor_seam_can_retry_a_transient_failure()
+    {
+        // Worker throws on its first start, succeeds on the second; the retrying seam recovers.
+        var sut = new RetryingExtractor(new[] { 5, 6 }, failuresBeforeSuccess: 1);
+
+        var items = await Drain(sut.ExtractAsync(CancellationToken.None));
+
+        Assert.Equal(new[] { 5, 6 }, items);
+        Assert.Equal(2, sut.WorkerStartCount);
+    }
+
+
+    [Fact]
+    public void Extractor_seam_throws_when_the_factory_is_null()
+    {
+        var sut = new SeamExtractor(Array.Empty<int>());
+
+        Assert.Throws<ArgumentNullException>(() => sut.InvokeSeamWithNull());
+    }
+
+
+    // ---------- Loader ----------
+
+    [Fact]
+    public async Task Loader_default_seam_loads_all_items_and_runs_the_worker_once()
+    {
+        var sut = new SeamLoader();
+
+        await sut.LoadAsync(AsyncSource(1, 2, 3), CancellationToken.None);
+
+        Assert.Equal(new[] { 1, 2, 3 }, sut.Loaded);
+        Assert.Equal(1, sut.WorkerStartCount);
+        Assert.Equal(1, sut.SeamCallCount);
+    }
+
+
+    [Fact]
+    public async Task Loader_override_re_invokes_the_factory_producing_a_fresh_run_each_time()
+    {
+        var sut = new SeamLoader { WorkerRuns = 3 };
+
+        await sut.LoadAsync(AsyncSource(1, 2), CancellationToken.None);
+
+        Assert.Equal(3, sut.WorkerStartCount);
+        Assert.Equal(1, sut.SeamCallCount);
+    }
+
+
+    [Fact]
+    public async Task Loader_seam_wraps_the_with_progress_path_too()
+    {
+        var sut = new SeamLoader { WorkerRuns = 2 };
+        var progress = new SynchronousProgress<EtlProgress>(_ => { });
+
+        await sut.LoadAsync(AsyncSource(9), progress, CancellationToken.None);
+
+        Assert.Equal(2, sut.WorkerStartCount);
+        Assert.Equal(1, sut.SeamCallCount);
+    }
+
+
+    [Fact]
+    public void Loader_seam_throws_when_the_factory_is_null()
+    {
+        var sut = new SeamLoader();
+
+        Assert.Throws<ArgumentNullException>(() => { _ = sut.InvokeSeamWithNull(); });
+    }
+
+
+    // ---------- Transformer ----------
+
+    [Fact]
+    public async Task Transformer_default_seam_yields_all_items_and_runs_the_worker_once()
+    {
+        var sut = new SeamTransformer();
+
+        var items = await Drain(sut.TransformAsync(AsyncSource(1, 2, 3), CancellationToken.None));
+
+        Assert.Equal(new[] { 10, 20, 30 }, items);
+        Assert.Equal(1, sut.WorkerStartCount);
+        Assert.Equal(1, sut.SeamCallCount);
+    }
+
+
+    [Fact]
+    public async Task Transformer_override_re_invokes_the_factory_producing_a_fresh_run_each_time()
+    {
+        var sut = new SeamTransformer { WorkerRuns = 3 };
+
+        var items = await Drain(sut.TransformAsync(AsyncSource(4), CancellationToken.None));
+
+        Assert.Equal(new[] { 40 }, items);   // only the final run is yielded
+        Assert.Equal(3, sut.WorkerStartCount);
+        Assert.Equal(1, sut.SeamCallCount);
+    }
+
+
+    [Fact]
+    public async Task Transformer_seam_wraps_the_with_progress_path_too()
+    {
+        var sut = new SeamTransformer { WorkerRuns = 2 };
+        var progress = new SynchronousProgress<EtlProgress>(_ => { });
+
+        var items = await Drain(sut.TransformAsync(AsyncSource(5), progress, CancellationToken.None));
+
+        Assert.Equal(new[] { 50 }, items);
+        Assert.Equal(2, sut.WorkerStartCount);
+        Assert.Equal(1, sut.SeamCallCount);
+    }
+
+
+    [Fact]
+    public void Transformer_seam_throws_when_the_factory_is_null()
+    {
+        var sut = new SeamTransformer();
+
+        Assert.Throws<ArgumentNullException>(() => sut.InvokeSeamWithNull());
+    }
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<int> AsyncSource(params int[] items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+    private static async Task<List<int>> Drain(IAsyncEnumerable<int> source)
+    {
+        var result = new List<int>();
+        await foreach (var item in source.ConfigureAwait(false))
+        {
+            result.Add(item);
+        }
+
+        return result;
+    }
+
+
+    // ---------- doubles ----------
+
+    // Extractor whose overridden seam invokes the factory (WorkerRuns - 1) discarded times then a
+    // final real run, proving the factory produces a fresh worker run on each call. WorkerRuns == 1
+    // (the default) leaves the seam a pass-through, exercising the base default no-op.
+    [ExcludeFromCodeCoverage]
+    private sealed class SeamExtractor : ExtractorBase<int, EtlProgress>
+    {
+        private readonly int[] _items;
+        private int _workerStarts;
+
+        public SeamExtractor(int[] items) => _items = items;
+
+        public int WorkerRuns { get; init; } = 1;
+
+        public int WorkerStartCount => Volatile.Read(ref _workerStarts);
+
+        public int SeamCallCount { get; private set; }
+
+        public IAsyncEnumerable<int> InvokeSeamWithNull() => base.WrapWorkerExecution(null!, CancellationToken.None);
+
+        protected override async IAsyncEnumerable<int> ExtractWorkerAsync([EnumeratorCancellation] CancellationToken token)
+        {
+            Interlocked.Increment(ref _workerStarts);
+            foreach (var item in _items)
+            {
+                await Task.Yield();
+                IncrementCurrentItemCount();
+                yield return item;
+            }
+        }
+
+        protected override async IAsyncEnumerable<int> WrapWorkerExecution(
+            Func<CancellationToken, IAsyncEnumerable<int>> workerFactory,
+            [EnumeratorCancellation] CancellationToken token)
+        {
+            SeamCallCount++;
+            if (WorkerRuns == 1)
+            {
+                await foreach (var item in base.WrapWorkerExecution(workerFactory, token).WithCancellation(token))
+                {
+                    yield return item;
+                }
+
+                yield break;
+            }
+
+            for (var run = 1; run < WorkerRuns; run++)
+            {
+                await foreach (var _ in workerFactory(token).WithCancellation(token))
+                {
+                    // discard – simulates a failed attempt being retried from scratch
+                }
+            }
+
+            await foreach (var item in workerFactory(token).WithCancellation(token))
+            {
+                yield return item;
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+
+
+    // Extractor whose seam retries a genuine transient failure by re-invoking the factory.
+    [ExcludeFromCodeCoverage]
+    private sealed class RetryingExtractor : ExtractorBase<int, EtlProgress>
+    {
+        private readonly int[] _items;
+        private readonly int _failuresBeforeSuccess;
+        private int _workerStarts;
+
+        public RetryingExtractor(int[] items, int failuresBeforeSuccess)
+        {
+            _items = items;
+            _failuresBeforeSuccess = failuresBeforeSuccess;
+        }
+
+        public int WorkerStartCount => Volatile.Read(ref _workerStarts);
+
+        protected override async IAsyncEnumerable<int> ExtractWorkerAsync([EnumeratorCancellation] CancellationToken token)
+        {
+            var attempt = Interlocked.Increment(ref _workerStarts);
+            await Task.Yield();
+            if (attempt <= _failuresBeforeSuccess)
+            {
+                throw new InvalidOperationException("transient");
+            }
+
+            foreach (var item in _items)
+            {
+                yield return item;
+            }
+        }
+
+        protected override async IAsyncEnumerable<int> WrapWorkerExecution(
+            Func<CancellationToken, IAsyncEnumerable<int>> workerFactory,
+            [EnumeratorCancellation] CancellationToken token)
+        {
+            for (var attempt = 1; ; attempt++)
+            {
+                var buffer = new List<int>();
+                var enumerator = workerFactory(token).GetAsyncEnumerator(token);
+                var failed = false;
+                try
+                {
+                    while (true)
+                    {
+                        try
+                        {
+                            if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                            {
+                                break;
+                            }
+                        }
+                        catch (InvalidOperationException) when (attempt <= _failuresBeforeSuccess)
+                        {
+                            failed = true;
+                            break;
+                        }
+
+                        buffer.Add(enumerator.Current);
+                    }
+                }
+                finally
+                {
+                    await enumerator.DisposeAsync().ConfigureAwait(false);
+                }
+
+                if (failed)
+                {
+                    continue;
+                }
+
+                foreach (var item in buffer)
+                {
+                    yield return item;
+                }
+
+                yield break;
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class SeamLoader : LoaderBase<int, EtlProgress>
+    {
+        private int _workerStarts;
+
+        public List<int> Loaded { get; } = new();
+
+        public int WorkerRuns { get; init; } = 1;
+
+        public int WorkerStartCount => Volatile.Read(ref _workerStarts);
+
+        public int SeamCallCount { get; private set; }
+
+        public Task InvokeSeamWithNull() => base.WrapWorkerExecution(null!, CancellationToken.None);
+
+        protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
+        {
+            Interlocked.Increment(ref _workerStarts);
+            Loaded.Clear();
+            await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+            {
+                Loaded.Add(item);
+                IncrementCurrentItemCount();
+            }
+        }
+
+        protected override async Task WrapWorkerExecution(
+            Func<CancellationToken, Task> workerFactory,
+            CancellationToken token)
+        {
+            SeamCallCount++;
+            if (WorkerRuns == 1)
+            {
+                await base.WrapWorkerExecution(workerFactory, token).ConfigureAwait(false);
+                return;
+            }
+
+            for (var run = 1; run <= WorkerRuns; run++)
+            {
+                await workerFactory(token).ConfigureAwait(false);
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class SeamTransformer : TransformerBase<int, int, EtlProgress>
+    {
+        private int _workerStarts;
+
+        public int WorkerRuns { get; init; } = 1;
+
+        public int WorkerStartCount => Volatile.Read(ref _workerStarts);
+
+        public int SeamCallCount { get; private set; }
+
+        public IAsyncEnumerable<int> InvokeSeamWithNull() => base.WrapWorkerExecution(null!, CancellationToken.None);
+
+        protected override async IAsyncEnumerable<int> TransformWorkerAsync(
+            IAsyncEnumerable<int> items, [EnumeratorCancellation] CancellationToken token)
+        {
+            Interlocked.Increment(ref _workerStarts);
+            await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+            {
+                IncrementCurrentItemCount();
+                yield return item * 10;
+            }
+        }
+
+        protected override async IAsyncEnumerable<int> WrapWorkerExecution(
+            Func<CancellationToken, IAsyncEnumerable<int>> workerFactory,
+            [EnumeratorCancellation] CancellationToken token)
+        {
+            SeamCallCount++;
+            if (WorkerRuns == 1)
+            {
+                await foreach (var item in base.WrapWorkerExecution(workerFactory, token).WithCancellation(token))
+                {
+                    yield return item;
+                }
+
+                yield break;
+            }
+
+            for (var run = 1; run < WorkerRuns; run++)
+            {
+                await foreach (var _ in workerFactory(token).WithCancellation(token))
+                {
+                    // discard
+                }
+            }
+
+            await foreach (var item in workerFactory(token).WithCancellation(token))
+            {
+                yield return item;
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+}


### PR DESCRIPTION
Closes #94.

## Summary
Adds a **dependency-free retry seam** — `protected virtual WrapWorkerExecution(...)` — to `ExtractorBase`, `LoaderBase`, and `TransformerBase`, wrapped around every worker invocation (both the no-progress and with-progress paths). The default is a **no-op**, so existing behaviour is unchanged; an override runs the worker through a retry / resilience strategy.

```csharp
protected virtual IAsyncEnumerable<TSource> WrapWorkerExecution(
    Func<CancellationToken, IAsyncEnumerable<TSource>> workerFactory, CancellationToken token)
    => workerFactory(token); // default: no wrapping
```

The override receives a **re-invocable worker factory** — calling it again produces a fresh worker run, which is what lets a strategy retry a transient failure.

## Design decision — Option 1 (dep-free), per maintainer
The issue recommended Option A (inject Polly's `ResiliencePipeline`), but Abstractions is intentionally **zero third-party runtime dependencies** and roots 8 downstream packages, so taking a Polly dependency here would force it on the whole fleet. Chosen approach: ship only the seam; a ready-made Polly integration lands as a separate opt-in **`Wolfgang.Etl.Polly`** package — tracked in **#332**.

## Scope
- **Stream-level** retry (whole worker re-run) per the issue; item-level deferred (composes with the #84 `OnItemError` hook later). Counter-reset and source re-enumeration semantics are documented on each seam.

## Verification
- **426 unit tests pass** (13 new `RetrySeamTests`: default no-op, seam-invoked-once on both paths, factory re-invocability, genuine transient-failure recovery, null guard — across all 3 bases).
- **Stryker 100.00 %, 0 survivors** (full project).
- Builds clean across all 11 TFMs; PublicAPI.Unshipped updated (3 protected-virtual entries, RS0017-validated).

## Notes for release-prep (not in this PR)
- Targets `vNext-plus-one` (the 0.20.0 line). The version bump 0.19.0 → 0.20.0 and `PackageValidationBaselineVersion` → 0.19.0 are **deferred to 0.20.0 release-prep**, gated on 0.19.0 publishing. The `[Unreleased]` section here still carries the #285/#328 entries inherited from the vNext fork; those get reconciled when main (0.19.0) merges into vNext-plus-one.
