### PR TITLE
Release v0.19.0 — overflow-safe progress counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.19.0] - 2026-07-28
+## [0.19.0] - 2026-07-29
 
 Minor release: makes the `EtlPipelineProgress` record counters overflow-safe.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Breaking (#285):** `EtlPipelineProgress`'s counters — `ExtractedItemCount`, `LoadedItemCount`, and
-  `ErrorItemCount` — are now `long` instead of `int`, so a long-running pipeline can report more than
-  `int.MaxValue` (~2.1 billion) records without overflow. This changes the record's getters, positional
-  constructor, and `Deconstruct` from `int` to `long`; Package Validation against the 0.18.0 baseline
-  waives the change via `CompatibilitySuppressions.xml`. `AssemblyVersion` stays pinned at `1.0.0.0`.
-  Pre-1.0.
-
 ### Deprecated
 
 ### Removed
@@ -25,6 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.19.0] - 2026-07-28
+
+Minor release: makes the `EtlPipelineProgress` record counters overflow-safe.
+
+### Changed
+
+- **Breaking (#285):** `EtlPipelineProgress`'s counters — `ExtractedItemCount`, `LoadedItemCount`, and
+  `ErrorItemCount` — are now `long` instead of `int`, so a long-running pipeline can report more than
+  `int.MaxValue` (~2.1 billion) records without overflow. This changes the record's getters, positional
+  constructor, and `Deconstruct` from `int` to `long`; Package Validation against the 0.18.1 baseline
+  waives the change via `CompatibilitySuppressions.xml`. `AssemblyVersion` stays pinned at `1.0.0.0`.
+  Pre-1.0.
 
 ## [0.18.1] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking (#285):** `EtlPipelineProgress`'s counters — `ExtractedItemCount`, `LoadedItemCount`, and
+  `ErrorItemCount` — are now `long` instead of `int`, so a long-running pipeline can report more than
+  `int.MaxValue` (~2.1 billion) records without overflow. This changes the record's getters, positional
+  constructor, and `Deconstruct` from `int` to `long`; Package Validation against the 0.18.0 baseline
+  waives the change via `CompatibilitySuppressions.xml`. `AssemblyVersion` stays pinned at `1.0.0.0`.
+  Pre-1.0.
+
 ### Deprecated
 
 ### Removed

--- a/src/Wolfgang.Etl.Abstractions/CompatibilitySuppressions.xml
+++ b/src/Wolfgang.Etl.Abstractions/CompatibilitySuppressions.xml
@@ -4,7 +4,7 @@
   0.19.0 widened the EtlPipelineProgress counters from int to long (#285) so a long-running
   pipeline can report more than int.MaxValue records without overflow. These CP0002 baseline
   suppressions waive the intentional int->long change of the record's getters, constructor, and
-  Deconstruct against the 0.18.0 baseline — a deliberate pre-1.0 breaking change. See CHANGELOG [0.19.0].
+  Deconstruct against the 0.18.1 baseline — a deliberate pre-1.0 breaking change. See CHANGELOG [0.19.0].
 -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>

--- a/src/Wolfgang.Etl.Abstractions/CompatibilitySuppressions.xml
+++ b/src/Wolfgang.Etl.Abstractions/CompatibilitySuppressions.xml
@@ -1,316 +1,393 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <!--
-  0.18.0 renamed EtlPipelineProgress.RecordsExtracted -> ExtractedItemCount and
-  RecordsLoaded -> LoadedItemCount for a consistent ...ItemCount naming (alongside the
-  new ErrorItemCount). These CP0002 baseline suppressions waive the intentional removal of
-  the old 0.17.0 accessors — a deliberate pre-1.0 breaking change. See CHANGELOG [0.18.0].
+  0.19.0 widened the EtlPipelineProgress counters from int to long (#285) so a long-running
+  pipeline can report more than int.MaxValue records without overflow. These CP0002 baseline
+  suppressions waive the intentional int->long change of the record's getters, constructor, and
+  Deconstruct against the 0.18.0 baseline — a deliberate pre-1.0 breaking change. See CHANGELOG [0.19.0].
 -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net10.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net462/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net462/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net462/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net462/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net462/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net462/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net462/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net462/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net462/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net462/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net472/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net472/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net472/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net472/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net472/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net472/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net472/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net472/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net472/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net472/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net48/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net48/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net48/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net48/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net48/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net48/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net48/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net48/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net48/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net48/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net481/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net481/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net481/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net481/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net481/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net481/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net481/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net481/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net481/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net481/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net5.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net6.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net7.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net8.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
     <Left>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsExtracted</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
+    <Left>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/net9.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.#ctor(System.Int32,System.Int32,System.TimeSpan)</Target>
     <Left>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_RecordsLoaded</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.Deconstruct(System.Int32@,System.Int32@,System.TimeSpan@)</Target>
     <Left>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsExtracted(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ErrorItemCount</Target>
     <Left>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.set_RecordsLoaded(System.Int32)</Target>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_ExtractedItemCount</Target>
+    <Left>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Left>
+    <Right>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Wolfgang.Etl.Abstractions.EtlPipelineProgress.get_LoadedItemCount</Target>
     <Left>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Left>
     <Right>lib/netstandard2.0/Wolfgang.Etl.Abstractions.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipelineProgress.cs
+++ b/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlPipelineProgress.cs
@@ -21,8 +21,8 @@ namespace Wolfgang.Etl.Abstractions;
 /// <param name="Elapsed">The wall-clock time elapsed since the run started.</param>
 public sealed record EtlPipelineProgress
 (
-    int ExtractedItemCount,
-    int LoadedItemCount,
+    long ExtractedItemCount,
+    long LoadedItemCount,
     TimeSpan Elapsed
 )
 {
@@ -35,5 +35,5 @@ public sealed record EtlPipelineProgress
     /// successfully flowed into the pipeline, so a failed record is never silent. Distinct from
     /// intentional skips (an extractor's <c>SkipItemCount</c> budget), which are not surfaced here.
     /// </summary>
-    public int ErrorItemCount { get; init; }
+    public long ErrorItemCount { get; init; }
 }

--- a/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlRunState.cs
+++ b/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlRunState.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 
 
 namespace Wolfgang.Etl.Abstractions;
@@ -12,7 +11,8 @@ namespace Wolfgang.Etl.Abstractions;
 /// </summary>
 internal sealed class EtlRunState
 {
-    private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+    private readonly ITimeSource _timeSource;
+    private readonly long _startTimestamp;
 
     public long ExtractedItemCount;
 
@@ -23,9 +23,33 @@ internal sealed class EtlRunState
     public Func<int>? ErrorCountReader;
 
 
+    public EtlRunState()
+        : this(SystemTimeSource.Instance)
+    {
+    }
+
+
+    // Test seam (#338): inject a fake time source so the elapsed metric is deterministic.
+    internal EtlRunState(ITimeSource timeSource)
+    {
+        _timeSource = timeSource;
+        _startTimestamp = timeSource.GetTimestamp();
+    }
+
+
+    private TimeSpan Elapsed
+    {
+        get
+        {
+            var ticks = _timeSource.GetTimestamp() - _startTimestamp;
+            return TimeSpan.FromSeconds(ticks / (double)_timeSource.TimestampFrequency);
+        }
+    }
+
+
     public EtlPipelineProgress Snapshot()
     {
-        return new EtlPipelineProgress(ExtractedItemCount, LoadedItemCount, _stopwatch.Elapsed)
+        return new EtlPipelineProgress(ExtractedItemCount, LoadedItemCount, Elapsed)
         {
             ErrorItemCount = ErrorCountReader?.Invoke() ?? 0,
         };

--- a/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlRunState.cs
+++ b/src/Wolfgang.Etl.Abstractions/EtlPipeline/EtlRunState.cs
@@ -14,9 +14,9 @@ internal sealed class EtlRunState
 {
     private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
 
-    public int ExtractedItemCount;
+    public long ExtractedItemCount;
 
-    public int LoadedItemCount;
+    public long LoadedItemCount;
 
     // Optional reader that surfaces an error-reporting source's error-item count into the snapshot.
     // Left null for sources that don't report errors (e.g. a raw IAsyncEnumerable), which reads as 0.

--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -33,6 +33,15 @@ public abstract class ExtractorBase<TSource, TProgress>
 
 
 
+    // Test seam (#338): when set, StartedAt/Elapsed derive from this time source instead of the
+    // system clock, so the timing-derived Report metrics can be driven deterministically. Left null
+    // in production (real clock). Internal + InternalsVisibleTo, mirroring the IProgressTimer
+    // injection pattern, so Test-Kit doubles can advance a fake clock.
+    internal ITimeSource? TimeSource;
+
+
+
+
     /// <summary>
     /// The UTC time at which the first item was processed (extracted or skipped), or
     /// <c>null</c> if extraction has not produced any items yet. Captured automatically
@@ -61,8 +70,9 @@ public abstract class ExtractorBase<TSource, TProgress>
                 return TimeSpan.Zero;
             }
 
-            var ticks = Stopwatch.GetTimestamp() - start;
-            return TimeSpan.FromSeconds(ticks / (double)Stopwatch.Frequency);
+            var source = TimeSource ?? SystemTimeSource.Instance;
+            var ticks = source.GetTimestamp() - start;
+            return TimeSpan.FromSeconds(ticks / (double)source.TimestampFrequency);
         }
     }
 
@@ -503,8 +513,9 @@ public abstract class ExtractorBase<TSource, TProgress>
             return;
         }
 
-        var now = DateTimeOffset.UtcNow;
-        var timestamp = Stopwatch.GetTimestamp();
+        var source = TimeSource ?? SystemTimeSource.Instance;
+        var now = source.UtcNow;
+        var timestamp = source.GetTimestamp();
         if (Interlocked.CompareExchange(ref _startTimestamp, timestamp, 0) == 0)
         {
             _startedAtUtc = now;

--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -290,10 +290,18 @@ public abstract class ExtractorBase<TSource, TProgress>
     /// <returns>A started <see cref="IProgressTimer"/> instance.</returns>
     protected virtual IProgressTimer CreateProgressTimer(IProgress<TProgress> progress)
     {
-        var timer = new SystemProgressTimer(ReportProgress, progress);
+        var timer = TimerCoreFactory is null
+            ? new SystemProgressTimer(ReportProgress, progress)
+            : new SystemProgressTimer(ReportProgress, progress, TimerCoreFactory);
         timer.Start(ReportingInterval);
         return timer;
     }
+
+
+    // Test seam: when set, CreateProgressTimer builds its SystemProgressTimer over this timer core
+    // (a deterministic fake) instead of a real System.Threading.Timer.
+    internal Func<System.Threading.TimerCallback, ITimerCore>? TimerCoreFactory;
+
 
 
 

--- a/src/Wolfgang.Etl.Abstractions/ITimeSource.cs
+++ b/src/Wolfgang.Etl.Abstractions/ITimeSource.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Wolfgang.Etl.Abstractions;
+
+/// <summary>
+/// Internal seam over the wall-clock and monotonic timer the base classes read when they compute
+/// their <see cref="Report"/> timing metrics (<c>StartedAt</c>, <c>Elapsed</c>, and the throughput
+/// values derived from them). The default is the system clock; a fake can be injected in tests — via
+/// <c>InternalsVisibleTo</c> — so those metrics become deterministic. Deliberately internal: no
+/// public API surface.
+/// </summary>
+internal interface ITimeSource
+{
+    /// <summary>The current UTC wall-clock time (used to capture <c>StartedAt</c>).</summary>
+    DateTimeOffset UtcNow { get; }
+
+    /// <summary>A monotonic timestamp tick count (used to measure <c>Elapsed</c>).</summary>
+    long GetTimestamp();
+
+    /// <summary>The number of <see cref="GetTimestamp"/> ticks per second.</summary>
+    long TimestampFrequency { get; }
+}

--- a/src/Wolfgang.Etl.Abstractions/ITimerCore.cs
+++ b/src/Wolfgang.Etl.Abstractions/ITimerCore.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Wolfgang.Etl.Abstractions;
+
+/// <summary>
+/// The minimal periodic-timer primitive that <see cref="SystemProgressTimer"/> drives. Production
+/// code uses a wrapper over <see cref="System.Threading.Timer"/>; tests inject a deterministic fake
+/// (one whose ticks fire on demand and that records <see cref="Change"/> / <see cref="IDisposable.Dispose"/>
+/// calls), which makes the timer's Start / StopTimer / Dispose contract observable without relying on
+/// real wall-clock ticks.
+/// </summary>
+internal interface ITimerCore : IDisposable
+{
+    /// <summary>
+    /// Arms or disarms the timer. <see cref="System.Threading.Timeout.Infinite"/> for both arguments
+    /// disarms it; a positive period arms it to fire repeatedly at that interval.
+    /// </summary>
+    void Change(int dueTime, int period);
+}

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -291,10 +291,18 @@ public abstract class LoaderBase<TDestination, TProgress>
     /// <returns>A started <see cref="IProgressTimer"/> instance.</returns>
     protected virtual IProgressTimer CreateProgressTimer(IProgress<TProgress> progress)
     {
-        var timer = new SystemProgressTimer(ReportProgress, progress);
+        var timer = TimerCoreFactory is null
+            ? new SystemProgressTimer(ReportProgress, progress)
+            : new SystemProgressTimer(ReportProgress, progress, TimerCoreFactory);
         timer.Start(ReportingInterval);
         return timer;
     }
+
+
+    // Test seam: when set, CreateProgressTimer builds its SystemProgressTimer over this timer core
+    // (a deterministic fake) instead of a real System.Threading.Timer.
+    internal Func<System.Threading.TimerCallback, ITimerCore>? TimerCoreFactory;
+
 
 
 

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -32,6 +32,15 @@ public abstract class LoaderBase<TDestination, TProgress>
 
 
 
+    // Test seam (#338): when set, StartedAt/Elapsed derive from this time source instead of the
+    // system clock, so the timing-derived Report metrics can be driven deterministically. Left null
+    // in production (real clock). Internal + InternalsVisibleTo, mirroring the IProgressTimer
+    // injection pattern, so Test-Kit doubles can advance a fake clock.
+    internal ITimeSource? TimeSource;
+
+
+
+
     /// <summary>
     /// The UTC time at which the first item was processed (loaded or skipped), or
     /// <c>null</c> if loading has not produced any items yet. Captured automatically
@@ -60,8 +69,9 @@ public abstract class LoaderBase<TDestination, TProgress>
                 return TimeSpan.Zero;
             }
 
-            var ticks = Stopwatch.GetTimestamp() - start;
-            return TimeSpan.FromSeconds(ticks / (double)Stopwatch.Frequency);
+            var source = TimeSource ?? SystemTimeSource.Instance;
+            var ticks = source.GetTimestamp() - start;
+            return TimeSpan.FromSeconds(ticks / (double)source.TimestampFrequency);
         }
     }
 
@@ -501,8 +511,9 @@ public abstract class LoaderBase<TDestination, TProgress>
             return;
         }
 
