### PR TITLE
Post-release: baseline → 0.20.0

### DIFF
--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -20,7 +20,7 @@
          recorded in CompatibilitySuppressions.xml, regenerated with
          `dotnet pack /p:GenerateCompatibilitySuppressionFile=true`. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.19.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.20.0</PackageValidationBaselineVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Contains interfaces and base classes used to build ETL applications</Description>


### PR DESCRIPTION
## Post-release baseline bump → 0.20.0

Routine post-release step now that **v0.20.0 is published**: point `main`'s Package Validation at the latest release so future work validates against 0.20.0.

### Changes
- `PackageValidationBaselineVersion` **0.19.0 → 0.20.0**.
- **Version unchanged** (`0.20.0`) — metadata only, no re-release.
- No `CompatibilitySuppressions.xml` needed (0.20 was additive vs 0.19; the file was already removed).

### Verification
- `dotnet pack` + Package Validation green (self-compare against the published 0.20.0).
- No protected files in the diff → no admin bypass needed.

_Note: if 0.20.0's registration-index propagation is still catching up when checks first run, a job may hit `NU1102` on the baseline restore — re-run it once indexed._
