### PR TITLE
Make ErrorPolicy a settable property (not init-only)

### DIFF
--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -479,12 +479,12 @@ public abstract class ExtractorBase<TSource, TProgress>
     private static readonly Func<ItemErrorContext, ItemErrorAction> AbortPolicy =
         static _ => ItemErrorAction.Abort;
 
-    private readonly Func<ItemErrorContext, ItemErrorAction> _errorPolicy = AbortPolicy;
+    private Func<ItemErrorContext, ItemErrorAction> _errorPolicy = AbortPolicy;
 
 
 
     /// <summary>
-    /// Gets the policy invoked when an item fails to process. Return <see cref="ItemErrorAction.Skip"/>
+    /// Gets or sets the policy invoked when an item fails to process. Return <see cref="ItemErrorAction.Skip"/>
     /// to discard the item and continue, or <see cref="ItemErrorAction.Abort"/> to re-throw and stop
     /// the run. Defaults to fail-fast: every failed item aborts the run until a policy is assigned.
     /// Ready-made policies are provided by <c>Wolfgang.Etl.ErrorPolicies.ItemErrorPolicy</c>.
@@ -493,7 +493,7 @@ public abstract class ExtractorBase<TSource, TProgress>
     public Func<ItemErrorContext, ItemErrorAction> ErrorPolicy
     {
         get => _errorPolicy;
-        init => _errorPolicy = value ?? throw new ArgumentNullException(nameof(value));
+        set => _errorPolicy = value ?? throw new ArgumentNullException(nameof(value));
     }
 
 

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -477,12 +477,12 @@ public abstract class LoaderBase<TDestination, TProgress>
     private static readonly Func<ItemErrorContext, ItemErrorAction> AbortPolicy =
         static _ => ItemErrorAction.Abort;
 
-    private readonly Func<ItemErrorContext, ItemErrorAction> _errorPolicy = AbortPolicy;
+    private Func<ItemErrorContext, ItemErrorAction> _errorPolicy = AbortPolicy;
 
 
 
     /// <summary>
-    /// Gets the policy invoked when an item fails to process. Return <see cref="ItemErrorAction.Skip"/>
+    /// Gets or sets the policy invoked when an item fails to process. Return <see cref="ItemErrorAction.Skip"/>
     /// to discard the item and continue, or <see cref="ItemErrorAction.Abort"/> to re-throw and stop
     /// the run. Defaults to fail-fast: every failed item aborts the run until a policy is assigned.
     /// Ready-made policies are provided by <c>Wolfgang.Etl.ErrorPolicies.ItemErrorPolicy</c>.
@@ -491,7 +491,7 @@ public abstract class LoaderBase<TDestination, TProgress>
     public Func<ItemErrorContext, ItemErrorAction> ErrorPolicy
     {
         get => _errorPolicy;
-        init => _errorPolicy = value ?? throw new ArgumentNullException(nameof(value));
+        set => _errorPolicy = value ?? throw new ArgumentNullException(nameof(value));
     }
 
 

--- a/src/Wolfgang.Etl.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.Abstractions/PublicAPI.Shipped.txt
@@ -19,7 +19,7 @@ Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.CurrentSkippedItemCo
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.Dispose() -> void
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.Elapsed.get -> System.TimeSpan
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.ErrorPolicy.get -> System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>!
-Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.ErrorPolicy.init -> void
+Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.ErrorPolicy.set -> void
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.ExtractorBase() -> void
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.HandleItemError(Wolfgang.Etl.Abstractions.ItemErrorContext! context) -> Wolfgang.Etl.Abstractions.ItemErrorAction
 Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.IncrementCurrentItemCount() -> void
@@ -122,7 +122,7 @@ Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.CurrentSkippedItem
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.Dispose() -> void
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.Elapsed.get -> System.TimeSpan
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.ErrorPolicy.get -> System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>!
-Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.ErrorPolicy.init -> void
+Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.ErrorPolicy.set -> void
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.HandleItemError(Wolfgang.Etl.Abstractions.ItemErrorContext! context) -> Wolfgang.Etl.Abstractions.ItemErrorAction
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.IncrementCurrentItemCount() -> void
 Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.IncrementCurrentSkippedItemCount() -> void
