### PR TITLE
Add assignable WorkerResilience property to base stages (#348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Assignable `WorkerResilience` on the base stages (#348):** `ExtractorBase`, `LoaderBase`, and
+  `TransformerBase` gained an `init`-only `WorkerResilience` wrapper (`Func<workerFactory, token, result>`,
+  non-null, default no-op passthrough) that the default `WrapWorkerExecution` consults — so a stage can
+  run its worker through a retry / circuit-breaker / timeout strategy by **assignment** (e.g. from a
+  ready-made `Wolfgang.Etl.*` resilience package) instead of subclassing, mirroring the assignable
+  `ErrorPolicy`. Overriding `WrapWorkerExecution` still works and takes precedence. Stream-level scope
+  (a retry re-runs the whole worker); per-item retry belongs inside the worker. Additive — default
+  behaviour unchanged. Unblocks the Polly package (#332).
+
 ### Changed
 
 ### Deprecated

--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -420,7 +420,7 @@ public abstract class ExtractorBase<TSource, TProgress>
 
 
 
-    private Func<Func<CancellationToken, IAsyncEnumerable<TSource>>, CancellationToken, IAsyncEnumerable<TSource>> _workerResilience =
+    private readonly Func<Func<CancellationToken, IAsyncEnumerable<TSource>>, CancellationToken, IAsyncEnumerable<TSource>> _workerResilience =
         static (workerFactory, token) => workerFactory(token);
 
 

--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -415,7 +415,37 @@ public abstract class ExtractorBase<TSource, TProgress>
             throw new ArgumentNullException(nameof(workerFactory));
         }
 
-        return workerFactory(token);
+        return WorkerResilience(workerFactory, token);
+    }
+
+
+
+    private Func<Func<CancellationToken, IAsyncEnumerable<TSource>>, CancellationToken, IAsyncEnumerable<TSource>> _workerResilience =
+        static (workerFactory, token) => workerFactory(token);
+
+
+
+    /// <summary>
+    /// Gets a resilience wrapper applied around the worker's execution — for example a retry /
+    /// circuit-breaker / timeout strategy. The default is a no-op passthrough (the worker runs once), so
+    /// behaviour is unchanged until a wrapper is assigned. Assign one — e.g. from a ready-made
+    /// <c>Wolfgang.Etl.*</c> resilience package — to run the worker through a resilience pipeline without
+    /// subclassing; the default <see cref="WrapWorkerExecution"/> consults it. The wrapper receives a
+    /// re-invocable worker factory (call it again to retry) and the run's <see cref="CancellationToken"/>,
+    /// and returns the (possibly resilience-wrapped) item stream.
+    /// </summary>
+    /// <remarks>
+    /// Assigned once, at construction (init-only); it cannot change during a run. This is
+    /// <b>stream-level</b> resilience: the wrapper spans the whole worker, so a retry re-runs the entire
+    /// extraction — per-item transient-fault retry belongs inside the worker. Overriding
+    /// <see cref="WrapWorkerExecution"/> is still available for stage-internal logic and takes precedence
+    /// over this property unless the override calls <c>base</c>.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The assigned value is <see langword="null"/>.</exception>
+    public Func<Func<CancellationToken, IAsyncEnumerable<TSource>>, CancellationToken, IAsyncEnumerable<TSource>> WorkerResilience
+    {
+        get => _workerResilience;
+        init => _workerResilience = value ?? throw new ArgumentNullException(nameof(value));
     }
 
 

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -413,7 +413,37 @@ public abstract class LoaderBase<TDestination, TProgress>
             throw new ArgumentNullException(nameof(workerFactory));
         }
 
-        return workerFactory(token);
+        return WorkerResilience(workerFactory, token);
+    }
+
+
+
+    private Func<Func<CancellationToken, Task>, CancellationToken, Task> _workerResilience =
+        static (workerFactory, token) => workerFactory(token);
+
+
+
+    /// <summary>
+    /// Gets a resilience wrapper applied around the worker's execution — for example a retry /
+    /// circuit-breaker / timeout strategy. The default is a no-op passthrough (the worker runs once), so
+    /// behaviour is unchanged until a wrapper is assigned. Assign one — e.g. from a ready-made
+    /// <c>Wolfgang.Etl.*</c> resilience package — to run the worker through a resilience pipeline without
+    /// subclassing; the default <see cref="WrapWorkerExecution"/> consults it. The wrapper receives a
+    /// re-invocable worker factory (call it again to retry) and the run's <see cref="CancellationToken"/>,
+    /// and returns the (possibly resilience-wrapped) load task.
+    /// </summary>
+    /// <remarks>
+    /// Assigned once, at construction (init-only); it cannot change during a run. This is
+    /// <b>stream-level</b> resilience: the wrapper spans the whole worker, so a retry re-runs the entire
+    /// load — per-item transient-fault retry belongs inside the worker. Overriding
+    /// <see cref="WrapWorkerExecution"/> is still available for stage-internal logic and takes precedence
+    /// over this property unless the override calls <c>base</c>.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The assigned value is <see langword="null"/>.</exception>
+    public Func<Func<CancellationToken, Task>, CancellationToken, Task> WorkerResilience
+    {
+        get => _workerResilience;
+        init => _workerResilience = value ?? throw new ArgumentNullException(nameof(value));
     }
 
 

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -418,7 +418,7 @@ public abstract class LoaderBase<TDestination, TProgress>
 
 
 