-        var now = DateTimeOffset.UtcNow;
-        var timestamp = Stopwatch.GetTimestamp();
+        var source = TimeSource ?? SystemTimeSource.Instance;
+        var now = source.UtcNow;
+        var timestamp = source.GetTimestamp();
         if (Interlocked.CompareExchange(ref _startTimestamp, timestamp, 0) == 0)
         {
             _startedAtUtc = now;

--- a/src/Wolfgang.Etl.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.Abstractions/PublicAPI.Shipped.txt
@@ -3,12 +3,12 @@ Wolfgang.Etl.Abstractions.EtlPipeline
 Wolfgang.Etl.Abstractions.EtlPipelineProgress
 Wolfgang.Etl.Abstractions.EtlPipelineProgress.Elapsed.get -> System.TimeSpan
 Wolfgang.Etl.Abstractions.EtlPipelineProgress.Elapsed.init -> void
-Wolfgang.Etl.Abstractions.EtlPipelineProgress.ErrorItemCount.get -> int
+Wolfgang.Etl.Abstractions.EtlPipelineProgress.ErrorItemCount.get -> long
 Wolfgang.Etl.Abstractions.EtlPipelineProgress.ErrorItemCount.init -> void
-Wolfgang.Etl.Abstractions.EtlPipelineProgress.EtlPipelineProgress(int ExtractedItemCount, int LoadedItemCount, System.TimeSpan Elapsed) -> void
-Wolfgang.Etl.Abstractions.EtlPipelineProgress.ExtractedItemCount.get -> int
+Wolfgang.Etl.Abstractions.EtlPipelineProgress.EtlPipelineProgress(long ExtractedItemCount, long LoadedItemCount, System.TimeSpan Elapsed) -> void
+Wolfgang.Etl.Abstractions.EtlPipelineProgress.ExtractedItemCount.get -> long
 Wolfgang.Etl.Abstractions.EtlPipelineProgress.ExtractedItemCount.init -> void
-Wolfgang.Etl.Abstractions.EtlPipelineProgress.LoadedItemCount.get -> int
+Wolfgang.Etl.Abstractions.EtlPipelineProgress.LoadedItemCount.get -> long
 Wolfgang.Etl.Abstractions.EtlPipelineProgress.LoadedItemCount.init -> void
 Wolfgang.Etl.Abstractions.EtlPipelineSinkExtensions
 Wolfgang.Etl.Abstractions.EtlPipelineSourceExtensions

--- a/src/Wolfgang.Etl.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.Abstractions/PublicAPI.Shipped.txt
@@ -133,6 +133,7 @@ Wolfgang.Etl.Abstractions.Report.EstimatedRemaining.get -> System.TimeSpan?
 Wolfgang.Etl.Abstractions.Report.ItemsPerSecond.get -> double
 Wolfgang.Etl.Abstractions.Report.PercentComplete.get -> double?
 Wolfgang.Etl.Abstractions.Report.Report(int currentItemCount) -> void
+Wolfgang.Etl.Abstractions.Report.Report(int currentItemCount, System.DateTimeOffset? startedAt, System.TimeSpan elapsed, int? totalItemCount = null) -> void
 Wolfgang.Etl.Abstractions.Report.StartedAt.get -> System.DateTimeOffset?
 Wolfgang.Etl.Abstractions.Report.StartedAt.init -> void
 Wolfgang.Etl.Abstractions.Report.TotalItemCount.get -> int?

--- a/src/Wolfgang.Etl.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Abstractions/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-Wolfgang.Etl.Abstractions.Report.Report(int currentItemCount, System.DateTimeOffset? startedAt, System.TimeSpan elapsed, int? totalItemCount = null) -> void

--- a/src/Wolfgang.Etl.Abstractions/SystemProgressTimer.cs
+++ b/src/Wolfgang.Etl.Abstractions/SystemProgressTimer.cs
@@ -6,22 +6,18 @@ namespace Wolfgang.Etl.Abstractions;
 
 /// <summary>
 /// The default <see cref="IProgressTimer"/> implementation that wraps
-/// <see cref="System.Threading.Timer"/> to drive progress callbacks on a
-/// background thread-pool thread at a regular interval.
+/// <see cref="System.Threading.Timer"/> (via <see cref="ITimerCore"/>) to drive progress callbacks on
+/// a background thread-pool thread at a regular interval.
 /// </summary>
 /// <remarks>
-/// This class is used internally by the ETL base classes. In production code
-/// it is created automatically by
-/// <c>ExtractorBase.CreateProgressTimer</c>,
-/// <c>TransformerBase.CreateProgressTimer</c>, and
-/// <c>LoaderBase.CreateProgressTimer</c>.
-/// In unit tests, override <c>CreateProgressTimer</c> to return a custom
-/// <see cref="IProgressTimer"/> implementation (for example, a manually
-/// controlled fake whose ticks the test fires on demand).
+/// This class is used internally by the ETL base classes. In production code it is created
+/// automatically by <c>ExtractorBase.CreateProgressTimer</c>, <c>TransformerBase.CreateProgressTimer</c>,
+/// and <c>LoaderBase.CreateProgressTimer</c>. In unit tests, inject a fake <see cref="ITimerCore"/> via
+/// the test constructor so the Start / StopTimer / Dispose contract can be verified deterministically.
 /// </remarks>
 internal sealed class SystemProgressTimer : IProgressTimer
 {
-    private readonly Timer _timer;
+    private readonly ITimerCore _timer;
     private bool _disposed;
 
 
@@ -32,25 +28,24 @@ internal sealed class SystemProgressTimer : IProgressTimer
 
 
     /// <summary>
-    /// Initialises a new <see cref="SystemProgressTimer"/> and immediately
-    /// wires the supplied <paramref name="callback"/> to fire on each tick.
+    /// Initialises a new <see cref="SystemProgressTimer"/> backed by a real
+    /// <see cref="System.Threading.Timer"/>, wiring <paramref name="callback"/> to fire on each tick.
     /// </summary>
-    internal SystemProgressTimer
-    (
-        TimerCallback callback,
-        object? state
-    )
+    internal SystemProgressTimer(TimerCallback callback, object? state)
+        : this(callback, state, onTick => new SystemTimerCore(onTick))
     {
-        // Timer is created stopped (Timeout.Infinite) — Start() arms it.
-#pragma warning disable MA0042 // Timer does not implement IAsyncDisposable
-        _timer = new Timer
-        (
-            _ => OnTick(callback, state),
-            state: null,
-            Timeout.Infinite,
-            Timeout.Infinite
-        );
-#pragma warning restore MA0042
+    }
+
+
+
+    /// <summary>
+    /// Test seam: initialises a new <see cref="SystemProgressTimer"/> whose underlying timer is produced
+    /// by <paramref name="coreFactory"/> (the factory receives the per-tick callback to invoke).
+    /// </summary>
+    internal SystemProgressTimer(TimerCallback callback, object? state, Func<TimerCallback, ITimerCore> coreFactory)
+    {
+        // The core is created stopped; Start() arms it.
+        _timer = coreFactory(_ => OnTick(callback, state));
     }
 
 
@@ -106,8 +101,31 @@ internal sealed class SystemProgressTimer : IProgressTimer
         }
         _disposed = true;
         Elapsed = null;
-#pragma warning disable CA1849, VSTHRD103 // Timer.Dispose() is correct here
         _timer.Dispose();
+    }
+
+
+
+    /// <summary>The production <see cref="ITimerCore"/> — a thin wrapper over <see cref="Timer"/>.</summary>
+    private sealed class SystemTimerCore : ITimerCore
+    {
+        private readonly Timer _timer;
+
+        internal SystemTimerCore(TimerCallback onTick)
+        {
+#pragma warning disable MA0042 // Timer does not implement IAsyncDisposable
+            _timer = new Timer(onTick, state: null, Timeout.Infinite, Timeout.Infinite);
+#pragma warning restore MA0042
+        }
+
+        public void Change(int dueTime, int period) => _timer.Change(dueTime, period);
+
+        [ExcludeFromCodeCoverage] // thin BCL delegation
+        public void Dispose()
+        {
+#pragma warning disable CA1849, VSTHRD103 // Timer.Dispose() is correct here
+            _timer.Dispose();
 #pragma warning restore CA1849, VSTHRD103
+        }
     }
 }

