### PR TITLE
fix: src correctness — shared default error policy + explicit dispose assertions

### DIFF
--- a/src/Wolfgang.Etl.Abstractions/DefaultItemErrorPolicy.cs
+++ b/src/Wolfgang.Etl.Abstractions/DefaultItemErrorPolicy.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Wolfgang.Etl.Abstractions;
+
+/// <summary>
+/// Holds the shared default item-error policy delegate in a non-generic type.
+/// The base stages (<see cref="ExtractorBase{TSource, TProgress}"/> and friends)
+/// are generic, so a <c>static</c> field declared on them would allocate one
+/// copy per closed <c>&lt;T&gt;</c>. Keeping the stateless default here shares a
+/// single instance across every instantiation.
+/// </summary>
+internal static class DefaultItemErrorPolicy
+{
+    /// <summary>
+    /// The default per-item error policy: abort the run on the first item error.
+    /// </summary>
+    public static readonly Func<ItemErrorContext, ItemErrorAction> Abort =
+        static _ => ItemErrorAction.Abort;
+}

--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -505,10 +505,7 @@ public abstract class ExtractorBase<TSource, TProgress>
 
 
 
-    private static readonly Func<ItemErrorContext, ItemErrorAction> AbortPolicy =
-        static _ => ItemErrorAction.Abort;
-
-    private readonly Func<ItemErrorContext, ItemErrorAction> _errorPolicy = AbortPolicy;
+    private readonly Func<ItemErrorContext, ItemErrorAction> _errorPolicy = DefaultItemErrorPolicy.Abort;
 
 
 

--- a/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/LoaderBase.cs
@@ -503,10 +503,7 @@ public abstract class LoaderBase<TDestination, TProgress>
 
 
 
-    private static readonly Func<ItemErrorContext, ItemErrorAction> AbortPolicy =
-        static _ => ItemErrorAction.Abort;
-
-    private readonly Func<ItemErrorContext, ItemErrorAction> _errorPolicy = AbortPolicy;
+    private readonly Func<ItemErrorContext, ItemErrorAction> _errorPolicy = DefaultItemErrorPolicy.Abort;
 
 
 

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -514,10 +514,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
 
 
 
-    private static readonly Func<ItemErrorContext, ItemErrorAction> AbortPolicy =
-        static _ => ItemErrorAction.Abort;
-
-    private readonly Func<ItemErrorContext, ItemErrorAction> _errorPolicy = AbortPolicy;
+    private readonly Func<ItemErrorContext, ItemErrorAction> _errorPolicy = DefaultItemErrorPolicy.Abort;
 
 
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/DisposableStageContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/DisposableStageContractTests.cs
@@ -138,7 +138,10 @@ public abstract class DisposableStageContractTests<TSut>
     {
         var sut = CreateSut();
         sut.Dispose();
-        sut.Dispose();
+
+        var secondDispose = Record.Exception(() => sut.Dispose());
+
+        Assert.Null(secondDispose);
     }
 
     /// <summary>
@@ -150,6 +153,11 @@ public abstract class DisposableStageContractTests<TSut>
     {
         var sut = CreateSut();
         await sut.DisposeAsync().ConfigureAwait(false);
-        await sut.DisposeAsync().ConfigureAwait(false);
+
+        var secondDispose = await Record
+            .ExceptionAsync(async () => await sut.DisposeAsync().ConfigureAwait(false))
+            .ConfigureAwait(false);
+
+        Assert.Null(secondDispose);
     }
 }


### PR DESCRIPTION
Stacked PR **5** on the Code Scanning cleanup — **src correctness**. Base: `fix/inspectcode-correctness-xunit1030` (PR #375).

## Fixes (shipped code)
- **`StaticMemberInGenericType` ×3** — `ExtractorBase`/`LoaderBase`/`TransformerBase` each declared `private static readonly Func<...> AbortPolicy`, which allocates one copy per closed `<T>`. Moved the stateless default into a non-generic internal holder (`DefaultItemErrorPolicy.Abort`) shared across all instantiations. Private/internal only — **no PublicAPI change**.
- **`S2699` ×2** — `Dispose_is_idempotent` / `DisposeAsync_is_idempotent` in the shipped `DisposableStageContractTests` had no explicit assertion (no-throw was the implicit test). Made intent explicit with `Record.Exception(...)` + `Assert.Null`. Behavior identical; improves the contract downstream consumers inherit.

## Handled by dismissal (not this PR)
The rest of the correctness backlog turned out to be **false positives** (code correct, warning wrong), dismissed in code scanning with rationale rather than "fixed":
- `VSTHRD002` ×5 — `.GetAwaiter().GetResult()` inside CsCheck's **synchronous** fuzz callback (blocking on async is unavoidable there).
- `AccessToDisposedClosure` ×6 — closures like `Record.Exception(() => timer.Fire())` run **synchronously before** the `using` disposes.
- `GenericEnumeratorNotDisposed` ×2 — the enumerator *is* the test subject (`Assert.Same`).
- `S125` ×1 — an explanatory doc comment, not commented-out code.
- `S2699` ×1 (AllocationBudget) — the assertion lives in the `RunBudgetAsync` helper.

## Verification
Full-matrix `dotnet build` green (net462…net10.0); `TestKit.Xunit.Tests.Unit` (313) + `Abstractions.Tests.Unit` (496) pass on net8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
