### PR TITLE
fix: scope PublicApiAnalyzers to projects with a PublicAPI baseline (clears ~1491 alerts)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -65,14 +65,17 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- A1: PublicApiAnalyzers — track public API surface for breaking-change
-         detection. AdditionalFiles below are opt-in PER PROJECT via Exists():
-         drop PublicAPI.Shipped.txt + PublicAPI.Unshipped.txt into a src
-         project directory and the analyzer activates for that project only.
-         Library projects under src/ should opt in; test / example /
-         benchmark projects should not. Per-repo enablement is tracked as a
-         follow-up maintenance issue. -->
+  <!-- A1: PublicApiAnalyzers — track public API surface for breaking-change
+       detection. Both the analyzer package AND its AdditionalFiles baseline are
+       gated on Exists('PublicAPI.Shipped.txt'), so the analyzer only runs in a
+       project that actually tracks a public-API baseline (the packable src
+       libraries). Without this gate the analyzer loads everywhere but finds no
+       baseline in test / example / benchmark projects, emitting RS0016 / RS0037
+       / RS0036 for every public symbol as (non-error) warnings — invisible in
+       the build but flooding the code-scanning dashboard. Gating the reference
+       is the correct fix: PublicAPI tracking does not apply to non-shipped
+       assemblies. -->
+  <ItemGroup Condition="Exists('PublicAPI.Shipped.txt')">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Stacked PR **1 of N** working through the open Code Scanning alerts. Base: `vNext`.

## What

Gate the `Microsoft.CodeAnalysis.PublicApiAnalyzers` package reference in `Directory.Build.props` on `Exists('PublicAPI.Shipped.txt')` — the same condition already used for its `AdditionalFiles` baseline.

## Why

The analyzer was referenced **unconditionally** (every project) while the baseline was `Exists()`-gated. Test / example / benchmark projects therefore loaded the analyzer with **no `PublicAPI.Shipped.txt`** to compare against, so `RS0016` (symbol missing from declared API), `RS0037` (missing nullability), and `RS0036` fired for **every public symbol** — as non-error warnings, invisible in build output but uploaded to code scanning.

These three rules accounted for **~1491 of the open InspectCode alerts** (`RS0016` ×872, `RS0037` ×440, `RS0036` ×179) — ~72% of the entire 2066-alert backlog.

Per the fix-don't-suppress principle: the code is correct (test assemblies legitimately have public types), the warning is wrong (PublicAPI tracking does not apply to non-shipped assemblies), so the correct fix is to **not run the analyzer where it has no baseline** — not to dismiss the alerts.

## Verification

- `Abstractions.Tests.Unit` (net8.0) now builds with **zero** `RS0016/RS0037/RS0036`.
- The four packable src libraries (`Abstractions`, `ErrorPolicies`, `TestKit`, `TestKit.Xunit`) all carry a root `PublicAPI.Shipped.txt`, so they retain the analyzer via the same gate — public-API breaking-change detection is unchanged there.
- The change is purely subtractive for non-baseline projects (removes an analyzer that produced only warnings), so it cannot break src or test compilation.

## Notes

- `Directory.Build.props` is a protected config file → will need admin bypass to merge.
- Expected effect on the dashboard: InspectCode open alerts drop from 2045 → ~554 once the next InspectCode scan runs on `vNext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
