### PR TITLE
fix: correctness rules — xUnit1030 (drop ConfigureAwait in tests) + S4456 eager validation

### DIFF
--- a/src/Wolfgang.Etl.TestKit/RetryingExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/RetryingExtractor.cs
@@ -152,10 +152,10 @@ public class RetryingExtractor<T> : ExtractorBase<T, Report>
     /// <param name="token">A token to observe.</param>
     /// <returns>The retried stream of extracted items.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="workerFactory"/> is <see langword="null"/>.</exception>
-    protected override async IAsyncEnumerable<T> WrapWorkerExecution
+    protected override IAsyncEnumerable<T> WrapWorkerExecution
     (
         Func<CancellationToken, IAsyncEnumerable<T>> workerFactory,
-        [EnumeratorCancellation] CancellationToken token
+        CancellationToken token
     )
     {
         if (workerFactory is null)
@@ -163,6 +163,19 @@ public class RetryingExtractor<T> : ExtractorBase<T, Report>
             throw new ArgumentNullException(nameof(workerFactory));
         }
 
+        // Split so the null check runs eagerly at call time rather than being
+        // deferred to the first MoveNextAsync of the iterator (S4456).
+        return WrapWorkerExecutionCore(workerFactory, token);
+    }
+
+
+
+    private async IAsyncEnumerable<T> WrapWorkerExecutionCore
+    (
+        Func<CancellationToken, IAsyncEnumerable<T>> workerFactory,
+        [EnumeratorCancellation] CancellationToken token
+    )
+    {
         for (var attempt = 1; ; attempt++)
         {
             var buffer  = new List<T>();

--- a/tests/Wolfgang.Etl.TestKit.Tests.DocExamples/DocExampleCompilationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.DocExamples/DocExampleCompilationTests.cs
@@ -103,7 +103,7 @@ public sealed class DocExampleCompilationTests
                 continue;
             }
 
-            var source = await File.ReadAllTextAsync(file).ConfigureAwait(false);
+            var source = await File.ReadAllTextAsync(file);
 
             foreach (var (line, code) in ExtractExampleCode(source))
             {

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
@@ -54,7 +54,7 @@ public class DelayingExtractorTests
     {
         var sut = new DelayingExtractor<int>(new[] { 1, 2, 3 }, TimeSpan.Zero);
 
-        var actual = await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        var actual = await sut.ExtractAsync(CancellationToken.None).ToListAsync();
 
         Assert.Equal(new[] { 1, 2, 3 }, actual);
     }
@@ -66,7 +66,7 @@ public class DelayingExtractorTests
     {
         var sut = new DelayingExtractor<int>(new[] { 1, 2, 3, 4, 5 }, TimeSpan.Zero) { MaximumItemCount = 2 };
 
-        var actual = await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        var actual = await sut.ExtractAsync(CancellationToken.None).ToListAsync();
 
         Assert.Equal(new[] { 1, 2 }, actual);
     }
@@ -78,7 +78,7 @@ public class DelayingExtractorTests
     {
         var sut = new DelayingExtractor<int>(new[] { 1, 2, 3, 4 }, TimeSpan.Zero) { SkipItemCount = 2 };
 
-        var actual = await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        var actual = await sut.ExtractAsync(CancellationToken.None).ToListAsync();
 
         Assert.Equal(new[] { 3, 4 }, actual);
     }
@@ -90,7 +90,7 @@ public class DelayingExtractorTests
     {
         var sut = new DelayingExtractor<int>(new[] { 10, 20, 30 }, i => TimeSpan.FromMilliseconds(i));
 
-        var actual = await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        var actual = await sut.ExtractAsync(CancellationToken.None).ToListAsync();
 
         Assert.Equal(new[] { 10, 20, 30 }, actual);
     }
@@ -111,11 +111,11 @@ public class DelayingExtractorTests
         (
             async () =>
             {
-                await foreach (var _ in sut.ExtractAsync(token).ConfigureAwait(false))
+                await foreach (var _ in sut.ExtractAsync(token))
                 {
                 }
             }
-        ).ConfigureAwait(false);
+        );
 
         Assert.Equal(0, sut.CurrentItemCount);
     }