-    private Func<Func<CancellationToken, Task>, CancellationToken, Task> _workerResilience =
+    private readonly Func<Func<CancellationToken, Task>, CancellationToken, Task> _workerResilience =
         static (workerFactory, token) => workerFactory(token);
 
 

--- a/src/Wolfgang.Etl.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.WorkerResilience.get -> System.Func<System.Func<System.Threading.CancellationToken, System.Collections.Generic.IAsyncEnumerable<TSource>!>!, System.Threading.CancellationToken, System.Collections.Generic.IAsyncEnumerable<TSource>!>!
+Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>.WorkerResilience.init -> void
+Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.WorkerResilience.get -> System.Func<System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>!
+Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>.WorkerResilience.init -> void
+Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.WorkerResilience.get -> System.Func<System.Func<System.Threading.CancellationToken, System.Collections.Generic.IAsyncEnumerable<TDestination>!>!, System.Threading.CancellationToken, System.Collections.Generic.IAsyncEnumerable<TDestination>!>!
+Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>.WorkerResilience.init -> void

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -423,7 +423,37 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
             throw new ArgumentNullException(nameof(workerFactory));
         }
 
-        return workerFactory(token);
+        return WorkerResilience(workerFactory, token);
+    }
+
+
+
+    private Func<Func<CancellationToken, IAsyncEnumerable<TDestination>>, CancellationToken, IAsyncEnumerable<TDestination>> _workerResilience =
+        static (workerFactory, token) => workerFactory(token);
+
+
+
+    /// <summary>
+    /// Gets a resilience wrapper applied around the worker's execution — for example a retry /
+    /// circuit-breaker / timeout strategy. The default is a no-op passthrough (the worker runs once), so
+    /// behaviour is unchanged until a wrapper is assigned. Assign one — e.g. from a ready-made
+    /// <c>Wolfgang.Etl.*</c> resilience package — to run the worker through a resilience pipeline without
+    /// subclassing; the default <see cref="WrapWorkerExecution"/> consults it. The wrapper receives a
+    /// re-invocable worker factory (call it again to retry) and the run's <see cref="CancellationToken"/>,
+    /// and returns the (possibly resilience-wrapped) item stream.
+    /// </summary>
+    /// <remarks>
+    /// Assigned once, at construction (init-only); it cannot change during a run. This is
+    /// <b>stream-level</b> resilience: the wrapper spans the whole worker, so a retry re-runs the entire
+    /// transformation — per-item transient-fault retry belongs inside the worker. Overriding
+    /// <see cref="WrapWorkerExecution"/> is still available for stage-internal logic and takes precedence
+    /// over this property unless the override calls <c>base</c>.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The assigned value is <see langword="null"/>.</exception>
+    public Func<Func<CancellationToken, IAsyncEnumerable<TDestination>>, CancellationToken, IAsyncEnumerable<TDestination>> WorkerResilience
+    {
+        get => _workerResilience;
+        init => _workerResilience = value ?? throw new ArgumentNullException(nameof(value));
     }
 
 

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -428,7 +428,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
 
 
 
