### PR TITLE
Centralize package version in Directory.Build.props

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,12 +51,20 @@ jobs:
           }
 
           [xml]$props = Get-Content $propsPath -Raw
-          $version = @($props.SelectNodes('//Version') | ForEach-Object { $_.InnerText.Trim() } | Where-Object { $_ }) | Select-Object -First 1
+          # Scope to PropertyGroup-level <Version> (the package version) — NOT a
+          # <PackageReference><Version> child element — and require exactly one distinct value.
+          $versions = @($props.SelectNodes('/Project/PropertyGroup/Version') | ForEach-Object { $_.InnerText.Trim() } | Where-Object { $_ } | Sort-Object -Unique)
 
-          if (-not $version) {
-            Write-Error "No <Version> found in Directory.Build.props"
+          if ($versions.Count -eq 0) {
+            Write-Error "No <Version> property found in Directory.Build.props"
             exit 1
           }
+          if ($versions.Count -gt 1) {
+            Write-Error "Multiple distinct <Version> values in Directory.Build.props: $($versions -join ', '). There must be exactly one."
+            exit 1
+          }
+
+          $version = $versions[0]
 
           Write-Host "Repository version (Directory.Build.props): $version" -ForegroundColor Cyan
           Write-Host ""

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,45 +42,29 @@ jobs:
           Write-Host "Expected version: $tagVersion" -ForegroundColor Cyan
           Write-Host ""
 
-          $srcCsprojs = @(Get-ChildItem -Path './src' -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue)
-          if ($srcCsprojs.Count -eq 0) {
-            Write-Warning "No src csprojs found - skipping version validation"
-            exit 0
-          }
-
-          # Collect <Version> and <PackageVersion> values from every src csproj
-          $found = @()
-          foreach ($proj in $srcCsprojs) {
-            try {
-              [xml]$xml = Get-Content $proj.FullName -Raw
-              $nodes = $xml.SelectNodes('//Version | //PackageVersion')
-              foreach ($node in $nodes) {
-                $v = $node.InnerText.Trim()
-                if ($v) {
-                  $found += [pscustomobject]@{ Project = $proj.Name; Version = $v }
-                }
-              }
-            } catch {
-              Write-Warning "Failed to parse $($proj.Name): $($_.Exception.Message)"
-            }
-          }
-
-          Write-Host "Versions found in src csprojs:" -ForegroundColor Cyan
-          foreach ($f in $found) {
-            Write-Host "  $($f.Project): $($f.Version)" -ForegroundColor DarkGray
-          }
-          Write-Host ""
-
-          if ($found.Count -eq 0) {
-            Write-Error "No <Version> or <PackageVersion> found in any src csproj"
+          # The four packages are lockstep-versioned; <Version> is the single source of truth in
+          # Directory.Build.props (no per-csproj <Version>). Read it there.
+          $propsPath = './Directory.Build.props'
+          if (-not (Test-Path $propsPath)) {
+            Write-Error "Directory.Build.props not found - cannot resolve the package version"
             exit 1
           }
 
-          if ($found.Version -contains $tagVersion) {
-            Write-Host "Release tag matches at least one src csproj version" -ForegroundColor Green
+          [xml]$props = Get-Content $propsPath -Raw
+          $version = @($props.SelectNodes('//Version') | ForEach-Object { $_.InnerText.Trim() } | Where-Object { $_ }) | Select-Object -First 1
+
+          if (-not $version) {
+            Write-Error "No <Version> found in Directory.Build.props"
+            exit 1
+          }
+
+          Write-Host "Repository version (Directory.Build.props): $version" -ForegroundColor Cyan
+          Write-Host ""
+
+          if ($version -eq $tagVersion) {
+            Write-Host "Release tag matches the repository version" -ForegroundColor Green
           } else {
-            $allVersions = ($found.Version | Sort-Object -Unique) -join ', '
-            Write-Error "Release tag '$tagName' (version '$tagVersion') does not match any src csproj version. Found: $allVersions. Bump the csproj <Version> or correct the release tag before re-running."
+            Write-Error "Release tag '$tagName' (version '$tagVersion') does not match the repository version '$version'. Bump <Version> in Directory.Build.props or correct the release tag before re-running."
             exit 1
           }
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -106,6 +106,9 @@
     <!-- Repo-uniform now that all four packages ship from this repo. RepositoryUrl is intentionally
          NOT set here — SourceLink derives it from the git remote via PublishRepositoryUrl below. -->
     <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Abstractions</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <!-- MIT does not require explicit acceptance; standardized to False for all packages. -->
+    <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <SignAssembly>False</SignAssembly>
     <LangVersion>latest</LangVersion>
     <RepositoryType>git</RepositoryType>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -90,6 +90,10 @@
          (Description, PackageTags, PackageProjectUrl, RepositoryUrl,
          PackageLicenseExpression, PackageReadmeFile) stay in each src
          csproj where they are repo-specific. -->
+    <!-- Single source of truth for the package version. All four packages are lockstep-versioned
+         with the repository; bump this one value per release. (Per-csproj <Version> is intentionally
+         absent so the versions can never drift out of sync.) -->
+    <Version>0.22.0</Version>
     <Authors>Chris Wolfgang</Authors>
     <Company>Chris Wolfgang</Company>
     <Copyright>Copyright (c) Chris Wolfgang</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -94,9 +94,20 @@
          with the repository; bump this one value per release. (Per-csproj <Version> is intentionally
          absent so the versions can never drift out of sync.) -->
     <Version>0.22.0</Version>
+    <!-- AssemblyVersion is pinned to a fixed binding-stability baseline so consumers do not need to
+         recompile / add binding redirects on every minor/patch bump — bump only on a deliberate
+         breaking API change. FileVersion (and the auto-derived InformationalVersion) carry the actual
+         release version. Centralized here so all four packages stay in lockstep. -->
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <Authors>Chris Wolfgang</Authors>
     <Company>Chris Wolfgang</Company>
     <Copyright>Copyright (c) Chris Wolfgang</Copyright>
+    <!-- Repo-uniform now that all four packages ship from this repo. RepositoryUrl is intentionally
+         NOT set here — SourceLink derives it from the git remote via PublishRepositoryUrl below. -->
+    <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Abstractions</PackageProjectUrl>
+    <SignAssembly>False</SignAssembly>
+    <LangVersion>latest</LangVersion>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -1,14 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 	<TargetFrameworks>net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-	<LangVersion>latest</LangVersion>
-	<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
-	     do not need to recompile / add binding redirects on every minor/patch
-	     bump. Bump only on a deliberate breaking API change. FileVersion +
-	     InformationalVersion (the latter auto-derived from <Version>) carry
-	     the actual release version. -->
-	<AssemblyVersion>1.0.0.0</AssemblyVersion>
-	<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <!-- API/ABI compatibility gate (#206). Package Validation compares the packed
          package against the last published version on NuGet and fails the pack if a
          non-major change breaks binary/API compatibility (default-value changes,
@@ -23,15 +15,12 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Contains interfaces and base classes used to build ETL applications</Description>
-    <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Abstractions</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>https://github.com/Chris-Wolfgang/ETL-Abstractions</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <PackageIcon>ETL-Abstractions.png</PackageIcon>
     <ApplicationIcon>ETL-Abstractions.ico</ApplicationIcon>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <SignAssembly>False</SignAssembly>
     <PackageTags>ETL;Extract-Transform-Load;</PackageTags>
   </PropertyGroup>
 

--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -16,8 +16,6 @@
     <Title>$(AssemblyName)</Title>
     <Description>Contains interfaces and base classes used to build ETL applications</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <PackageIcon>ETL-Abstractions.png</PackageIcon>
     <ApplicationIcon>ETL-Abstractions.ico</ApplicationIcon>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
 	<TargetFrameworks>net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
-	<Version>0.22.0</Version>
 	<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 	     do not need to recompile / add binding redirects on every minor/patch
 	     bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
+++ b/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
@@ -4,7 +4,6 @@
 	<LangVersion>latest</LangVersion>
 	<!-- Lockstep with Wolfgang.Etl.Abstractions: this package is built and released from the same
 	     repo under the same version and tag (like Wolfgang.Etl.TestKit + Wolfgang.Etl.TestKit.Xunit). -->
-	<Version>0.22.0</Version>
 	<AssemblyVersion>1.0.0.0</AssemblyVersion>
 	<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <!-- No EnablePackageValidation on the FIRST release: there is no previously-published baseline to

--- a/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
+++ b/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
@@ -9,8 +9,6 @@
     <Title>$(AssemblyName)</Title>
     <Description>Ready-made item-error policies — skip, log, and dead-letter (to a collection or a channel) — assignable to the ErrorPolicy property of Wolfgang.Etl extractors, loaders, and transformers. Built on Wolfgang.Etl.Abstractions.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <PackageIcon>ETL-Abstractions.png</PackageIcon>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <!-- The 10.0.10 logging packages drop net5.0/net7.0 from their tested TFM list; they resolve the

--- a/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
+++ b/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
@@ -1,24 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 	<TargetFrameworks>net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-	<LangVersion>latest</LangVersion>
 	<!-- Lockstep with Wolfgang.Etl.Abstractions: this package is built and released from the same
 	     repo under the same version and tag (like Wolfgang.Etl.TestKit + Wolfgang.Etl.TestKit.Xunit). -->
-	<AssemblyVersion>1.0.0.0</AssemblyVersion>
-	<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <!-- No EnablePackageValidation on the FIRST release: there is no previously-published baseline to
          compare against. Enable it next cycle with PackageValidationBaselineVersion set to 0.21.0. -->
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Ready-made item-error policies — skip, log, and dead-letter (to a collection or a channel) — assignable to the ErrorPolicy property of Wolfgang.Etl extractors, loaders, and transformers. Built on Wolfgang.Etl.Abstractions.</Description>
-    <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Abstractions</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>https://github.com/Chris-Wolfgang/ETL-Abstractions</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <PackageIcon>ETL-Abstractions.png</PackageIcon>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <SignAssembly>False</SignAssembly>
     <!-- The 10.0.10 logging packages drop net5.0/net7.0 from their tested TFM list; they resolve the
          netstandard2.0 asset there and work. Silence the NETSDK TFM-support warnings on those TFMs. -->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -2,15 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
-         do not need to recompile / add binding redirects on every minor/patch
-         bump. Bump only on a deliberate breaking API change. FileVersion +
-         InformationalVersion (the latter auto-derived from <Version>) carry
-         the actual release version. -->
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <!-- PackageValidation (#125): validate ABI compatibility against the previous
          published NuGet version at pack time, so a non-major bump can't ship a
@@ -23,13 +15,9 @@
     <PackageValidationBaselineVersion>0.13.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit.Xunit</Title>
     <Description>Abstract xUnit contract test base classes for verifying custom ETL extractors, transformers, and loaders built on Wolfgang.Etl.Abstractions.</Description>
-    <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Test-Kit</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/Chris-Wolfgang/ETL-Test-Kit</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <SignAssembly>False</SignAssembly>
     <IsTestProject>false</IsTestProject>
     <PackageTags>ETL;Extract-Transform-Load;TestKit;Testing;xUnit;ContractTests</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.22.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -15,8 +15,6 @@
     <PackageValidationBaselineVersion>0.13.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit.Xunit</Title>
     <Description>Abstract xUnit contract test base classes for verifying custom ETL extractors, transformers, and loaders built on Wolfgang.Etl.Abstractions.</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <IsTestProject>false</IsTestProject>
     <PackageTags>ETL;Extract-Transform-Load;TestKit;Testing;xUnit;ContractTests</PackageTags>

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -15,8 +15,6 @@
     <PackageValidationBaselineVersion>0.13.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit</Title>
     <Description>An implementation of Extractor, Transformer and Loader for use in ETL examples and benchmarks. Built on Wolfgang.Etl.Abstractions.</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageTags>ETL;Extract-Transform-Load;TestKit;Testing;Benchmarks</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -2,15 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
-         do not need to recompile / add binding redirects on every minor/patch
-         bump. Bump only on a deliberate breaking API change. FileVersion +
-         InformationalVersion (the latter auto-derived from <Version>) carry
-         the actual release version. -->
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <!-- PackageValidation (#125): validate ABI compatibility against the previous
          published NuGet version at pack time, so a non-major bump can't ship a
@@ -23,13 +15,9 @@
     <PackageValidationBaselineVersion>0.13.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit</Title>
     <Description>An implementation of Extractor, Transformer and Loader for use in ETL examples and benchmarks. Built on Wolfgang.Etl.Abstractions.</Description>
-    <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Test-Kit</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/Chris-Wolfgang/ETL-Test-Kit</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <SignAssembly>False</SignAssembly>
     <PackageTags>ETL;Extract-Transform-Load;TestKit;Testing;Benchmarks</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <ApplicationIcon>..\..\assets\testkit_icon.ico</ApplicationIcon>

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.22.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Fuzz/Wolfgang.Etl.Abstractions.Tests.Fuzz.csproj
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Fuzz/Wolfgang.Etl.Abstractions.Tests.Fuzz.csproj
@@ -7,7 +7,6 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Wolfgang.Etl.Abstractions.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Wolfgang.Etl.Abstractions.Tests.Unit.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-    <Version>0.13.0</Version>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/tests/Wolfgang.Etl.TestKit.Tests.Fuzz/Wolfgang.Etl.TestKit.Tests.Fuzz.csproj
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Fuzz/Wolfgang.Etl.TestKit.Tests.Fuzz.csproj
@@ -7,7 +7,6 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/Wolfgang.Etl.TestKit.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/Wolfgang.Etl.TestKit.Tests.Unit.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net462;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.8.0</Version>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/Wolfgang.Etl.TestKit.Xunit.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/Wolfgang.Etl.TestKit.Xunit.Tests.Unit.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net462;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.8.0</Version>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Centralize the package version

**Stacked on #357 (the fold).** With four lockstep-versioned packages, this makes `<Version>` a single source of truth.

- Define `<Version>` **once** in `Directory.Build.props`; remove the per-csproj `<Version>` from all four packages. They inherit it — versions **can't drift out of sync**, and a release bump is one line.
- **Companion fix (required):** `release.yaml`'s tag-vs-version check parsed *raw csproj XML* for `<Version>`, which no longer exists there → it now reads the single `<Version>` from `Directory.Build.props`.

### Verified
- Full solution build **0/0**; all four packages pack at **0.22.0** via the inherited version; `dotnet msbuild -getProperty:Version` returns `0.22.0` for each.

### Notes
- Pure refactor — **no version-number change** (still 0.22.0). Merges after the fold, so it's 0.23.0-cycle material; the next release bumps the single `Directory.Build.props` value.
- Touches **`release.yaml`** (a protected file) → when this reaches `main` it'll need the admin-bypass / protected-file path, same as other workflow changes.
- Base is `chore/fold-testkit`; GitHub will retarget to `main` once #357 merges.