@@ -134,7 +134,7 @@ public class DelayingExtractorTests
         (
             async () =>
             {
-                await foreach (var _ in sut.ExtractAsync(cts.Token).ConfigureAwait(false))
+                await foreach (var _ in sut.ExtractAsync(cts.Token))
                 {
                     processed++;
                     if (processed == 3)
@@ -145,7 +145,7 @@ public class DelayingExtractorTests
                     }
                 }
             }
-        ).ConfigureAwait(false);
+        );
 
         // Stopped near the cancel point rather than draining all 100.
         Assert.True(processed <= 4, $"Expected a prompt stop (≤ 4), but processed {processed}.");

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualProgressTimerCoreTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualProgressTimerCoreTests.cs
@@ -31,7 +31,7 @@ public class ManualProgressTimerCoreTests
         var progress = new SyncProgress<Report>(r => captured = r);
 
         await using var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
-        await enumerator.MoveNextAsync().ConfigureAwait(false);   // starts the run; builds the progress timer
+        await enumerator.MoveNextAsync();   // starts the run; builds the progress timer
         timer.Tick();                                            // fires the callback exactly once
 
         Assert.NotNull(captured);

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualTimeSourceTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualTimeSourceTests.cs
@@ -43,7 +43,7 @@ public class ManualTimeSourceTests
         var sut   = new ExposedExtractor<int>(Enumerable.Range(0, 50).ToArray());
         sut.WithTimeSource(clock);
 
-        await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        await sut.ExtractAsync(CancellationToken.None).ToListAsync();
         clock.Advance(TimeSpan.FromSeconds(10));
 
         var report = sut.GetProgressReport();
@@ -60,7 +60,7 @@ public class ManualTimeSourceTests
         var sut   = new ExposedExtractor<int>(new[] { 1, 2, 3 });
         sut.WithTimeSource(clock);
 
-        await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        await sut.ExtractAsync(CancellationToken.None).ToListAsync();
 
         var report = sut.GetProgressReport();
 
@@ -76,7 +76,7 @@ public class ManualTimeSourceTests
         var sut   = new ExposedExtractor<int>(Enumerable.Range(0, 50).ToArray());
         sut.WithTimeSource(clock);
 
-        await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        await sut.ExtractAsync(CancellationToken.None).ToListAsync();
         clock.Advance(TimeSpan.FromSeconds(10));
 
         var report = sut.GetProgressReport();

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/RecordingMiddlewareTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/RecordingMiddlewareTests.cs
@@ -26,7 +26,7 @@ public class RecordingMiddlewareTests
         var recorder = new RecordingMiddleware<int>();
         var source   = new[] { 1, 2, 3 }.ToAsyncEnumerable();
 
-        var kept = await source.WithMiddleware(recorder, CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        var kept = await source.WithMiddleware(recorder, CancellationToken.None).ToListAsync();
 
         Assert.Equal(new[] { 1, 2, 3 }, kept);
         Assert.Equal(new[] { 1, 2, 3 }, recorder.Observed);
@@ -40,7 +40,7 @@ public class RecordingMiddlewareTests
         var shaping = new RecordingMiddleware<int>(i => MiddlewareResult.Continue(i * 10));
         var source  = new[] { 1, 2, 3 }.ToAsyncEnumerable();
 
-        var kept = await source.WithMiddleware(shaping, CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        var kept = await source.WithMiddleware(shaping, CancellationToken.None).ToListAsync();
 
         Assert.Equal(new[] { 10, 20, 30 }, kept);
         // Observed reflects the items as received, before transformation.
@@ -58,7 +58,7 @@ public class RecordingMiddlewareTests
         );
         var source = new[] { 1, 2, 3, 4, 5, 6 }.ToAsyncEnumerable();
 
-        var kept = await source.WithMiddleware(evensOnly, CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        var kept = await source.WithMiddleware(evensOnly, CancellationToken.None).ToListAsync();
 
         Assert.Equal(new[] { 2, 4, 6 }, kept);
         Assert.Equal(new[] { 1, 2, 3, 4, 5, 6 }, evensOnly.Observed);
@@ -76,7 +76,7 @@ public class RecordingMiddlewareTests
         var kept = await source
             .WithMiddleware(new IItemMiddleware<int>[] { first, second }, CancellationToken.None)
             .ToListAsync()
-            .ConfigureAwait(false);
+            ;
 
         Assert.Equal(new[] { 2, 3, 4 }, kept);
         // `second` sees the output of `first`.

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/RetryingExtractorBranchesTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/RetryingExtractorBranchesTests.cs
@@ -17,7 +17,7 @@ public class RetryingExtractorBranchesTests
             MaximumItemCount = 2,
         };
 
-        var items = await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        var items = await sut.ExtractAsync(CancellationToken.None).ToListAsync();
 
         Assert.Equal(new[] { 2, 3 }, items);
     }
