### PR TITLE
test: remove 184 redundant using directives (full-matrix verified)

### DIFF
--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/AsyncDisposableTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/AsyncDisposableTests.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/BaseClassTimingTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/BaseClassTimingTests.cs
@@ -1,7 +1,4 @@
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ClockSeamTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ClockSeamTests.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
-using Xunit;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ConvenienceBaseTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ConvenienceBaseTests.cs
@@ -1,11 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
-using Xunit;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ResetRunStateTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ResetRunStateTests.cs
@@ -1,7 +1,4 @@
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/RetrySeamTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/RetrySeamTests.cs
@@ -1,12 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
-using Xunit;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/SystemProgressTimerTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/SystemProgressTimerTests.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TimerSeamTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TimerSeamTests.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/WorkerResilienceTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/WorkerResilienceTests.cs
@@ -1,10 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
-using Xunit;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ConfigureAwaitContextTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ConfigureAwaitContextTests.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/DisposedGuardTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/DisposedGuardTests.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/AggregateErrorsTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/AggregateErrorsTests.cs
@@ -1,12 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
-using Xunit;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.EtlPipelineTests;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineSinkExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineSinkExtensionsTests.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.EtlPipelineTests;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
-using Xunit;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.EtlPipelineTests;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/TestDoubles.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/TestDoubles.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.EtlPipelineTests;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/FinalizationSuppressionTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/FinalizationSuppressionTests.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ItemErrorHandlingTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ItemErrorHandlingTests.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/MiddlewareTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/MiddlewareTests.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
-using Xunit;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Performance/AllocationFreeTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Performance/AllocationFreeTests.cs
@@ -2,10 +2,7 @@
 // suite compiles on net48+ / netcoreapp3.1+ / net5.0+ but not net462/net472. The
 // allocation behaviour under test is TFM-agnostic, so the modern targets cover it.
 #if !NET462 && !NET472
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.Performance;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/BareTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/BareTests.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/CancelOnlyTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/CancelOnlyTests.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/DisposeStagesTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/DisposeStagesTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/FullTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/FullTests.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
 using Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/MixedCapabilityTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/MixedCapabilityTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
 using Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/NoProgressPathTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/NoProgressPathTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/NullGuardOnChainedStagesTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/NullGuardOnChainedStagesTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/PipelineBehaviorTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/PipelineBehaviorTests.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/ProgressOnlyTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/ProgressOnlyTests.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
 using Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Extractors.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Extractors.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using Wolfgang.Etl.Abstractions;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Loaders.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Loaders.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Transformers.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Transformers.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using Wolfgang.Etl.Abstractions;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/WrongOverloadCalledException.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/WrongOverloadCalledException.cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/WithProgressSemanticsTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/WithProgressSemanticsTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 using Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
 using Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 

--- a/tests/Wolfgang.Etl.ErrorPolicies.Tests.Unit/ItemErrorPolicyTests.cs
+++ b/tests/Wolfgang.Etl.ErrorPolicies.Tests.Unit/ItemErrorPolicyTests.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.ErrorPolicies;
 
 namespace Wolfgang.Etl.ErrorPolicies.Tests.Unit;
 

--- a/tests/Wolfgang.Etl.TestKit.Tests.Concurrency/ConcurrencyTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Concurrency/ConcurrencyTests.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Coyote;
 using Microsoft.Coyote.SystematicTesting;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Tests.Concurrency;

--- a/tests/Wolfgang.Etl.TestKit.Tests.Fuzz/TestKitFuzzTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Fuzz/TestKitFuzzTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using CsCheck;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Tests.Fuzz;

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/Globalization/CultureInvarianceTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/Globalization/CultureInvarianceTests.cs
@@ -1,9 +1,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Tests.Unit.Globalization;

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualProgressTimerCoreTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualProgressTimerCoreTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualTimeSourceTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualTimeSourceTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/ProgressTimerExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/ProgressTimerExtensionsTests.cs
@@ -1,6 +1,5 @@
 using System;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/RecordingMiddlewareTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/RecordingMiddlewareTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/RetryingExtractorBranchesTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/RetryingExtractorBranchesTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/RetryingExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/RetryingExtractorTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/SnapshotTestLoaderTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/SnapshotTestLoaderTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TimeSourceExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TimeSourceExtensionsTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/DelayingExtractorCancellationContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/DelayingExtractorCancellationContractTests.cs
@@ -2,8 +2,6 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Wolfgang.Etl.TestKit;
-using Wolfgang.Etl.TestKit.Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
 

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlPipelineErrorAggregationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlPipelineErrorAggregationTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlPipelineProgressTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlPipelineProgressTests.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlScenarioTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlScenarioTests.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Wolfgang.Etl.TestKit;
-using Wolfgang.Etl.TestKit.Xunit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/FaultyExtractorErrorHandlingContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/FaultyExtractorErrorHandlingContractTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/FaultyLoaderErrorHandlingContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/FaultyLoaderErrorHandlingContractTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/FaultyTransformerErrorHandlingContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/FaultyTransformerErrorHandlingContractTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ManualProgressTimerTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ManualProgressTimerTests.cs
@@ -1,5 +1,4 @@
 using System;
-using Wolfgang.Etl.TestKit.Xunit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressAssertTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressAssertTests.cs
@@ -2,8 +2,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.TestKit;
-using Wolfgang.Etl.TestKit.Xunit;
 using Xunit;
 using Xunit.Sdk;
 

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressCaptureTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressCaptureTests.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using Wolfgang.Etl.TestKit.Xunit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/RetryingExtractorRetryContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/RetryingExtractorRetryContractTests.cs
@@ -2,8 +2,6 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Wolfgang.Etl.TestKit;
-using Wolfgang.Etl.TestKit.Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
 

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/SynchronousProgressTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/SynchronousProgressTests.cs
@@ -1,5 +1,4 @@
 using System;
-using Wolfgang.Etl.TestKit.Xunit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestLoaderPipelineContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestLoaderPipelineContractTests.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.TestKit;
-using Wolfgang.Etl.TestKit.Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
 


### PR DESCRIPTION
Stacked PR **3** on the Code Scanning cleanup. Base: `fix/inspectcode-abstractions-redundancies` (PR #371).

## What
Removes **184 genuinely-redundant `using` directives** across **59 test/example files** (`RedundantUsingDirective`).

## How it was done safely
The code-scanning alert line numbers were **stale** (predate current vNext) — a first attempt using them removed *used* `using`s where files had shifted. So instead:

1. **Fresh `jb inspectcode`** on current vNext → accurate line numbers (189 findings in test/example).
2. Precise line removal, each line **re-verified as a `using X;`** before deletion; BOM preserved.
3. **Full-matrix `dotnet build`** across all TFMs (net462 … net10.0) — required because a `using` redundant on one TFM can be needed on another, and vNext PRs skip the CI test matrix.

## One false positive excluded
`AllocationRegressionTests.cs` was **reverted**: its `using`s are redundant on net462 (the test body is `#if NET6_0_OR_GREATER`-gated, so the netfx view sees them unused) but **required on net6+**. That's 5 findings correctly left in place.

## Verification
- Diff is **using-only**: 0 additions, 184 deletions, every removed line a `using` directive.
- Full solution builds **green on all TFMs**. No behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