--- a/src/Wolfgang.Etl.Abstractions/SystemTimeSource.cs
+++ b/src/Wolfgang.Etl.Abstractions/SystemTimeSource.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Diagnostics;
+
+namespace Wolfgang.Etl.Abstractions;
+
+/// <summary>
+/// The default <see cref="ITimeSource"/>: reads the real system clock via
+/// <see cref="DateTimeOffset.UtcNow"/> and <see cref="Stopwatch"/>. A shared stateless singleton —
+/// the base classes use it whenever no test time source has been injected.
+/// </summary>
+internal sealed class SystemTimeSource : ITimeSource
+{
+    internal static readonly SystemTimeSource Instance = new();
+
+
+    private SystemTimeSource()
+    {
+    }
+
+
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+
+
+    public long GetTimestamp() => Stopwatch.GetTimestamp();
+
+
+    public long TimestampFrequency => Stopwatch.Frequency;
+}

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -297,10 +297,18 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
     /// <returns>A started <see cref="IProgressTimer"/> instance.</returns>
     protected virtual IProgressTimer CreateProgressTimer(IProgress<TProgress> progress)
     {
-        var timer = new SystemProgressTimer(ReportProgress, progress);
+        var timer = TimerCoreFactory is null
+            ? new SystemProgressTimer(ReportProgress, progress)
+            : new SystemProgressTimer(ReportProgress, progress, TimerCoreFactory);
         timer.Start(ReportingInterval);
         return timer;
     }