@@ -34,11 +34,11 @@ public class RetryingExtractorBranchesTests
         (
             async () =>
             {
-                await foreach (var _ in sut.ExtractAsync(token).ConfigureAwait(false))
+                await foreach (var _ in sut.ExtractAsync(token))
                 {
                 }
             }
-        ).ConfigureAwait(false);
+        );
 
         // Cancellation is not a retryable fault — only the single attempt ran.
         Assert.Equal(1, sut.AttemptCount);

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/RetryingExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/RetryingExtractorTests.cs
@@ -54,7 +54,7 @@ public class RetryingExtractorTests
     {
         var sut = new RetryingExtractor<int>(new[] { 1, 2, 3 }, failFirstAttempts: 0, maxAttempts: 5);
 
-        var items = await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        var items = await sut.ExtractAsync(CancellationToken.None).ToListAsync();
 
         Assert.Equal(new[] { 1, 2, 3 }, items);
         Assert.Equal(1, sut.AttemptCount);
@@ -67,7 +67,7 @@ public class RetryingExtractorTests
     {
         var sut = new RetryingExtractor<int>(new[] { 1, 2, 3 }, failFirstAttempts: 2, maxAttempts: 5);
 
-        var items = await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        var items = await sut.ExtractAsync(CancellationToken.None).ToListAsync();
 
         Assert.Equal(new[] { 1, 2, 3 }, items);
         Assert.Equal(3, sut.AttemptCount);
@@ -84,11 +84,11 @@ public class RetryingExtractorTests
         (
             async () =>
             {
-                await foreach (var _ in sut.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+                await foreach (var _ in sut.ExtractAsync(CancellationToken.None))
                 {
                 }
             }
-        ).ConfigureAwait(false);
+        );
 
         Assert.Equal(3, sut.AttemptCount);
     }

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TimeSourceExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TimeSourceExtensionsTests.cs
@@ -78,7 +78,7 @@ public class TimeSourceExtensionsTests
         var same   = loader.WithTimeSource(clock);
         Assert.Same(loader, same);
 
-        await loader.LoadAsync(new[] { 1, 2, 3, 4, 5 }.ToAsyncEnumerable(), CancellationToken.None).ConfigureAwait(false);
+        await loader.LoadAsync(new[] { 1, 2, 3, 4, 5 }.ToAsyncEnumerable(), CancellationToken.None);
         clock.Advance(TimeSpan.FromSeconds(5));
 
         Assert.Equal(TimeSpan.FromSeconds(5), loader.GetProgressReport().Elapsed);
@@ -94,7 +94,7 @@ public class TimeSourceExtensionsTests
         var same        = transformer.WithTimeSource(clock);
         Assert.Same(transformer, same);
 
-        await transformer.TransformAsync(new[] { 1, 2, 3 }.ToAsyncEnumerable(), CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        await transformer.TransformAsync(new[] { 1, 2, 3 }.ToAsyncEnumerable(), CancellationToken.None).ToListAsync();
         clock.Advance(TimeSpan.FromSeconds(2));
 
         Assert.Equal(TimeSpan.FromSeconds(2), transformer.GetProgressReport().Elapsed);

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlPipelineErrorAggregationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlPipelineErrorAggregationTests.cs
@@ -29,7 +29,7 @@ public class EtlPipelineErrorAggregationTests
             .From(source)
             .To(sink)
             .RunAsync(capture)
-            .ConfigureAwait(false);
+            ;
 
         var final = capture.FinalReport;
         Assert.NotNull(final);
@@ -59,7 +59,7 @@ public class EtlPipelineErrorAggregationTests
             .Through(transformer)
             .To(sink)
             .RunAsync(capture)
-            .ConfigureAwait(false);
+            ;
 
         var final = capture.FinalReport;
         Assert.NotNull(final);

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlPipelineProgressTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlPipelineProgressTests.cs
@@ -27,7 +27,7 @@ public class EtlPipelineProgressTests
             .From(source)
             .To(sink)
             .RunAsync(capture)
-            .ConfigureAwait(false);
+            ;
 
         var final = capture.FinalReport;
         Assert.NotNull(final);
@@ -49,7 +49,7 @@ public class EtlPipelineProgressTests
             .To(sink)
             .DisposingOwned(owned)
             .RunAsync()
-            .ConfigureAwait(false);
+            ;
 
         Assert.True(owned.WasDisposed);
     }

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlScenarioTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlScenarioTests.cs
@@ -12,7 +12,7 @@ public class EtlScenarioTests
         await EtlScenario
             .From(1, 2, 3)
             .RunAndAssertAsync(new[] { 1, 2, 3 }, expectedErrors: 0)
-            .ConfigureAwait(false);
+            ;
     }
 
 