-    private Func<Func<CancellationToken, IAsyncEnumerable<TDestination>>, CancellationToken, IAsyncEnumerable<TDestination>> _workerResilience =
+    private readonly Func<Func<CancellationToken, IAsyncEnumerable<TDestination>>, CancellationToken, IAsyncEnumerable<TDestination>> _workerResilience =
         static (workerFactory, token) => workerFactory(token);
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/WorkerResilienceTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/WorkerResilienceTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
+
+/// <summary>
+/// Covers the #348 <c>WorkerResilience</c> seam on the three base stages: the default is a no-op
+/// passthrough, an assigned wrapper is consulted by the base <c>WrapWorkerExecution</c>, the wrapper
+/// receives a re-invocable worker factory (the retry primitive), and a null assignment throws.
+/// </summary>
+public class WorkerResilienceTests
+{
+    // ---------- Extractor ----------
+
+    [Fact]
+    public async Task Extractor_default_WorkerResilience_is_a_passthrough_Async()
+    {
+        var sut = new CountingExtractor();
+
+        var items = await Drain(sut.ExtractAsync(CancellationToken.None));
+
+        Assert.Equal(new[] { 1, 2, 3 }, items);
+        Assert.Equal(1, sut.WorkerInvocations);       // worker ran exactly once
+    }
+
+
+    [Fact]
+    public async Task Extractor_assigned_WorkerResilience_wraps_the_worker_Async()
+    {
+        var wrapped = false;
+        var sut = new CountingExtractor
+        {
+            WorkerResilience = (factory, token) =>
+            {
+                wrapped = true;
+                return factory(token);
+            },
+        };
+
+        await Drain(sut.ExtractAsync(CancellationToken.None));
+
+        Assert.True(wrapped);
+    }
+
+
+    [Fact]
+    public async Task Extractor_WorkerResilience_receives_a_reinvocable_factory_Async()
+    {
+        Func<CancellationToken, IAsyncEnumerable<int>>? captured = null;
+        var sut = new CountingExtractor
+        {
+            WorkerResilience = (factory, token) =>
+            {
+                captured = factory;
+                return factory(token);
+            },
+        };
+
+        await Drain(sut.ExtractAsync(CancellationToken.None));
+        var again = await Drain(captured!(CancellationToken.None));   // re-invoke -> a fresh stream (the retry primitive)
+
+        Assert.Equal(new[] { 1, 2, 3 }, again);
+        Assert.Equal(2, sut.WorkerInvocations);
+    }
+
+
+    [Fact]
+    public void Extractor_WorkerResilience_assigned_null_throws()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new CountingExtractor { WorkerResilience = null! });
+        Assert.Equal("value", ex.ParamName);
+    }
+
+
+    // ---------- Loader ----------
+
+    [Fact]
+    public async Task Loader_assigned_WorkerResilience_wraps_the_worker_Async()
+    {
+        var wrapped = false;
+        var sut = new CountingLoader
+        {
+            WorkerResilience = (factory, token) =>
+            {
+                wrapped = true;
+                return factory(token);
+            },
+        };
+
+        await sut.LoadAsync(AsyncSource(1, 2, 3), CancellationToken.None);
+
+        Assert.True(wrapped);
+        Assert.Equal(new[] { 1, 2, 3 }, sut.Loaded);
+    }
+
+
+    [Fact]
+    public void Loader_WorkerResilience_assigned_null_throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CountingLoader { WorkerResilience = null! });
+    }
+
+
+    // ---------- Transformer ----------
+
+    [Fact]
+    public async Task Transformer_assigned_WorkerResilience_wraps_the_worker_Async()
+    {
+        var wrapped = false;
+        var sut = new CountingTransformer
+        {
+            WorkerResilience = (factory, token) =>
+            {
+                wrapped = true;
+                return factory(token);
+            },
+        };
+
+        var items = await Drain(sut.TransformAsync(AsyncSource(1, 2, 3), CancellationToken.None));
+
+        Assert.True(wrapped);
+        Assert.Equal(new[] { 10, 20, 30 }, items);
+    }
+
+
+    [Fact]
+    public void Transformer_WorkerResilience_assigned_null_throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CountingTransformer { WorkerResilience = null! });
+    }
+
+
+    // ---------- helpers / doubles ----------
+
+    private static async IAsyncEnumerable<int> AsyncSource(params int[] items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Yield();
+            yield return item;
+        }
+    }
+
+
+    private static async Task<List<int>> Drain(IAsyncEnumerable<int> source)
+    {
+        var result = new List<int>();
+        await foreach (var item in source.ConfigureAwait(false))
+        {
+            result.Add(item);
+        }
+
+        return result;
+    }
+
+
+    private sealed class CountingExtractor : ExtractorBase<int>
+    {
+        public int WorkerInvocations { get; private set; }
+
+        protected override async IAsyncEnumerable<int> ExtractWorkerAsync([EnumeratorCancellation] CancellationToken token)
+        {
+            WorkerInvocations++;
+            foreach (var i in new[] { 1, 2, 3 })
+            {
+                await Task.Yield();
+                IncrementCurrentItemCount();
+                yield return i;
+            }
+        }
+    }
+
+
+    private sealed class CountingLoader : LoaderBase<int>
+    {
+        public List<int> Loaded { get; } = new();
+
+        protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
+        {
+            await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+            {
+                Loaded.Add(item);
+                IncrementCurrentItemCount();
+            }
+        }
+    }
+
+
+    private sealed class CountingTransformer : TransformerBase<int, int>
+    {
+        protected override async IAsyncEnumerable<int> TransformWorkerAsync(
+            IAsyncEnumerable<int> items, [EnumeratorCancellation] CancellationToken token)
+        {
+            await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+            {
+                IncrementCurrentItemCount();
+                yield return item * 10;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #348.

Gives the `WrapWorkerExecution` retry seam (#94) an assignable-property twin, mirroring how `ErrorPolicy` relates to `OnItemError` — so resilience plugs in by **assignment**, not subclassing.

- `WorkerResilience` on all three bases, correct per-stage delegate type (`IAsyncEnumerable<TSource>` / `Task` / `IAsyncEnumerable<TDestination>`), non-null, **init-only** (consistent with the immutable-config direction, #351), default no-op passthrough.
- Default `WrapWorkerExecution` delegates to it; overriding `WrapWorkerExecution` still works and takes precedence.
- Stream-level scope documented (retry re-runs the whole worker; per-item retry stays in the worker).
- Additive — default behaviour unchanged. **Unblocks #332** (Polly package ships as assign-a-`Func`).
- +8 tests; Abstractions suite **471 green**; PublicAPI + CHANGELOG updated.

Base of a stack: #351 (config init-only) stacks on top.