+
+
+    // Test seam: when set, CreateProgressTimer builds its SystemProgressTimer over this timer core
+    // (a deterministic fake) instead of a real System.Threading.Timer.
+    internal Func<System.Threading.TimerCallback, ITimerCore>? TimerCoreFactory;
+
 
 
 

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -35,6 +35,15 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
 
 
 
+    // Test seam (#338): when set, StartedAt/Elapsed derive from this time source instead of the
+    // system clock, so the timing-derived Report metrics can be driven deterministically. Left null
+    // in production (real clock). Internal + InternalsVisibleTo, mirroring the IProgressTimer
+    // injection pattern, so Test-Kit doubles can advance a fake clock.
+    internal ITimeSource? TimeSource;
+
+
+
+
     /// <summary>
     /// The UTC time at which the first item was processed (transformed or skipped), or
     /// <c>null</c> if transformation has not produced any items yet. Captured automatically
@@ -63,8 +72,9 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
                 return TimeSpan.Zero;
             }
 
-            var ticks = Stopwatch.GetTimestamp() - start;
-            return TimeSpan.FromSeconds(ticks / (double)Stopwatch.Frequency);
+            var source = TimeSource ?? SystemTimeSource.Instance;
+            var ticks = source.GetTimestamp() - start;
+            return TimeSpan.FromSeconds(ticks / (double)source.TimestampFrequency);
         }
     }
 