@@ -24,7 +24,7 @@ public class EtlScenarioTests
             .From(1, 2, 3, 4)
             .WithExtractorFault(index: 2, new FormatException("bad row"))
             .RunAndAssertAsync(new[] { 1, 2, 4 }, expectedErrors: 1)
-            .ConfigureAwait(false);
+            ;
     }
 
 
@@ -36,7 +36,7 @@ public class EtlScenarioTests
             .From(1, 2, 3, 4)
             .WithLoaderFault(index: 1, new FormatException("bad write"))
             .RunAndAssertAsync(new[] { 1, 3, 4 }, expectedErrors: 1)
-            .ConfigureAwait(false);
+            ;
     }
 
 
@@ -48,7 +48,7 @@ public class EtlScenarioTests
             .From(1, 2, 3)
             .Through(new TestTransformer<int>())
             .RunAndAssertAsync(new[] { 1, 2, 3 }, expectedErrors: 0)
-            .ConfigureAwait(false);
+            ;
     }
 
 
@@ -60,6 +60,6 @@ public class EtlScenarioTests
             .From(1, 2, 3)
             .WithExtractorFault(index: 1, new InvalidOperationException("boom"), skip: false)
             .RunAndAssertThrowsAsync<InvalidOperationException>()
-            .ConfigureAwait(false);
+            ;
     }
 }

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressAssertTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressAssertTests.cs
@@ -353,7 +353,7 @@ public class ProgressAssertTests
         var extractor = new TestExtractor<int>(items);
         var capture = new ProgressCapture<Report>();
 
-        var extracted = await extractor.ExtractAsync(capture).ToListAsync().ConfigureAwait(false);
+        var extracted = await extractor.ExtractAsync(capture).ToListAsync();
 
         Assert.Equal(items, extracted);
         ProgressAssert.HasReports(capture);


### PR DESCRIPTION
Stacked PR **4** on the Code Scanning cleanup — **correctness rules**. Base: `fix/inspectcode-test-redundant-usings` (PR #374).

## Fixes
- **`xUnit1030` ×32** — removed `.ConfigureAwait(false)` from 12 test files (36 call sites). xUnit test methods shouldn't use ConfigureAwait; it can interfere with the framework's async context/parallelization. **CA2007 is already disabled for test projects** in `.editorconfig`, so there's no conflict — the resumed-on-context behavior is exactly what xUnit1030 wants.
- **`S4456` ×1** — split `RetryingExtractor.WrapWorkerExecution` into a non-async wrapper that validates `workerFactory` **eagerly** + a private async iterator `WrapWorkerExecutionCore`. Public signature unchanged (`async` isn't part of it) → no PublicAPI change; behavior identical.

## Dismissed as false-positive (code correct, warning wrong) — not in this PR
The remaining src correctness findings are being **dismissed** in code scanning with rationale:
- **`IteratorNeverReturns` ×2 + `S2190` ×2** on `TestExtractor.Generate(Func<T>)` / `GenerateIndexed(Func<int,T>)` — these are the **intentional infinite generators** (the count-less factory ctors, consumed via `MaximumItemCount`). Not recursion; by design.
- **`AccessToDisposedClosure` ×1** on `LoaderBaseContractTests` — the `onPull` closure captures `cts` but runs **during** the awaited `LoadAsync`, before the `using` disposes it. No real access-after-dispose.

## Verification
Full-matrix `dotnet build` green (net462…net10.0). `TestKit.Tests.Unit` (248) + `TestKit.Xunit.Tests.Unit` (313) pass on net8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
