### PR TITLE
Aggregate per-item error counts across all pipeline stages (#335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`IReportsItemErrors` (#335):** a small interface (`int CurrentErrorItemCount { get; }`) implemented
+  by `ExtractorBase`, `LoaderBase`, and `TransformerBase`, letting a pipeline read any stage's
+  error-item count uniformly regardless of concrete type.
 - **Middleware / interceptor (#93):** a composable per-item hook — `IItemMiddleware<T>` returning
   `MiddlewareResult<T>` (`Continue` to keep/replace an item, `Drop` to remove it) — attached to any
   stream with the `WithMiddleware(...)` extensions (single or ordered chain). Lets cross-cutting
@@ -24,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`EtlPipelineProgress.ErrorItemCount` now aggregates every stage (#335).** Previously it reported
+  only the extractor's error-item count; it now sums the error-item counts of the source, every
+  transformer, and the loader (each stage that implements `IReportsItemErrors`), so an item any
+  stage's error policy discarded is reflected in the total. Pre-1.0 behaviour change.
 - **Breaking (#285):** `EtlPipelineProgress`'s counters — `ExtractedItemCount`, `LoadedItemCount`, and
   `ErrorItemCount` — are now `long` instead of `int`, so a long-running pipeline can report more than
   `int.MaxValue` (~2.1 billion) records without overflow. This changes the record's getters, positional

--- a/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipelineImpl.cs
+++ b/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipelineImpl.cs
@@ -46,7 +46,11 @@ internal sealed class EtlPipelineImpl<T> : IEtlPipeline<T>
             throw new ArgumentNullException(nameof(transformer));
         }
 
-        return new EtlPipelineImpl<TOut>((state, token) => transformer.TransformAsync(_factory(state, token)));
+        return new EtlPipelineImpl<TOut>((state, token) =>
+        {
+            RegisterErrorReader(transformer, state);
+            return transformer.TransformAsync(_factory(state, token));
+        });
     }
 
 
@@ -59,7 +63,11 @@ internal sealed class EtlPipelineImpl<T> : IEtlPipeline<T>
             throw new ArgumentNullException(nameof(transformer));
         }
 
-        return new EtlPipelineImpl<TOut>((state, token) => transformer.TransformAsync(_factory(state, token), token));
+        return new EtlPipelineImpl<TOut>((state, token) =>
+        {
+            RegisterErrorReader(transformer, state);
+            return transformer.TransformAsync(_factory(state, token), token);
+        });
     }
 
 
@@ -106,6 +114,18 @@ internal sealed class EtlPipelineImpl<T> : IEtlPipeline<T>
     public IAsyncEnumerable<T> AsAsyncEnumerable(CancellationToken token = default)
     {
         return _factory(new EtlRunState(), token);
+    }
+
+
+    // Registers a transformer stage's error-item count with the run so
+    // EtlPipelineProgress.ErrorItemCount sums it alongside the source and sink. A transformer that
+    // does not report errors (for example a plain delegate transform) is skipped.
+    private static void RegisterErrorReader(object transformer, EtlRunState state)
+    {
+        if (transformer is IReportsItemErrors reporter)
+        {
+            state.AddErrorCountReader(() => reporter.CurrentErrorItemCount);
+        }
     }
 
 