@@ -511,8 +521,9 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
             return;
         }
 
-        var now = DateTimeOffset.UtcNow;
-        var timestamp = Stopwatch.GetTimestamp();
+        var source = TimeSource ?? SystemTimeSource.Instance;
+        var now = source.UtcNow;
+        var timestamp = source.GetTimestamp();
         if (Interlocked.CompareExchange(ref _startTimestamp, timestamp, 0) == 0)
         {
             _startedAtUtc = now;

--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -20,7 +20,7 @@
          recorded in CompatibilitySuppressions.xml, regenerated with
          `dotnet pack /p:GenerateCompatibilitySuppressionFile=true`. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.18.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.18.1</PackageValidationBaselineVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Contains interfaces and base classes used to build ETL applications</Description>

--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<TargetFrameworks>net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
-	<Version>0.18.0</Version>
+	<Version>0.19.0</Version>
 	<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 	     do not need to recompile / add binding redirects on every minor/patch
 	     bump. Bump only on a deliberate breaking API change. FileVersion +
@@ -20,7 +20,7 @@
          recorded in CompatibilitySuppressions.xml, regenerated with
          `dotnet pack /p:GenerateCompatibilitySuppressionFile=true`. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.17.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.18.0</PackageValidationBaselineVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Contains interfaces and base classes used to build ETL applications</Description>

--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -38,6 +38,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Wolfgang.Etl.Abstractions.Tests.Unit" />
+    <!-- #338: lets ETL-Test-Kit doubles inject a fake ITimeSource for deterministic Report timing. -->
+    <InternalsVisibleTo Include="Wolfgang.Etl.TestKit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ClockSeamTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ClockSeamTests.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
+using Xunit;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
+
+/// <summary>
+/// Covers the #338 clock seam: when an <c>ITimeSource</c> is injected, the base classes' timing
+/// metrics (<c>StartedAt</c> / <c>Elapsed</c>) and <c>EtlRunState</c>'s elapsed derive from it
+/// deterministically; with no injection the real system clock is used. The seam is internal (surfaced
+/// to tests via <c>InternalsVisibleTo</c>); no public API change.
+/// </summary>
+public class ClockSeamTests
+{
+    private static readonly DateTimeOffset Start = new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+
+    [Fact]
+    public async Task Extractor_StartedAt_and_Elapsed_derive_from_the_injected_time_source()
+    {
+        var clock = new FakeTimeSource();
+        var sut = new ClockExtractor { TimeSource = clock };
+
+        await Drain(sut.ExtractAsync(CancellationToken.None));   // first item captures start
+
+        Assert.Equal(Start, sut.PeekStartedAt);
+        Assert.Equal(TimeSpan.Zero, sut.PeekElapsed);
+
+        clock.Advance(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(TimeSpan.FromSeconds(5), sut.PeekElapsed);
+        Assert.Equal(Start, sut.PeekStartedAt);   // StartedAt is the captured value, not "now"
+    }
+
+
+    [Fact]
+    public async Task Loader_Elapsed_derives_from_the_injected_time_source()
+    {
+        var clock = new FakeTimeSource();
+        var sut = new ClockLoader { TimeSource = clock };
+
+        await sut.LoadAsync(AsyncSource(1), CancellationToken.None);
+        clock.Advance(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(Start, sut.PeekStartedAt);
+        Assert.Equal(TimeSpan.FromSeconds(2), sut.PeekElapsed);
+    }
+
+
+    [Fact]
+    public async Task Transformer_Elapsed_derives_from_the_injected_time_source()
+    {
+        var clock = new FakeTimeSource();
+        var sut = new ClockTransformer { TimeSource = clock };
+
+        await Drain(sut.TransformAsync(AsyncSource(1), CancellationToken.None));
+        clock.Advance(TimeSpan.FromSeconds(9));
+
+        Assert.Equal(Start, sut.PeekStartedAt);
+        Assert.Equal(TimeSpan.FromSeconds(9), sut.PeekElapsed);
+    }
+
+
+    [Fact]
+    public void Before_the_first_item_StartedAt_is_null_and_Elapsed_is_zero()
+    {
+        var sut = new ClockExtractor { TimeSource = new FakeTimeSource() };
+
+        Assert.Null(sut.PeekStartedAt);
+        Assert.Equal(TimeSpan.Zero, sut.PeekElapsed);
+    }
+
+
+    [Fact]
+    public async Task With_no_injected_source_the_real_system_clock_is_used()
+    {
+        var sut = new ClockExtractor();   // TimeSource null -> SystemTimeSource
+
+        var before = DateTimeOffset.UtcNow;
+        await Drain(sut.ExtractAsync(CancellationToken.None));
+        var after = DateTimeOffset.UtcNow;
+
+        Assert.NotNull(sut.PeekStartedAt);
+        Assert.InRange(sut.PeekStartedAt!.Value, before.AddSeconds(-1), after.AddSeconds(1));
+        Assert.True(sut.PeekElapsed >= TimeSpan.Zero);
+    }
+
+
+    [Fact]
+    public void EtlRunState_elapsed_derives_from_the_injected_time_source()
+    {
+        var clock = new FakeTimeSource();
+        var state = new EtlRunState(clock);
+
+        clock.Advance(TimeSpan.FromSeconds(3));
+
+        Assert.Equal(TimeSpan.FromSeconds(3), state.Snapshot().Elapsed);
+    }
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<int> AsyncSource(params int[] items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+    private static async Task Drain(IAsyncEnumerable<int> source)
+    {
+        await foreach (var _ in source.ConfigureAwait(false))
+        {
+        }
+    }
+
+
+    // ---------- doubles ----------
+
+    // A fake clock: UtcNow and a monotonic tick counter the test advances by hand. The tick counter
+    // starts non-zero so a captured start never collides with the base's "not started" sentinel (0).
+    private sealed class FakeTimeSource : ITimeSource
+    {
+        public DateTimeOffset UtcNow { get; private set; } = Start;
+
+        public long Timestamp { get; private set; } = TimeSpan.TicksPerSecond;
+
+        public long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public long GetTimestamp() => Timestamp;
+
+        public void Advance(TimeSpan by)
+        {
+            UtcNow += by;
+            Timestamp += (long)(by.TotalSeconds * TimestampFrequency);
+        }
+    }
+
+
+    private sealed class ClockExtractor : ExtractorBase<int, EtlProgress>
+    {
+        public DateTimeOffset? PeekStartedAt => StartedAt;
+
+        public TimeSpan PeekElapsed => Elapsed;
+
+        protected override async IAsyncEnumerable<int> ExtractWorkerAsync([EnumeratorCancellation] CancellationToken token)
+        {
+            await Task.Yield();
+            IncrementCurrentItemCount();
+            yield return 1;
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+
+
+    private sealed class ClockLoader : LoaderBase<int, EtlProgress>
+    {
+        public DateTimeOffset? PeekStartedAt => StartedAt;
+
+        public TimeSpan PeekElapsed => Elapsed;
+
+        protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
+        {
+            await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+            {
+                IncrementCurrentItemCount();
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+
+
+    private sealed class ClockTransformer : TransformerBase<int, int, EtlProgress>
+    {
+        public DateTimeOffset? PeekStartedAt => StartedAt;
+
+        public TimeSpan PeekElapsed => Elapsed;
+
+        protected override async IAsyncEnumerable<int> TransformWorkerAsync(
+            IAsyncEnumerable<int> items, [EnumeratorCancellation] CancellationToken token)
+        {
+            await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+            {
+                IncrementCurrentItemCount();
+                yield return item;
+            }
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TimerSeamTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TimerSeamTests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
+
+/// <summary>
+/// Deterministic tests for the <see cref="SystemProgressTimer"/> Start / StopTimer / Dispose contract
+/// and the base classes' <c>CreateProgressTimer</c> factory, driven through the <see cref="ITimerCore"/>
+/// seam (#328). A fake core records <c>Change</c>/<c>Dispose</c> calls, so the timer behaviour is
+/// verified without relying on real wall-clock ticks (which made the pre-seam tests flaky and left
+/// mutation survivors).
+/// </summary>
+public class TimerSeamTests
+{
+    // ---- SystemProgressTimer: Start / StopTimer ----
+
+    [Fact]
+    public void Start_arms_the_core_with_the_interval()
+    {
+        var (timer, core) = NewTimer();
+
+        timer.Start(250);
+
+        Assert.Equal(1, core.ChangeCount);
+        Assert.Equal(250, core.LastDueTime);
+        Assert.Equal(250, core.LastPeriod);
+    }
+
+
+    [Fact]
+    public void StopTimer_disarms_the_core()
+    {
+        var (timer, core) = NewTimer();
+
+        timer.Start(250);
+        timer.StopTimer();
+
+        Assert.Equal(2, core.ChangeCount);
+        Assert.Equal(Timeout.Infinite, core.LastDueTime);
+        Assert.Equal(Timeout.Infinite, core.LastPeriod);
+    }
+
+
+    // ---- SystemProgressTimer: Dispose ----
+
+    [Fact]
+    public void Dispose_disposes_the_core()
+    {
+        var (timer, core) = NewTimer();
+
+        timer.Dispose();
+
+        Assert.Equal(1, core.DisposeCount);
+    }
+
+
+    [Fact]
+    public void Dispose_is_idempotent()
+    {
+        var (timer, core) = NewTimer();
+
+        timer.Dispose();
+        timer.Dispose();
+
+        Assert.Equal(1, core.DisposeCount); // the second Dispose short-circuits
+    }
+
+
+    // ---- SystemProgressTimer: operations after Dispose are no-ops ----
+
+    [Fact]
+    public void Start_after_Dispose_does_not_touch_the_core()
+    {
+        var (timer, core) = NewTimer();
+
+        timer.Dispose();
+        timer.Start(250);
+
+        Assert.Equal(0, core.ChangeCount); // Start short-circuited; the disposed timer is not re-armed
+    }
+
+
+    [Fact]
+    public void StopTimer_after_Dispose_does_not_touch_the_core()
+    {
+        var (timer, core) = NewTimer();
+
+        timer.Dispose();
+        timer.StopTimer();
+
+        Assert.Equal(0, core.ChangeCount); // StopTimer short-circuited
+    }
+
+
+    // ---- A tick drives the callback + Elapsed event ----
+
+    [Fact]
+    public void A_tick_invokes_the_callback_and_raises_Elapsed()
+    {
+        var callbackFired = 0;
+        var elapsedFired = 0;
+        FakeTimerCore? core = null;
+        using var timer = new SystemProgressTimer(_ => callbackFired++, state: null, onTick => core = new FakeTimerCore(onTick));
+        timer.Elapsed += () => elapsedFired++;
+        timer.Start(100);
+
+        core!.Tick();
+
+        Assert.Equal(1, callbackFired);
+        Assert.Equal(1, elapsedFired);
+    }
+
+
+    // ---- CreateProgressTimer factory starts the timer (base classes) ----
+
+    [Fact]
+    public void LoaderBase_CreateProgressTimer_returns_a_started_timer()
+    {
+        FakeTimerCore? core = null;
+        using var loader = new TimerSeamLoader { ReportingInterval = 321, TimerCoreFactory = onTick => core = new FakeTimerCore(onTick) };
+
+        using var timer = loader.CallCreateProgressTimer();
+
+        Assert.NotNull(core);
+        Assert.Equal(321, core!.LastDueTime); // CreateProgressTimer called Start(ReportingInterval)
+        Assert.Equal(321, core.LastPeriod);
+    }
+
+
+    [Fact]
+    public void TransformerBase_CreateProgressTimer_returns_a_started_timer()
+    {
+        FakeTimerCore? core = null;
+        using var transformer = new TimerSeamTransformer { ReportingInterval = 654, TimerCoreFactory = onTick => core = new FakeTimerCore(onTick) };
+
+        using var timer = transformer.CallCreateProgressTimer();
+
+        Assert.NotNull(core);
+        Assert.Equal(654, core!.LastDueTime);
+        Assert.Equal(654, core.LastPeriod);
+    }
+
+
+    [Fact]
+    public void ExtractorBase_CreateProgressTimer_returns_a_started_timer()
+    {
+        FakeTimerCore? core = null;
+        using var extractor = new TimerSeamExtractor { ReportingInterval = 111, TimerCoreFactory = onTick => core = new FakeTimerCore(onTick) };
+
+        using var timer = extractor.CallCreateProgressTimer();
+
+        Assert.NotNull(core);
+        Assert.Equal(111, core!.LastDueTime);
+        Assert.Equal(111, core.LastPeriod);
+    }
+
+
+    // ---- helpers / doubles ----
+
+    private static (SystemProgressTimer timer, FakeTimerCore core) NewTimer()
+    {
+        FakeTimerCore? core = null;
+        var timer = new SystemProgressTimer(_ => { }, state: null, onTick => core = new FakeTimerCore(onTick));
+        return (timer, core!);
+    }
+
+
+    // A deterministic ITimerCore that records Change/Dispose calls and fires ticks on demand.
+    [ExcludeFromCodeCoverage]
+    private sealed class FakeTimerCore : ITimerCore
+    {
+        private readonly TimerCallback _onTick;
+
+        public int ChangeCount;
+        public int LastDueTime = int.MinValue;
+        public int LastPeriod = int.MinValue;
+        public int DisposeCount;
+
+        public FakeTimerCore(TimerCallback onTick) => _onTick = onTick;
+
+        public void Change(int dueTime, int period)
+        {
+            ChangeCount++;
+            LastDueTime = dueTime;
+            LastPeriod = period;
+        }
+
+        public void Dispose() => DisposeCount++;
+
+        public void Tick() => _onTick(null);
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class TimerSeamLoader : LoaderBase<int, EtlProgress>
+    {
+        public IProgressTimer CallCreateProgressTimer() =>
+            CreateProgressTimer(new SynchronousProgress<EtlProgress>(_ => { }));
+
+        protected override Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token) => Task.CompletedTask;
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class TimerSeamTransformer : TransformerBase<int, int, EtlProgress>
+    {
+        public IProgressTimer CallCreateProgressTimer() =>
+            CreateProgressTimer(new SynchronousProgress<EtlProgress>(_ => { }));
+
+        protected override async IAsyncEnumerable<int> TransformWorkerAsync(
+            IAsyncEnumerable<int> items, [EnumeratorCancellation] CancellationToken token)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class TimerSeamExtractor : ExtractorBase<int, EtlProgress>
+    {
+        public IProgressTimer CallCreateProgressTimer() =>
+            CreateProgressTimer(new SynchronousProgress<EtlProgress>(_ => { }));
+
+        protected override async IAsyncEnumerable<int> ExtractWorkerAsync([EnumeratorCancellation] CancellationToken token)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        protected override EtlProgress CreateProgressReport() => new(CurrentItemCount);
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
@@ -393,4 +393,19 @@ public class EtlPipelineCoreTests
         // ToString surfaces the members.
         Assert.Contains("ExtractedItemCount", a.ToString());
     }
+
+
+    [Fact]
+    public void EtlPipelineProgress_counters_hold_values_beyond_int_MaxValue()
+    {
+        // #285: the counters are long so a long-running pipeline can report more than
+        // int.MaxValue (~2.1B) records without overflow.
+        var big = (long)int.MaxValue + 1;
+
+        var p = new EtlPipelineProgress(big, big, TimeSpan.Zero) { ErrorItemCount = big };
+
+        Assert.Equal(big, p.ExtractedItemCount);
+        Assert.Equal(big, p.LoadedItemCount);
+        Assert.Equal(big, p.ErrorItemCount);
+    }
 }


### PR DESCRIPTION
## Release: Wolfgang.Etl.Abstractions 0.19.0 — overflow-safe progress counters

Minor release. Bundles the 0.19.0 line from `vNext` → `main`.

### What's in it
- **Breaking (#285):** `EtlPipelineProgress` counters (`ExtractedItemCount` / `LoadedItemCount` / `ErrorItemCount`) widened `int` → `long` — overflow-safe past `int.MaxValue`. Waived via `CompatibilitySuppressions.xml` against the 0.18.1 baseline. `AssemblyVersion` stays `1.0.0.0`. Pre-1.0.
- **#328 (internal):** deterministic `ITimerCore` seam that killed the 10 timer mutation survivors (100% mutation score). No public API change.
- Carries the 0.18.1 `Report` timing ctor (merge-down already in `vNext`).

### Release-prep done in this PR (commit 853ee46)
- `PackageValidationBaselineVersion` 0.18.0 → **0.18.1**; pack + Package Validation green against the published 0.18.1.
- CHANGELOG `[Unreleased]` → `[0.19.0] - 2026-07-28`.
- `Report` timing ctor promoted `PublicAPI.Unshipped` → `Shipped` (ordinal); Unshipped reset.
- 413 tests pass; all 11 TFMs build clean.

### ⚠️ Timing — do NOT tag until after 8 PM EDT tonight
Merging this PR is **safe anytime** — `release.yaml` fires only on `release:published`, not on push to `main`. But **do not create the `v0.19.0` tag/release until after `2026-07-29T00:00Z` (≥ 8:00 PM EDT)** so it lands on a NuGet UTC date (2026-07-29) distinct from 0.18.1's (2026-07-28). See the scheduled reminder.

Tag `v0.19.0` (bare), release title e.g. `v0.19.0 — overflow-safe progress counters`.

No protected files in the diff → no admin bypass needed. The 0.20.0 stack (#333/#334/#336 on `vNext-plus-one`) is separate and not part of this release.