@@ -164,7 +164,7 @@ Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.Curr
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.Dispose() -> void
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.Elapsed.get -> System.TimeSpan
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.ErrorPolicy.get -> System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>!
-Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.ErrorPolicy.init -> void
+Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.ErrorPolicy.set -> void
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.HandleItemError(Wolfgang.Etl.Abstractions.ItemErrorContext! context) -> Wolfgang.Etl.Abstractions.ItemErrorAction
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.IncrementCurrentItemCount() -> void
 Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.IncrementCurrentSkippedItemCount() -> void

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -488,12 +488,12 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
     private static readonly Func<ItemErrorContext, ItemErrorAction> AbortPolicy =
         static _ => ItemErrorAction.Abort;
 
-    private readonly Func<ItemErrorContext, ItemErrorAction> _errorPolicy = AbortPolicy;
+    private Func<ItemErrorContext, ItemErrorAction> _errorPolicy = AbortPolicy;
 
 
 
     /// <summary>
-    /// Gets the policy invoked when an item fails to process. Return <see cref="ItemErrorAction.Skip"/>
+    /// Gets or sets the policy invoked when an item fails to process. Return <see cref="ItemErrorAction.Skip"/>
     /// to discard the item and continue, or <see cref="ItemErrorAction.Abort"/> to re-throw and stop
     /// the run. Defaults to fail-fast: every failed item aborts the run until a policy is assigned.
     /// Ready-made policies are provided by <c>Wolfgang.Etl.ErrorPolicies.ItemErrorPolicy</c>.
@@ -502,7 +502,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
     public Func<ItemErrorContext, ItemErrorAction> ErrorPolicy
     {
         get => _errorPolicy;
-        init => _errorPolicy = value ?? throw new ArgumentNullException(nameof(value));
+        set => _errorPolicy = value ?? throw new ArgumentNullException(nameof(value));
     }
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ItemErrorHandlingTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ItemErrorHandlingTests.cs
@@ -408,6 +408,21 @@ public sealed class ItemErrorHandlingTests
 
 
     [Fact]
+    public void ErrorPolicy_can_be_reassigned_after_construction()
+    {
+        // The stages are reusable across runs, so ErrorPolicy is a settable property (not init-only),
+        // changeable between runs — consistent with the other config properties (MaximumItemCount etc.).
+        var sut = new DefaultPolicyExtractor { ErrorPolicy = _ => ItemErrorAction.Abort };
+
+        sut.ErrorPolicy = _ => ItemErrorAction.Skip;
+        var action = sut.Handle(new ItemErrorContext(1, new Exception()));
+
+        Assert.Equal(ItemErrorAction.Skip, action);
+        Assert.Equal(1, sut.CurrentErrorItemCount);
+    }
+
+
+    [Fact]
     public void Loader_ErrorPolicy_when_assigned_is_used_by_the_base_OnItemError()
     {
         var sut = new DefaultPolicyLoader { ErrorPolicy = _ => ItemErrorAction.Skip };


### PR DESCRIPTION
## Make `ErrorPolicy` a full setter (addresses Copilot on #349)

Copilot flagged (3×) that `ErrorPolicy` on the base stages is **`init`-only**, which:
- can't be changed between runs on a **reused** stage instance (the bases explicitly support multiple runs via `ResetRunState`), and
- is inconsistent with every sibling config property — `ReportingInterval`, `MaximumItemCount`, `SkipItemCount` are all `{ get; set; }` — and with the "settable/assignable" wording in the docs/CHANGELOG.

### Change
- `init` → `set` on `ExtractorBase` / `LoaderBase` / `TransformerBase` (backing field no longer `readonly`; the null-guard is unchanged).
- `PublicAPI.Shipped.txt`: three `.ErrorPolicy.init -> void` → `.ErrorPolicy.set -> void`.
- Doc: "Gets" → "Gets or sets".
- New test: `ErrorPolicy_can_be_reassigned_after_construction` locks the between-runs contract. Abstractions suite **464 green**.

### Why now (pre-release)
This lands **before 0.21.0 ships**. Doing `init`→`set` *after* release would be a **binary-breaking** setter-modreq change (`IsExternalInit` dropped) that PackageValidation would block. Fixing it now keeps 0.21.0's `ErrorPolicy` a plain settable property from day one.

Targets `vNext`, so release **[#349](https://github.com/Chris-Wolfgang/ETL-Abstractions/pull/349)** carries it to `main`.
