### PR TITLE
Use ConfigureAwait(false) on await foreach in ExtractorBase and TransformerBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.22.0] - 2026-08-04
 
-Repository consolidation only — the `Wolfgang.Etl.TestKit` and `Wolfgang.Etl.TestKit.Xunit` packages now
-build and release from this repository. **No public API change** to any of the four packages; a
-release-source move, not a behavioural change.
+Repository consolidation — the `Wolfgang.Etl.TestKit` and `Wolfgang.Etl.TestKit.Xunit` packages now
+build and release from this repository. **No public API change** to any of the four packages. The
+consolidation itself is a release-source move; it ships alongside one behavioural fix, noted below.
+
+### Fixed
+
+- **`await foreach` in `ExtractorBase` and `TransformerBase` now uses `ConfigureAwait(false)`.** Four
+  sites (`ExtractorBase.ExtractAsync` / `ExtractWithProgressAsync`, `TransformerBase.TransformAsync` /
+  `TransformWithProgressAsync`) resumed on the captured synchronization context, a deadlock risk for
+  consumers calling sync-over-async on the `net462` and `netstandard2.0` targets. `CA2007` does not
+  analyse `await foreach`, so this was invisible to the analyzer gate; the rest of the package already
+  used `ConfigureAwait(false)` at every other `await foreach`.
 
 ### Changed
 

--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -323,7 +323,7 @@ public abstract class ExtractorBase<TSource, TProgress>
     {
         ResetRunState();
 
-        await foreach (var item in WrapWorkerExecution(ExtractWorkerAsync, token))
+        await foreach (var item in WrapWorkerExecution(ExtractWorkerAsync, token).ConfigureAwait(false))
         {
             yield return item;
         }
@@ -341,7 +341,7 @@ public abstract class ExtractorBase<TSource, TProgress>
 
         try
         {
-            await foreach (var item in WrapWorkerExecution(ExtractWorkerAsync, token))
+            await foreach (var item in WrapWorkerExecution(ExtractWorkerAsync, token).ConfigureAwait(false))
             {
                 yield return item;
             }

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -331,7 +331,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
     {
         ResetRunState();
 
-        await foreach (var item in WrapWorkerExecution(ct => TransformWorkerAsync(items, ct), token))
+        await foreach (var item in WrapWorkerExecution(ct => TransformWorkerAsync(items, ct), token).ConfigureAwait(false))
         {
             yield return item;
         }
@@ -349,7 +349,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
 
         try
         {
-            await foreach (var item in WrapWorkerExecution(ct => TransformWorkerAsync(items, ct), token))
+            await foreach (var item in WrapWorkerExecution(ct => TransformWorkerAsync(items, ct), token).ConfigureAwait(false))
             {
                 yield return item;
             }


### PR DESCRIPTION
## Use `ConfigureAwait(false)` on `await foreach` in `ExtractorBase` / `TransformerBase`

Stacked on #357. Found during the 0.22.0 code-review pass.

### The defect
Four `await foreach` sites resume on the caller's captured synchronization context:

| Site | |
|---|---|
| `ExtractorBase.ExtractAsync` | `ExtractorBase.cs:326` |
| `ExtractorBase.ExtractWithProgressAsync` | `ExtractorBase.cs:344` |
| `TransformerBase.TransformAsync` | `TransformerBase.cs:334` |
| `TransformerBase.TransformWithProgressAsync` | `TransformerBase.cs:352` |

These packages ship **`net462` and `netstandard2.0`**, where that is a real deadlock risk for any consumer calling sync-over-async. And because these are the two base classes every ETL stage inherits, the exposure is the whole family, not one code path.

### Why CI never caught it
`CA2007` is `warning` for `src` (`.editorconfig:192`) — but **it does not analyse `await foreach` at all**. The analyzer gate is structurally blind here, so this can only be found by reading.

### Why this is a fix, not a style change
The rest of the package already does it — `EtlPipelineImpl.cs:142`, `EtlPipelineSink.cs:59`, `MiddlewareExtensions.cs:56` and `:121`. These four were inconsistent with the package's own established convention, not a deliberate exception.

### CHANGELOG
The 0.22.0 entry asserted the release was *"not a behavioural change"*. That is no longer strictly true, so the entry is amended with a `### Fixed` section rather than left to mislead.

### Verification
Full solution build **0 warnings / 0 errors**; **1085 tests green** on net10.0.