--- a/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipelineSink.cs
+++ b/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipelineSink.cs
@@ -35,6 +35,11 @@ internal sealed class EtlPipelineSink<T, TProgress> : IEtlPipelineSink
     public async Task RunAsync(IProgress<EtlPipelineProgress>? progress = null, CancellationToken token = default)
     {
         var state = new EtlRunState();
+
+        // Surface the loader's error-item count into the snapshot too, summed with the source and any
+        // transformer error counts so the pipeline total reflects every stage, not just the source.
+        state.AddErrorCountReader(() => _loader.CurrentErrorItemCount);
+
         var stream = CountLoaded(_factory(state, token), state, progress, token);
 
         await _loader.LoadAsync(stream, token).ConfigureAwait(false);

--- a/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipelineSourceExtensions.cs
+++ b/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipelineSourceExtensions.cs
@@ -56,7 +56,8 @@ public static class EtlPipelineSourceExtensions
         {
             // Surface the extractor's error-item count into the pipeline snapshot so a bad record
             // the extractor's error policy discarded is reported, not silently absent from the totals.
-            state.ErrorCountReader = () => extractor.CurrentErrorItemCount;
+            // Summed with any transformer/loader error counts (see EtlRunState.AddErrorCountReader).
+            state.AddErrorCountReader(() => extractor.CurrentErrorItemCount);
             return extractor.ExtractAsync(token);
         });
     }

--- a/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlRunState.cs
+++ b/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlRunState.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 
@@ -18,16 +19,27 @@ internal sealed class EtlRunState
 
     public long LoadedItemCount;
 
-    // Optional reader that surfaces an error-reporting source's error-item count into the snapshot.
-    // Left null for sources that don't report errors (e.g. a raw IAsyncEnumerable), which reads as 0.
-    public Func<int>? ErrorCountReader;
+    // Error-item-count readers, one per stage that reports errors (source, transformers, sink). Their
+    // values are summed into the snapshot so an item any stage's error policy discarded is reported,
+    // not just the source's. Empty for a pipeline of stages that don't report errors, which reads as 0.
+    private readonly List<Func<int>> _errorCountReaders = new();
+
+
+    // Registers a stage's error-item-count reader. Called once per stage as the factory chain runs.
+    public void AddErrorCountReader(Func<int> reader) => _errorCountReaders.Add(reader);
 
 
     public EtlPipelineProgress Snapshot()
     {
+        long errorItemCount = 0;
+        foreach (var reader in _errorCountReaders)
+        {
+            errorItemCount += reader();
+        }
+
         return new EtlPipelineProgress(ExtractedItemCount, LoadedItemCount, _stopwatch.Elapsed)
         {
-            ErrorItemCount = ErrorCountReader?.Invoke() ?? 0,
+            ErrorItemCount = errorItemCount,
         };
     }
 }

--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -19,6 +19,7 @@ namespace Wolfgang.Etl.Abstractions;
 /// <typeparam name="TProgress">The type of the progress object</typeparam>
 public abstract class ExtractorBase<TSource, TProgress>
     : IExtractWithProgressAndCancellationAsync<TSource, TProgress>,
+      IReportsItemErrors,
       IAsyncDisposable,
       IDisposable
     where TSource : notnull

--- a/src/Wolfgang.Etl.Abstractions/IReportsItemErrors.cs
+++ b/src/Wolfgang.Etl.Abstractions/IReportsItemErrors.cs
@@ -1,0 +1,17 @@
+namespace Wolfgang.Etl.Abstractions;
+
+/// <summary>
+/// Implemented by an ETL stage that counts items its error policy discarded, so a pipeline can read
+/// that count uniformly regardless of the stage's concrete type. <see cref="ExtractorBase{TSource, TProgress}"/>,
+/// <see cref="LoaderBase{TDestination, TProgress}"/>, and <see cref="TransformerBase{TSource, TDestination, TProgress}"/>
+/// all implement it, and <c>EtlPipeline</c> sums <see cref="CurrentErrorItemCount"/> across every stage
+/// that reports it into <see cref="EtlPipelineProgress.ErrorItemCount"/>.
+/// </summary>
+public interface IReportsItemErrors
+{
+    /// <summary>
+    /// The number of items this stage's error policy has discarded (<c>OnItemError</c> returned
+    /// <see cref="ItemErrorAction.Skip"/>) so far in the current run.
+    /// </summary>
+    int CurrentErrorItemCount { get; }
+}

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -18,6 +18,7 @@ namespace Wolfgang.Etl.Abstractions;
 /// <typeparam name="TProgress">The type of the progress object</typeparam>
 public abstract class LoaderBase<TDestination, TProgress>
     : ILoadWithProgressAndCancellationAsync<TDestination, TProgress>,
