### PR TITLE
Convenience base classes fixing TProgress=Report (#344 Part A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Convenience base classes (#344):** `ExtractorBase<TSource>`, `LoaderBase<TDestination>`, and
+  `TransformerBase<TSource, TDestination>` fix the progress type to the built-in `Report` and supply a
+  default `CreateProgressReport()`, so a component that doesn't need a custom progress-report type
+  implements only its worker method — no progress record and no `CreateProgressReport` override.
+  Override it to enrich the report (for example a known total). The existing two/three-type-parameter
+  bases are unchanged. Additive.
+
 ### Changed
 
 ### Deprecated

--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase{TSource}.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase{TSource}.cs
@@ -1,0 +1,21 @@
+namespace Wolfgang.Etl.Abstractions;
+
+/// <summary>
+/// A convenience <see cref="ExtractorBase{TSource, TProgress}"/> that reports progress with the
+/// built-in <see cref="Report"/> type and supplies a default <see cref="CreateProgressReport"/>, so a
+/// derived extractor only has to implement <c>ExtractWorkerAsync</c>. Use this instead of the
+/// two-type-parameter base when you don't need a custom progress-report type — it removes the
+/// progress-record and <c>CreateProgressReport</c> boilerplate. Override
+/// <see cref="CreateProgressReport"/> if you want to enrich the report (for example set a known total).
+/// </summary>
+/// <typeparam name="TSource">The type of the object being extracted.</typeparam>
+public abstract class ExtractorBase<TSource> : ExtractorBase<TSource, Report>
+    where TSource : notnull
+{
+    /// <summary>
+    /// Builds a <see cref="Report"/> snapshot from the current item count and timing. Override to add
+    /// more detail (for example a known <see cref="Report.TotalItemCount"/>).
+    /// </summary>
+    /// <returns>A <see cref="Report"/> for the current run.</returns>
+    protected override Report CreateProgressReport() => new(CurrentItemCount, StartedAt, Elapsed);
+}

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase{TDestination}.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase{TDestination}.cs
@@ -1,0 +1,21 @@
+namespace Wolfgang.Etl.Abstractions;
+
+/// <summary>
+/// A convenience <see cref="LoaderBase{TDestination, TProgress}"/> that reports progress with the
+/// built-in <see cref="Report"/> type and supplies a default <see cref="CreateProgressReport"/>, so a
+/// derived loader only has to implement <c>LoadWorkerAsync</c>. Use this instead of the
+/// two-type-parameter base when you don't need a custom progress-report type — it removes the
+/// progress-record and <c>CreateProgressReport</c> boilerplate. Override
+/// <see cref="CreateProgressReport"/> if you want to enrich the report (for example set a known total).
+/// </summary>
+/// <typeparam name="TDestination">The type of the object being loaded.</typeparam>
+public abstract class LoaderBase<TDestination> : LoaderBase<TDestination, Report>
+    where TDestination : notnull
+{
+    /// <summary>
+    /// Builds a <see cref="Report"/> snapshot from the current item count and timing. Override to add
+    /// more detail (for example a known <see cref="Report.TotalItemCount"/>).
+    /// </summary>
+    /// <returns>A <see cref="Report"/> for the current run.</returns>
+    protected override Report CreateProgressReport() => new(CurrentItemCount, StartedAt, Elapsed);
+}

--- a/src/Wolfgang.Etl.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,10 @@
 #nullable enable
+Wolfgang.Etl.Abstractions.ExtractorBase<TSource>
+Wolfgang.Etl.Abstractions.ExtractorBase<TSource>.ExtractorBase() -> void
+Wolfgang.Etl.Abstractions.LoaderBase<TDestination>
+Wolfgang.Etl.Abstractions.LoaderBase<TDestination>.LoaderBase() -> void
+Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination>
+Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination>.TransformerBase() -> void
+override Wolfgang.Etl.Abstractions.ExtractorBase<TSource>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
+override Wolfgang.Etl.Abstractions.LoaderBase<TDestination>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
+override Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase{TSource,TDestination}.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase{TSource,TDestination}.cs
@@ -1,0 +1,23 @@
+namespace Wolfgang.Etl.Abstractions;
+
+/// <summary>
+/// A convenience <see cref="TransformerBase{TSource, TDestination, TProgress}"/> that reports progress
+/// with the built-in <see cref="Report"/> type and supplies a default <see cref="CreateProgressReport"/>,
+/// so a derived transformer only has to implement <c>TransformWorkerAsync</c>. Use this instead of the
+/// three-type-parameter base when you don't need a custom progress-report type — it removes the
+/// progress-record and <c>CreateProgressReport</c> boilerplate. Override
+/// <see cref="CreateProgressReport"/> if you want to enrich the report (for example set a known total).
+/// </summary>
+/// <typeparam name="TSource">The type of the source object.</typeparam>
+/// <typeparam name="TDestination">The type of the destination object.</typeparam>
+public abstract class TransformerBase<TSource, TDestination> : TransformerBase<TSource, TDestination, Report>
+    where TSource : notnull
+    where TDestination : notnull
+{
+    /// <summary>
+    /// Builds a <see cref="Report"/> snapshot from the current item count and timing. Override to add
+    /// more detail (for example a known <see cref="Report.TotalItemCount"/>).
+    /// </summary>
+    /// <returns>A <see cref="Report"/> for the current run.</returns>
+    protected override Report CreateProgressReport() => new(CurrentItemCount, StartedAt, Elapsed);
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ConvenienceBaseTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ConvenienceBaseTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
+
+/// <summary>
+/// Covers the #344 convenience base classes — <see cref="ExtractorBase{TSource}"/>,
+/// <see cref="LoaderBase{TDestination}"/>, and <see cref="TransformerBase{TSource, TDestination}"/> —
+/// which fix the progress type to the built-in <see cref="Report"/> and supply a default
+/// <c>CreateProgressReport()</c>, so a derived component only implements its worker method.
+/// </summary>
+public class ConvenienceBaseTests
+{
+    [Fact]
+    public async Task Extractor_convenience_base_yields_items_and_reports_the_built_in_Report()
+    {
+        var sut = new ConvenienceExtractor();
+
+        var items = await Drain(sut.ExtractAsync(CancellationToken.None));
+        var report = sut.Report();
+
+        Assert.Equal(new[] { 1, 2, 3 }, items);
+        Assert.Equal(3, report.CurrentItemCount);
+        Assert.NotNull(report.StartedAt);              // captured once the first item was processed
+        Assert.True(report.Elapsed >= TimeSpan.Zero);
+    }
+
+
+    [Fact]
+    public async Task Loader_convenience_base_loads_items_and_reports_the_built_in_Report()
+    {
+        var sut = new ConvenienceLoader();
+
+        await sut.LoadAsync(AsyncSource(1, 2, 3), CancellationToken.None);
+        var report = sut.Report();
+
+        Assert.Equal(new[] { 1, 2, 3 }, sut.Loaded);
+        Assert.Equal(3, report.CurrentItemCount);
+    }
+
+
+    [Fact]
+    public async Task Transformer_convenience_base_transforms_items_and_reports_the_built_in_Report()
+    {
+        var sut = new ConvenienceTransformer();
+
+        var items = await Drain(sut.TransformAsync(AsyncSource(1, 2, 3), CancellationToken.None));
+        var report = sut.Report();
+
+        Assert.Equal(new[] { 10, 20, 30 }, items);
+        Assert.Equal(3, report.CurrentItemCount);
+    }
+
+
+    [Fact]
+    public async Task Convenience_base_CreateProgressReport_can_still_be_overridden()
+    {
+        // The default CreateProgressReport is not sealed — a component can enrich it (here: a known total).
+        var sut = new TotalAwareExtractor(total: 10);
+
+        await Drain(sut.ExtractAsync(CancellationToken.None));
+
+        Assert.Equal(10, sut.Report().TotalItemCount);
+    }
+
+
+    // ---------- helpers ----------
+
+    private static async IAsyncEnumerable<int> AsyncSource(params int[] items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+    private static async Task<List<int>> Drain(IAsyncEnumerable<int> source)
+    {
+        var result = new List<int>();
+        await foreach (var item in source.ConfigureAwait(false))
+        {
+            result.Add(item);
+        }
+
+        return result;
+    }
+
+
+    // ---------- doubles (each implements ONLY its worker — no progress record, no CreateProgressReport) ----------
+
+    private sealed class ConvenienceExtractor : ExtractorBase<int>
+    {
+        public Report Report() => CreateProgressReport();
+
+        protected override async IAsyncEnumerable<int> ExtractWorkerAsync([EnumeratorCancellation] CancellationToken token)
+        {
+            foreach (var i in new[] { 1, 2, 3 })
+            {
+                await Task.Yield();
+                IncrementCurrentItemCount();
+                yield return i;
+            }
+        }
+    }
+
+
+    private sealed class ConvenienceLoader : LoaderBase<int>
+    {
+        public List<int> Loaded { get; } = new();
+
+        public Report Report() => CreateProgressReport();
+
+        protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
+        {
+            await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+            {
+                Loaded.Add(item);
+                IncrementCurrentItemCount();
+            }
+        }
+    }
+
+
+    private sealed class ConvenienceTransformer : TransformerBase<int, int>
+    {
+        public Report Report() => CreateProgressReport();
+
+        protected override async IAsyncEnumerable<int> TransformWorkerAsync(
+            IAsyncEnumerable<int> items, [EnumeratorCancellation] CancellationToken token)
+        {
+            await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+            {
+                IncrementCurrentItemCount();
+                yield return item * 10;
+            }
+        }
+    }
+
+
+    // Shows a component enriching the default report (proves CreateProgressReport isn't sealed).
+    private sealed class TotalAwareExtractor : ExtractorBase<int>
+    {
+        private readonly int _total;
+
+        public TotalAwareExtractor(int total) => _total = total;
+
+        public Report Report() => CreateProgressReport();
+
+        protected override Report CreateProgressReport() => new(CurrentItemCount, StartedAt, Elapsed, _total);
+
+        protected override async IAsyncEnumerable<int> ExtractWorkerAsync([EnumeratorCancellation] CancellationToken token)
+        {
+            await Task.Yield();
+            IncrementCurrentItemCount();
+            yield return 1;
+        }
+    }
+}


### PR DESCRIPTION
Closes #344 (Part A). The lighter-weight alternative to the #96 source generator.

## What
Three convenience base classes that fix the progress type to the built-in `Report` and default `CreateProgressReport()`:

```csharp
public abstract class ExtractorBase<TSource> : ExtractorBase<TSource, Report>
    where TSource : notnull
{
    protected override Report CreateProgressReport() => new(CurrentItemCount, StartedAt, Elapsed);
}
// + LoaderBase<TDestination> and TransformerBase<TSource, TDestination>
```

A component that's happy with the standard `Report` now implements **only its worker method** — no progress record, no `CreateProgressReport` override:

```csharp
public class CsvExtractor : ExtractorBase<CsvRow>   // one type param
{
    protected override async IAsyncEnumerable<CsvRow> ExtractWorkerAsync(...) { ... }
}
```

- `CreateProgressReport` is **not sealed** — a component can still override it to enrich the report (e.g. a known `TotalItemCount`).
- The existing two/three-type-parameter bases are **unchanged**. Purely additive.

## Why (vs #96)
Eliminates the progress-record + `CreateProgressReport` boilerplate with plain OO — no new package, no Roslyn generator, no analyzer/contract-sync upkeep; discoverable in IntelliSense. See #344 / #96.

**Part B** (lifting the timer-injection `_progressTimerWired` guard into the base) is tracked in #344 as a follow-up — it needs a small API-design decision on the test seam.

## Verification
- **456 tests** (4 new `ConvenienceBaseTests`), **100% mutation** (0 survivors), all **11 TFMs** clean.
- PublicAPI.Unshipped updated (RS0016 completeness + RS0017 correctness validated). Additive vs 0.20.0 baseline.

Targets `vNext` (next MINOR). Version bump + release-prep deferred to release time.
