### PR TITLE
chore: protected-file split for 0.22.0 (release.yaml, coyote.yaml, Directory.Build.props)

### DIFF
--- a/.github/workflows/coyote.yaml
+++ b/.github/workflows/coyote.yaml
@@ -78,7 +78,15 @@ jobs:
           dll="bin/Release/net8.0/Wolfgang.Etl.Abstractions.Tests.Concurrency.dll"
           methods=(
             Concurrent_item_count_increments_never_lose_an_update
-            Dispose_racing_enumeration_never_deadlocks
+            # Dispose_racing_enumeration_never_deadlocks is DISABLED (#364).
+            # Coyote 1.7.11 throws a NullReferenceException inside its own
+            # CoyoteRuntime.IsTaskUncontrolled when it meets the
+            # ConfiguredCancelableAsyncEnumerable awaiter that the ConfigureAwait(false)
+            # fix (#363) introduced in ExtractorBase.ExtractWithResetAsync. It is an
+            # instrumentation crash, not a race we found: "Found 1 bug" on iteration #1,
+            # 1 execution path explored, 0.096 sec. Coyote is dormant (1.7.11 is the
+            # newest on nuget.org; last upstream commit 2024-12-11), so there is no
+            # version to upgrade to. Re-enable via #364.
           )
           for m in "${methods[@]}"; do
             echo "::group::coyote test $m ($iterations iterations)"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,45 +42,37 @@ jobs:
           Write-Host "Expected version: $tagVersion" -ForegroundColor Cyan
           Write-Host ""
 