+      IReportsItemErrors,
       IAsyncDisposable,
       IDisposable
     where TDestination : notnull

--- a/src/Wolfgang.Etl.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Abstractions/PublicAPI.Unshipped.txt
@@ -20,3 +20,5 @@ static Wolfgang.Etl.Abstractions.MiddlewareResult<T>.operator !=(Wolfgang.Etl.Ab
 Wolfgang.Etl.Abstractions.MiddlewareExtensions
 static Wolfgang.Etl.Abstractions.MiddlewareExtensions.WithMiddleware<T>(this System.Collections.Generic.IAsyncEnumerable<T>! source, Wolfgang.Etl.Abstractions.IItemMiddleware<T>! middleware, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T>!
 static Wolfgang.Etl.Abstractions.MiddlewareExtensions.WithMiddleware<T>(this System.Collections.Generic.IAsyncEnumerable<T>! source, System.Collections.Generic.IEnumerable<Wolfgang.Etl.Abstractions.IItemMiddleware<T>!>! middlewares, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T>!
+Wolfgang.Etl.Abstractions.IReportsItemErrors
+Wolfgang.Etl.Abstractions.IReportsItemErrors.CurrentErrorItemCount.get -> int

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -20,6 +20,7 @@ namespace Wolfgang.Etl.Abstractions;
 /// <typeparam name="TProgress">The type of the progress object</typeparam>
 public abstract class TransformerBase<TSource, TDestination, TProgress>
     : ITransformWithProgressAndCancellationAsync<TSource, TDestination, TProgress>,
+      IReportsItemErrors,
       IAsyncDisposable,
       IDisposable
     where TSource : notnull

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/AggregateErrorsTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/AggregateErrorsTests.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
+using Xunit;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.EtlPipelineTests;
+
+/// <summary>
+/// Covers #335: <see cref="EtlPipelineProgress.ErrorItemCount"/> aggregates the per-item error counts
+/// of every stage that reports them (source, transformers, sink) via <see cref="IReportsItemErrors"/>,
+/// not just the extractor.
+/// </summary>
+public class AggregateErrorsTests
+{
+    [Fact]
+    public void All_three_base_classes_implement_IReportsItemErrors()
+    {
+        Assert.IsAssignableFrom<IReportsItemErrors>(new ErroringExtractor(good: 0, errors: 0));
+        Assert.IsAssignableFrom<IReportsItemErrors>(new ErroringTransformer(errors: 0));
+        Assert.IsAssignableFrom<IReportsItemErrors>(new ErroringLoader(errors: 0));
+    }
+
+
+    [Fact]
+    public async Task ErrorItemCount_sums_extractor_transformer_and_loader_errors()
+    {
+        var reports = new List<EtlPipelineProgress>();
+        var extractor = new ErroringExtractor(good: 3, errors: 2);
+        var transformer = new ErroringTransformer(errors: 4);
+        var loader = new ErroringLoader(errors: 1);
+
+        await EtlPipeline
+            .Create()
+            .From(extractor)
+            .Through(transformer)
+            .To(loader)
+            .RunAsync(new SyncProgress(reports.Add));
+
+        var final = reports[^1];
+        Assert.Equal(3, final.ExtractedItemCount);
+        Assert.Equal(3, final.LoadedItemCount);
+        Assert.Equal(7, final.ErrorItemCount);   // 2 (extract) + 4 (transform) + 1 (load)
+    }
+
+
+    [Fact]
+    public async Task ErrorItemCount_counts_only_stages_that_report_errors()
+    {
+        // A delegate transform stage does not implement IReportsItemErrors, so it contributes nothing.
+        var reports = new List<EtlPipelineProgress>();
+        var extractor = new ErroringExtractor(good: 2, errors: 5);
+        var loader = new ErroringLoader(errors: 3);
+
+        await EtlPipeline
+            .Create()
+            .From(extractor)
+            .Through(s => s)
+            .To(loader)
+            .RunAsync(new SyncProgress(reports.Add));
+
+        Assert.Equal(8, reports[^1].ErrorItemCount);   // 5 (extract) + 3 (load); delegate adds 0
+    }
+
+
+    [Fact]
+    public async Task ErrorItemCount_includes_a_plain_ITransformAsync_stage_that_reports_errors()
+    {
+        // Binds the non-cancellation Through overload (a bare ITransformAsync, not a TransformerBase).
+        var reports = new List<EtlPipelineProgress>();
+        var extractor = new ErroringExtractor(good: 2, errors: 1);
+        var transform = new ReportingPassThroughTransform(errors: 5);
+        var loader = new ErroringLoader(errors: 0);
+
+        await EtlPipeline
+            .Create()
+            .From(extractor)
+            .Through(transform)
+            .To(loader)
+            .RunAsync(new SyncProgress(reports.Add));
+
+        Assert.Equal(6, reports[^1].ErrorItemCount);   // 1 (extract) + 5 (plain transform)
+    }
+
+
+    [Fact]
+    public async Task ErrorItemCount_is_zero_when_no_stage_reports_errors()
+    {
+        var reports = new List<EtlPipelineProgress>();
+        var loader = new ErroringLoader(errors: 0);
+
+        await EtlPipeline
+            .Create()
+            .From(AsyncSource(1, 2, 3))          // raw IAsyncEnumerable — not an IReportsItemErrors stage
+            .To(loader)
+            .RunAsync(new SyncProgress(reports.Add));
+
+        Assert.Equal(0, reports[^1].ErrorItemCount);
+    }
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<int> AsyncSource(params int[] items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+    // A bare ITransformAsync (not a TransformerBase) that still reports an error count — exercises the
+    // non-cancellation Through overload's error-reader registration.
+    private sealed class ReportingPassThroughTransform : ITransformAsync<int, int>, IReportsItemErrors
+    {
+        public ReportingPassThroughTransform(int errors) => CurrentErrorItemCount = errors;
+
+        public int CurrentErrorItemCount { get; }
+
+        public IAsyncEnumerable<int> TransformAsync(IAsyncEnumerable<int> items) => items;
+    }
+
+
+    private sealed class SyncProgress : IProgress<EtlPipelineProgress>
+    {
+        private readonly Action<EtlPipelineProgress> _report;
+
+        public SyncProgress(Action<EtlPipelineProgress> report) => _report = report;
+
+        public void Report(EtlPipelineProgress value) => _report(value);
+    }
+
+
+    // ---------- error-reporting doubles (route real #84 errors through HandleItemError) ----------
+
+    private sealed class ErroringExtractor : ExtractorBase<int, EtlProgress>
+    {
+        private readonly int _good;
+        private readonly int _errors;
+
+        public ErroringExtractor(int good, int errors)
+        {
+            _good = good;
+            _errors = errors;
+        }
+
+        protected override ItemErrorAction OnItemError(ItemErrorContext context) => ItemErrorAction.Skip;
+
+        protected override async IAsyncEnumerable<int> ExtractWorkerAsync([EnumeratorCancellation] CancellationToken token)
+        {
+            for (var i = 0; i < _good; i++)
+            {
+                await Task.Yield();
+                IncrementCurrentItemCount();
+                yield return i;
+            }
+
+            for (var e = 0; e < _errors; e++)
+            {
+                // Route a synthetic failure through the base #84 hook: with OnItemError => Skip,
+                // HandleItemError increments CurrentErrorItemCount and returns without rethrowing.
+                try
+                {
+                    throw new InvalidOperationException("bad item");
+                }
+                catch (InvalidOperationException ex)
+                {
+                    HandleItemError(new ItemErrorContext(e, ex));
+                }
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+
+
+    private sealed class ErroringTransformer : TransformerBase<int, int, EtlProgress>
+    {
+        private readonly int _errors;
+
+        public ErroringTransformer(int errors) => _errors = errors;
+
+        protected override ItemErrorAction OnItemError(ItemErrorContext context) => ItemErrorAction.Skip;
+
+        protected override async IAsyncEnumerable<int> TransformWorkerAsync(
+            IAsyncEnumerable<int> items, [EnumeratorCancellation] CancellationToken token)
+        {
+            await foreach (var item in items.WithCancellation(token))
+            {
+                IncrementCurrentItemCount();
+                yield return item;
+            }
+
+            for (var e = 0; e < _errors; e++)
+            {
+                // Route a synthetic failure through the base #84 hook: with OnItemError => Skip,
+                // HandleItemError increments CurrentErrorItemCount and returns without rethrowing.
+                try
+                {
+                    throw new InvalidOperationException("bad item");
+                }
+                catch (InvalidOperationException ex)
+                {
+                    HandleItemError(new ItemErrorContext(e, ex));
+                }
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+
+
+    private sealed class ErroringLoader : LoaderBase<int, EtlProgress>
+    {
+        private readonly int _errors;
+
+        public ErroringLoader(int errors) => _errors = errors;
+
+        protected override ItemErrorAction OnItemError(ItemErrorContext context) => ItemErrorAction.Skip;
+
+        protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
+        {
+            await foreach (var item in items.WithCancellation(token))
+            {
+                IncrementCurrentItemCount();
+            }
+
+            for (var e = 0; e < _errors; e++)
+            {
+                // Route a synthetic failure through the base #84 hook: with OnItemError => Skip,
+                // HandleItemError increments CurrentErrorItemCount and returns without rethrowing.
+                try
+                {
+                    throw new InvalidOperationException("bad item");
+                }
+                catch (InvalidOperationException ex)
+                {
+                    HandleItemError(new ItemErrorContext(e, ex));
+                }
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+}


### PR DESCRIPTION
Closes #335. Stacked on #334 (#93) — base is `feat/93-middleware`.

## Summary
Fixes the base-class asymmetry surfaced while reviewing the #93/#94 error interaction: the #84 error mechanism is on all three base classes, but `EtlPipelineProgress.ErrorItemCount` only reflected the **extractor's** errors. Root cause — `CurrentErrorItemCount` lived only on the concrete bases, and `Through(ITransformAsync<…>)` takes an *interface* that didn't expose it, so the pipeline structurally couldn't read a transformer's error count.

## Changes
- **New `IReportsItemErrors`** — `int CurrentErrorItemCount { get; }`, implemented by `ExtractorBase`, `LoaderBase`, `TransformerBase` (the property already existed — purely additive).
- **`EtlRunState`** now holds a list of error-count readers and **sums** them in `Snapshot()`.
- Every error-reporting stage registers a reader as the factory chain runs: the extractor (`From`), each transformer (`Through`, via `is IReportsItemErrors` — so a bare `ITransformAsync` that opts in counts too), and the loader (sink).

`EtlPipelineProgress.ErrorItemCount` now reports the total items **any** stage's error policy discarded.

## Behaviour change (pre-1.0)
`ErrorItemCount` was extractor-only; it now aggregates source + transformers + loader. 0.19.0 hasn't shipped, so no released consumer depends on the old meaning. Documented in the CHANGELOG.

## Verification
- **446 unit tests pass** (5 new `AggregateErrorsTests`: sum across all three stages `2+4+1=7`, delegate stage contributes 0, zero when nothing reports, plain-`ITransformAsync` overload, and the interface is implemented by all three bases).
- **Stryker 100.00 %, 0 survivors** (full project).
- Builds clean across all 11 TFMs; PublicAPI.Unshipped updated (RS0016 completeness + RS0017 correctness both validated).

## Notes for release-prep
Targets the 0.20.0 line (`vNext-plus-one`). Version bump 0.19.0 → 0.20.0 + baseline → 0.19.0 deferred to 0.20.0 release-prep (gated on 0.19.0 publishing).
