### PR TITLE
Bump Abstractions test TestKit refs to 0.14.0 (pay down drift)

### DIFF
--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ExtractorBaseTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ExtractorBaseTests.cs
@@ -75,8 +75,8 @@ public class SequenceExtractor : ExtractorBase<int, EtlProgress>
 
             if (i > SkipItemCount)
             {
-                yield return i;
                 IncrementCurrentItemCount();
+                yield return i;
 
                 if (CurrentItemCount >= MaximumItemCount)
                 {

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/LoaderBaseTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/LoaderBaseTests.cs
@@ -69,6 +69,8 @@ public class ListLoader : LoaderBase<string, EtlProgress>
         var skipped = 0;
         var loaded = 0;
 
+        token.ThrowIfCancellationRequested();
+
         await foreach (var item in items.WithCancellation(token))
         {
             token.ThrowIfCancellationRequested();

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TransformerBaseTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TransformerBaseTests.cs
@@ -92,6 +92,8 @@ public class IdentityTransformer : TransformerBase<string, string, EtlProgress>
         var skipped = 0;
         var transformed = 0;
 
+        token.ThrowIfCancellationRequested();
+
         await foreach (var item in items.WithCancellation(token))
         {
             token.ThrowIfCancellationRequested();
@@ -103,9 +105,9 @@ public class IdentityTransformer : TransformerBase<string, string, EtlProgress>
                 continue;
             }
 
-            yield return item;
             IncrementCurrentItemCount();
             transformed++;
+            yield return item;
 
             if (transformed >= MaximumItemCount)
             {

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Wolfgang.Etl.Abstractions.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Wolfgang.Etl.Abstractions.Tests.Unit.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net481'">
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
@@ -39,7 +39,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
@@ -57,7 +57,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
@@ -75,7 +75,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
@@ -93,7 +93,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.2" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.6" />
   </ItemGroup>
 
   <!-- net5.0; net6.0; net7.0; net8.0; net9.0; net10.0 (coverlet) -->
@@ -104,9 +104,9 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.5" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.6.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.5.0" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.14.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.14.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The Abstractions test project pinned **TestKit.Xunit 0.5.0 / TestKit 0.6.0** while current is **0.14** — ~9 versions of drift. Bumps both to 0.14.0.

- **Transitive cascade:** direct pins bumped to clear NU1605 (Microsoft.Bcl.Memory 10.0.10, System.Linq.Async 7.0.1, System.Linq.AsyncEnumerable 10.0.6).
- **Contract catch-up (the drift the old pin hid):** the newer contract base added stricter tests the old doubles didn't satisfy —
  - increment `CurrentItemCount` **before** `yield` (tracks each yielded item), and
  - guard the token **before** the read loop (a pre-cancelled token reads nothing).
- Full suite **488 green**.

Keeps Abstractions' contract base current so future bumps are one-version, not another 10-version catch-up. Independent of the config-init work — clean maintenance on its own.