-          $srcCsprojs = @(Get-ChildItem -Path './src' -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue)
-          if ($srcCsprojs.Count -eq 0) {
-            Write-Warning "No src csprojs found - skipping version validation"
-            exit 0
-          }
-
-          # Collect <Version> and <PackageVersion> values from every src csproj
-          $found = @()
-          foreach ($proj in $srcCsprojs) {
-            try {
-              [xml]$xml = Get-Content $proj.FullName -Raw
-              $nodes = $xml.SelectNodes('//Version | //PackageVersion')
-              foreach ($node in $nodes) {
-                $v = $node.InnerText.Trim()
-                if ($v) {
-                  $found += [pscustomobject]@{ Project = $proj.Name; Version = $v }
-                }
-              }
-            } catch {
-              Write-Warning "Failed to parse $($proj.Name): $($_.Exception.Message)"
-            }
-          }
-
-          Write-Host "Versions found in src csprojs:" -ForegroundColor Cyan
-          foreach ($f in $found) {
-            Write-Host "  $($f.Project): $($f.Version)" -ForegroundColor DarkGray
-          }
-          Write-Host ""
-
-          if ($found.Count -eq 0) {
-            Write-Error "No <Version> or <PackageVersion> found in any src csproj"
+          # The four packages are lockstep-versioned; <Version> is the single source of truth in
+          # Directory.Build.props (no per-csproj <Version>). Read it there.
+          $propsPath = './Directory.Build.props'
+          if (-not (Test-Path $propsPath)) {
+            Write-Error "Directory.Build.props not found - cannot resolve the package version"
             exit 1
           }
 
-          if ($found.Version -contains $tagVersion) {
-            Write-Host "Release tag matches at least one src csproj version" -ForegroundColor Green
+          [xml]$props = Get-Content $propsPath -Raw
+          # Scope to PropertyGroup-level <Version> (the package version) — NOT a
+          # <PackageReference><Version> child element — and require exactly one distinct value.
+          $versions = @($props.SelectNodes('/Project/PropertyGroup/Version') | ForEach-Object { $_.InnerText.Trim() } | Where-Object { $_ } | Sort-Object -Unique)
+
+          if ($versions.Count -eq 0) {
+            Write-Error "No <Version> property found in Directory.Build.props"
+            exit 1
+          }
+          if ($versions.Count -gt 1) {
+            Write-Error "Multiple distinct <Version> values in Directory.Build.props: $($versions -join ', '). There must be exactly one."
+            exit 1
+          }
+
+          $version = $versions[0]
+
+          Write-Host "Repository version (Directory.Build.props): $version" -ForegroundColor Cyan
+          Write-Host ""
+
+          if ($version -eq $tagVersion) {
+            Write-Host "Release tag matches the repository version" -ForegroundColor Green
           } else {
-            $allVersions = ($found.Version | Sort-Object -Unique) -join ', '
-            Write-Error "Release tag '$tagName' (version '$tagVersion') does not match any src csproj version. Found: $allVersions. Bump the csproj <Version> or correct the release tag before re-running."
+            Write-Error "Release tag '$tagName' (version '$tagVersion') does not match the repository version '$version'. Bump <Version> in Directory.Build.props or correct the release tag before re-running."
             exit 1
           }
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -90,9 +90,27 @@
          (Description, PackageTags, PackageProjectUrl, RepositoryUrl,
          PackageLicenseExpression, PackageReadmeFile) stay in each src
          csproj where they are repo-specific. -->
+    <!-- Single source of truth for the package version. All four packages are lockstep-versioned
+         with the repository; bump this one value per release. (Per-csproj <Version> is intentionally
+         absent so the versions can never drift out of sync.) -->
+    <Version>0.22.0</Version>
+    <!-- AssemblyVersion is pinned to a fixed binding-stability baseline so consumers do not need to
+         recompile / add binding redirects on every minor/patch bump — bump only on a deliberate
+         breaking API change. FileVersion (and the auto-derived InformationalVersion) carry the actual
+         release version. Centralized here so all four packages stay in lockstep. -->
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <Authors>Chris Wolfgang</Authors>
     <Company>Chris Wolfgang</Company>
     <Copyright>Copyright (c) Chris Wolfgang</Copyright>
+    <!-- Repo-uniform now that all four packages ship from this repo. RepositoryUrl is intentionally
+         NOT set here — SourceLink derives it from the git remote via PublishRepositoryUrl below. -->
+    <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Abstractions</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <!-- MIT does not require explicit acceptance; standardized to False for all packages. -->
+    <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
+    <SignAssembly>False</SignAssembly>
+    <LangVersion>latest</LangVersion>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Protected-file split for the 0.22.0 TestKit fold (#357), per the `protected-file-pr-split` recipe.

#357 carries 100 files, exactly **three** of which are protected configuration:

| file | why it changed |
| --- | --- |
| `Directory.Build.props` | Version centralization for the fold — `Version` / `AssemblyVersion` / `FileVersion` / `PackageProjectUrl` / `LangVersion` / `SignAssembly` / License moved here and removed from the individual csprojs. |
| `.github/workflows/release.yaml` | Version-check now reads `Directory.Build.props` via the scoped XPath `/Project/PropertyGroup/Version`. Depends on the above — the two are one logical change. |
| `.github/workflows/coyote.yaml` | Excludes `Dispose_racing_enumeration_never_deadlocks`, which crashes Coyote 1.7.11's own instrumentation. See #364. |

Extracting them here lets #357 pass `Detect .NET Projects` on its own rather than admin-bypassing a 100-file PR.

## Verification

- Branch cut from `origin/main`; `git diff origin/main --name-only` lists **only** these three files.
- All three are **byte-identical** to `chore/fold-testkit` (`git diff origin/chore/fold-testkit -- <files>` is empty). This PR introduces no changes of its own — it is purely a lift.
- The protected set was confirmed against the guard's own definition in `pr.yaml` (the `exact_files` array plus the `.globalconfig` / `.ruleset` / `.github/workflows/*.ya?ml` pattern), not from memory.

## Note on the Coyote change

`Dispose_racing_enumeration_never_deadlocks` is excluded, not deleted — the test body and its attribute stay in the source file, and #364 tracks restoring it.

The trigger was PR #363, which added the missing `ConfigureAwait(false)` to the `await foreach` sites in `ExtractorBase` and `TransformerBase`. That is a real fix: those packages ship `net462`/`netstandard2.0`, where a consumer with a sync context can deadlock, and every extract and transform stage inherits those two methods. CA2007 is enabled but structurally blind to `await foreach`, which is why it went unnoticed.

The fix changes the awaiter to `ConfiguredCancelableAsyncEnumerable<T>`, which Coyote 1.7.11 cannot classify — it throws a `NullReferenceException` inside `CoyoteRuntime.IsTaskUncontrolled`. It is an instrumentation crash, not a race: "Found 1 bug" on iteration #1, 1 execution path explored, 0.096 sec. 1.7.11 is the newest release on nuget.org and upstream's last commit was 2024-12-11, so there is no version to upgrade to. Reverting #363 to satisfy a dormant test tool was rejected.

Verified on `chore/fold-testkit` before this split was cut: **`Coyote systematic exploration` now passes**, leaving `Detect .NET Projects` as the only failure on #357.

## This PR expects an admin bypass

It exists solely to move protected files, so it will trip the same guard by design. Merge with admin bypass, then merge `main` back into `chore/fold-testkit`; #357 should then show `failing=[]`.

Note that admin bypass waives **all** ruleset rules, not just the protected-file guard — worth a glance at the other checks before merging.
