### PR TITLE
docs(examples): correctness cleanup — static helpers, dispose CTS, dedup interfaces

### DIFF
--- a/examples/Net4.8/Example1-BasicETL/ConsoleColors.cs
+++ b/examples/Net4.8/Example1-BasicETL/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example1_BasicETL
 {
-    internal class ConsoleColors
+    internal static class ConsoleColors
     {
         public const string Green = "\u001b[32m";
         public const string Yellow = "\u001b[33m";

--- a/examples/Net4.8/Example2-WithCancellationToken/ConsoleColors.cs
+++ b/examples/Net4.8/Example2-WithCancellationToken/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example2_WithCancellationToken
 {
-    internal class ConsoleColors
+    internal static class ConsoleColors
     {
         public const string Green = "\u001b[32m";
         public const string Yellow = "\u001b[33m";

--- a/examples/Net4.8/Example2-WithCancellationToken/Program.cs
+++ b/examples/Net4.8/Example2-WithCancellationToken/Program.cs
@@ -26,7 +26,7 @@ namespace Example2_WithCancellationToken
             Console.WriteLine($"{ConsoleColors.Yellow} Starting ETL process...{ConsoleColors.Reset}\n\n");
 
             // Set a cancellation token to cancel the extraction after 1 second
-            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             var token = cts.Token;
 
             try

--- a/examples/Net4.8/Example3-WithGracefulCancellation/ConsoleColors.cs
+++ b/examples/Net4.8/Example3-WithGracefulCancellation/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example3_WithGracefulCancellation
 {
-    internal class ConsoleColors
+    internal static class ConsoleColors
     {
         public const string Green = "\u001b[32m";
         public const string Yellow = "\u001b[33m";

--- a/examples/Net4.8/Example3-WithGracefulCancellation/Program.cs
+++ b/examples/Net4.8/Example3-WithGracefulCancellation/Program.cs
@@ -26,7 +26,7 @@ namespace Example3_WithGracefulCancellation
             Console.WriteLine($"{ConsoleColors.Yellow} Starting ETL process...{ConsoleColors.Reset}\n\n");
 
             // Set a cancellation token to cancel the extraction after 1 second
-            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             var token = cts.Token;
 
             var sourceItems = extractor.ExtractAsync(token);

--- a/examples/Net4.8/Example4a-WithExtractorProgress/ConsoleColors.cs
+++ b/examples/Net4.8/Example4a-WithExtractorProgress/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example4a_WithExtractorProgress
 {
-    internal class ConsoleColors
+    internal static class ConsoleColors
     {
         public const string Green = "\e[32m";
         public const string Yellow = "\e[33m";

--- a/examples/Net4.8/Example4a-WithExtractorProgress/ETL/FibonacciExtractor.cs
+++ b/examples/Net4.8/Example4a-WithExtractorProgress/ETL/FibonacciExtractor.cs
@@ -6,7 +6,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example4a_WithExtractorProgress.ETL;
 
-internal class FibonacciExtractor : IExtractAsync<int>, IExtractWithProgressAsync<int, EtlProgress>
+internal class FibonacciExtractor : IExtractWithProgressAsync<int, EtlProgress>
 {
     private int _progressInterval = 1_000;
 

--- a/examples/Net4.8/Example4a-WithExtractorProgress/ETL/IntToStringTransformer.cs
+++ b/examples/Net4.8/Example4a-WithExtractorProgress/ETL/IntToStringTransformer.cs
@@ -7,7 +7,7 @@ using Wolfgang.Etl.Abstractions;
 namespace Example4a_WithExtractorProgress.ETL;
 
 internal class IntToStringTransformer
-    : ITransformAsync<int, string>, ITransformWithProgressAsync<int, string, EtlProgress>
+    : ITransformWithProgressAsync<int, string, EtlProgress>
 {
 
     private int _progressInterval = 1_000;

--- a/examples/Net4.8/Example4b-WithTransformerProgress/ETL/ConsoleLoader.cs
+++ b/examples/Net4.8/Example4b-WithTransformerProgress/ETL/ConsoleLoader.cs
@@ -6,7 +6,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example4b_WithTransformerProgress.ETL;
 
-internal class ConsoleLoader : ILoadAsync<string>, ILoadWithProgressAsync<string, EtlProgress>
+internal class ConsoleLoader : ILoadWithProgressAsync<string, EtlProgress>
 {
 
 

--- a/examples/Net4.8/Example4b-WithTransformerProgress/ETL/FibonacciExtractor.cs
+++ b/examples/Net4.8/Example4b-WithTransformerProgress/ETL/FibonacciExtractor.cs
@@ -6,7 +6,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example4b_WithTransformerProgress.ETL;
 
-internal class FibonacciExtractor : IExtractAsync<int>, IExtractWithProgressAsync<int, EtlProgress>
+internal class FibonacciExtractor : IExtractWithProgressAsync<int, EtlProgress>
 {
     private int _progressInterval = 1_000;
 

--- a/examples/Net4.8/Example4b-WithTransformerProgress/ETL/IntToStringTransformer.cs
+++ b/examples/Net4.8/Example4b-WithTransformerProgress/ETL/IntToStringTransformer.cs
@@ -7,7 +7,7 @@ using Wolfgang.Etl.Abstractions;
 namespace Example4b_WithTransformerProgress.ETL;
 
 internal class IntToStringTransformer
-    : ITransformAsync<int, string>, ITransformWithProgressAsync<int, string, EtlProgress>
+    : ITransformWithProgressAsync<int, string, EtlProgress>
 {
 
     private int _progressInterval = 1_000;

--- a/examples/Net4.8/Example4c-WithLoaderProgress/ConsoleColors.cs
+++ b/examples/Net4.8/Example4c-WithLoaderProgress/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example4c_WithLoaderProgress
 {
-    internal class ConsoleColors
+    internal static class ConsoleColors
     {
         public const string Green = "\e[32m";
         public const string Yellow = "\e[33m";

--- a/examples/Net4.8/Example4c-WithLoaderProgress/ETL/FibonacciExtractor.cs
+++ b/examples/Net4.8/Example4c-WithLoaderProgress/ETL/FibonacciExtractor.cs
@@ -6,7 +6,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example4c_WithLoaderProgress.ETL;
 
-internal class FibonacciExtractor : IExtractAsync<int>, IExtractWithProgressAsync<int, EtlProgress>
+internal class FibonacciExtractor : IExtractWithProgressAsync<int, EtlProgress>
 {
     private int _progressInterval = 1_000;
 

--- a/examples/Net4.8/Example4c-WithLoaderProgress/ETL/IntToStringTransformer.cs
+++ b/examples/Net4.8/Example4c-WithLoaderProgress/ETL/IntToStringTransformer.cs
@@ -7,7 +7,7 @@ using Wolfgang.Etl.Abstractions;
 namespace Example4c_WithLoaderProgress.ETL;
 
 internal class IntToStringTransformer
-    : ITransformAsync<int, string>, ITransformWithProgressAsync<int, string, EtlProgress>
+    : ITransformWithProgressAsync<int, string, EtlProgress>
 {
 
     private int _progressInterval = 1_000;

--- a/examples/Net4.8/Example5a-ExtractorWithProgressAndCancellation/ConsoleColors.cs
+++ b/examples/Net4.8/Example5a-ExtractorWithProgressAndCancellation/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example5a_ExtractorWithProgressAndCancellation
 {
-    internal class ConsoleColors
+    internal static class ConsoleColors
     {
         public const string Green = "\e[32m";
         public const string Yellow = "\e[33m";

--- a/examples/Net4.8/Example5a-ExtractorWithProgressAndCancellation/Program.cs
+++ b/examples/Net4.8/Example5a-ExtractorWithProgressAndCancellation/Program.cs
@@ -31,7 +31,7 @@ internal class Program
         });
 
         // Set a cancellation token to cancel the extraction after 1 second
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         var token = cts.Token;
 
         // Best practice is to only use one progress reporter per ETL process. Using multiple progress reporters

--- a/examples/Net4.8/Example6-ReducingDuplicateCode/ConsoleColors.cs
+++ b/examples/Net4.8/Example6-ReducingDuplicateCode/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example6_ReducingDuplicateCode
 {
-    internal class ConsoleColors
+    internal static class ConsoleColors
     {
         public const string Green = "\e[32m";
         public const string Yellow = "\e[33m";

--- a/examples/Net4.8/Example6-ReducingDuplicateCode/ETL/ConsoleLoader.cs
+++ b/examples/Net4.8/Example6-ReducingDuplicateCode/ETL/ConsoleLoader.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/examples/Net4.8/Example6-ReducingDuplicateCode/ETL/FibonacciExtractor.cs
+++ b/examples/Net4.8/Example6-ReducingDuplicateCode/ETL/FibonacciExtractor.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/examples/Net4.8/Example6-ReducingDuplicateCode/ETL/IntToStringTransformer.cs
+++ b/examples/Net4.8/Example6-ReducingDuplicateCode/ETL/IntToStringTransformer.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/examples/Net4.8/Example6-ReducingDuplicateCode/Program.cs
+++ b/examples/Net4.8/Example6-ReducingDuplicateCode/Program.cs
@@ -60,7 +60,7 @@ internal class Program
         Console.WriteLine($"{ConsoleColors.Yellow} Starting ETL process wit cancellation...{ConsoleColors.Reset}\n\n");
 
         // Set a cancellation token to cancel the extraction after 1 second
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         var token = cts.Token;
 
         var extractor = new FibonacciExtractor();
@@ -111,7 +111,7 @@ internal class Program
         Console.WriteLine($"{ConsoleColors.Yellow} Starting ETL process wit cancellation...{ConsoleColors.Reset}\n\n");
 
         // Set a cancellation token to cancel the extraction after 1 second
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         var token = cts.Token;
 
         var progress = new Progress<EtlProgress>(p =>

--- a/examples/Net4.8/Example7-FluentPipeline/ConsoleColors.cs
+++ b/examples/Net4.8/Example7-FluentPipeline/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example7_FluentPipeline
 {
-    internal class ConsoleColors
+    internal static class ConsoleColors
     {
         public const string Green = "\u001b[32m";
         public const string Yellow = "\u001b[33m";

--- a/examples/Net4.8/Example7-FluentPipeline/Program.cs
+++ b/examples/Net4.8/Example7-FluentPipeline/Program.cs
@@ -5,7 +5,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example7_FluentPipeline
 {
-    internal class Program
+    internal static class Program
     {
         private static async Task Main()
         {

--- a/examples/Net4.8/Example8-EtlPipeline/ConsoleColors.cs
+++ b/examples/Net4.8/Example8-EtlPipeline/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example8_EtlPipeline
 {
-    internal class ConsoleColors
+    internal static class ConsoleColors
     {
         public const string Green = "\u001b[32m";
         public const string Yellow = "\u001b[33m";

--- a/examples/Net4.8/Example8-EtlPipeline/Program.cs
+++ b/examples/Net4.8/Example8-EtlPipeline/Program.cs
@@ -6,7 +6,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example8_EtlPipeline
 {
-    internal class Program
+    internal static class Program
     {
         private static async Task Main()
         {

--- a/examples/Net8.0/Example1-BasicETL/ConsoleColors.cs
+++ b/examples/Net8.0/Example1-BasicETL/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example1_BasicETL;
 
-internal class ConsoleColors
+internal static class ConsoleColors
 {
     public const string Green = "\e[32m";
     public const string Yellow = "\e[33m";

--- a/examples/Net8.0/Example2-WithCancellationToken/ConsoleColors.cs
+++ b/examples/Net8.0/Example2-WithCancellationToken/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example2_WithCancellationToken;
 
-internal class ConsoleColors
+internal static class ConsoleColors
 {
     public const string Green = "\e[32m";
     public const string Yellow = "\e[33m";

--- a/examples/Net8.0/Example2-WithCancellationToken/Program.cs
+++ b/examples/Net8.0/Example2-WithCancellationToken/Program.cs
@@ -23,7 +23,7 @@ internal class Program
         Console.WriteLine($"{ConsoleColors.Yellow} Starting ETL process...{ConsoleColors.Reset}\n\n");
 
         // Set a cancellation token to cancel the extraction after 1 second
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         var token = cts.Token;
 
         try

--- a/examples/Net8.0/Example3-WithGracefulCancellation/ConsoleColors.cs
+++ b/examples/Net8.0/Example3-WithGracefulCancellation/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example3_WithGracefulCancellation;
 
-internal class ConsoleColors
+internal static class ConsoleColors
 {
     public const string Green = "\e[32m";
     public const string Yellow = "\e[33m";

--- a/examples/Net8.0/Example3-WithGracefulCancellation/Program.cs
+++ b/examples/Net8.0/Example3-WithGracefulCancellation/Program.cs
@@ -23,7 +23,7 @@ internal class Program
         Console.WriteLine($"{ConsoleColors.Yellow} Starting ETL process...{ConsoleColors.Reset}\n\n");
 
         // Set a cancellation token to cancel the extraction after 1 second
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         var token = cts.Token;
 
         var sourceItems = extractor.ExtractAsync(token);

--- a/examples/Net8.0/Example4a-WithExtractorProgress/ConsoleColors.cs
+++ b/examples/Net8.0/Example4a-WithExtractorProgress/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example4a_WithExtractorProgress;
 
-internal class ConsoleColors
+internal static class ConsoleColors
 {
     public const string Green = "\e[32m";
     public const string Yellow = "\e[33m";

--- a/examples/Net8.0/Example4a-WithExtractorProgress/ETL/ConsoleLoader.cs
+++ b/examples/Net8.0/Example4a-WithExtractorProgress/ETL/ConsoleLoader.cs
@@ -2,7 +2,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example4a_WithExtractorProgress.ETL;
 
-internal class ConsoleLoader : ILoadAsync<string>, ILoadWithProgressAsync<string, EtlProgress>
+internal class ConsoleLoader : ILoadWithProgressAsync<string, EtlProgress>
 {
 
 

--- a/examples/Net8.0/Example4a-WithExtractorProgress/ETL/FibonacciExtractor.cs
+++ b/examples/Net8.0/Example4a-WithExtractorProgress/ETL/FibonacciExtractor.cs
@@ -2,7 +2,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example4a_WithExtractorProgress.ETL;
 
-internal class FibonacciExtractor : IExtractAsync<int>, IExtractWithProgressAsync<int, EtlProgress>
+internal class FibonacciExtractor : IExtractWithProgressAsync<int, EtlProgress>
 {
     private int _progressInterval = 1_000;
 

--- a/examples/Net8.0/Example4a-WithExtractorProgress/ETL/IntToStringTransformer.cs
+++ b/examples/Net8.0/Example4a-WithExtractorProgress/ETL/IntToStringTransformer.cs
@@ -3,7 +3,7 @@ using Wolfgang.Etl.Abstractions;
 namespace Example4a_WithExtractorProgress.ETL;
 
 internal class IntToStringTransformer
-    : ITransformAsync<int, string>, ITransformWithProgressAsync<int, string, EtlProgress>
+    : ITransformWithProgressAsync<int, string, EtlProgress>
 {
 
     private int _progressInterval = 1_000;

--- a/examples/Net8.0/Example4b-WithTransformerProgress/ConsoleColors.cs
+++ b/examples/Net8.0/Example4b-WithTransformerProgress/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example4b_WithTransformerProgress;
 
-internal class ConsoleColors
+internal static class ConsoleColors
 {
     public const string Green = "\e[32m";
     public const string Yellow = "\e[33m";

--- a/examples/Net8.0/Example4b-WithTransformerProgress/ETL/ConsoleLoader.cs
+++ b/examples/Net8.0/Example4b-WithTransformerProgress/ETL/ConsoleLoader.cs
@@ -2,7 +2,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example4b_WithTransformerProgress.ETL;
 
-internal class ConsoleLoader : ILoadAsync<string>, ILoadWithProgressAsync<string, EtlProgress>
+internal class ConsoleLoader : ILoadWithProgressAsync<string, EtlProgress>
 {
 
 

--- a/examples/Net8.0/Example4b-WithTransformerProgress/ETL/FibonacciExtractor.cs
+++ b/examples/Net8.0/Example4b-WithTransformerProgress/ETL/FibonacciExtractor.cs
@@ -2,7 +2,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example4b_WithTransformerProgress.ETL;
 
-internal class FibonacciExtractor : IExtractAsync<int>, IExtractWithProgressAsync<int, EtlProgress>
+internal class FibonacciExtractor : IExtractWithProgressAsync<int, EtlProgress>
 {
     private int _progressInterval = 1_000;
 

--- a/examples/Net8.0/Example4b-WithTransformerProgress/ETL/IntToStringTransformer.cs
+++ b/examples/Net8.0/Example4b-WithTransformerProgress/ETL/IntToStringTransformer.cs
@@ -3,7 +3,7 @@ using Wolfgang.Etl.Abstractions;
 namespace Example4b_WithTransformerProgress.ETL;
 
 internal class IntToStringTransformer
-    : ITransformAsync<int, string>, ITransformWithProgressAsync<int, string, EtlProgress>
+    : ITransformWithProgressAsync<int, string, EtlProgress>
 {
 
     private int _progressInterval = 1_000;

--- a/examples/Net8.0/Example4c-WithLoaderProgress/ConsoleColors.cs
+++ b/examples/Net8.0/Example4c-WithLoaderProgress/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example4c_WithLoaderProgress;
 
-internal class ConsoleColors
+internal static class ConsoleColors
 {
     public const string Green = "\e[32m";
     public const string Yellow = "\e[33m";

--- a/examples/Net8.0/Example4c-WithLoaderProgress/ETL/ConsoleLoader.cs
+++ b/examples/Net8.0/Example4c-WithLoaderProgress/ETL/ConsoleLoader.cs
@@ -2,7 +2,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example4c_WithLoaderProgress.ETL;
 
-internal class ConsoleLoader : ILoadAsync<string>, ILoadWithProgressAsync<string, EtlProgress>
+internal class ConsoleLoader : ILoadWithProgressAsync<string, EtlProgress>
 {
 
 

--- a/examples/Net8.0/Example4c-WithLoaderProgress/ETL/FibonacciExtractor.cs
+++ b/examples/Net8.0/Example4c-WithLoaderProgress/ETL/FibonacciExtractor.cs
@@ -2,7 +2,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example4c_WithLoaderProgress.ETL;
 
-internal class FibonacciExtractor : IExtractAsync<int>, IExtractWithProgressAsync<int, EtlProgress>
+internal class FibonacciExtractor : IExtractWithProgressAsync<int, EtlProgress>
 {
     private int _progressInterval = 1_000;
 

--- a/examples/Net8.0/Example4c-WithLoaderProgress/ETL/IntToStringTransformer.cs
+++ b/examples/Net8.0/Example4c-WithLoaderProgress/ETL/IntToStringTransformer.cs
@@ -3,7 +3,7 @@ using Wolfgang.Etl.Abstractions;
 namespace Example4c_WithLoaderProgress.ETL;
 
 internal class IntToStringTransformer
-    : ITransformAsync<int, string>, ITransformWithProgressAsync<int, string, EtlProgress>
+    : ITransformWithProgressAsync<int, string, EtlProgress>
 {
 
     private int _progressInterval = 1_000;

--- a/examples/Net8.0/Example5a-ExtractorWithProgressAndCancellation/ConsoleColors.cs
+++ b/examples/Net8.0/Example5a-ExtractorWithProgressAndCancellation/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example5a_ExtractorWithProgressAndCancellation;
 
-internal class ConsoleColors
+internal static class ConsoleColors
 {
     public const string Green = "\e[32m";
     public const string Yellow = "\e[33m";

--- a/examples/Net8.0/Example5a-ExtractorWithProgressAndCancellation/Program.cs
+++ b/examples/Net8.0/Example5a-ExtractorWithProgressAndCancellation/Program.cs
@@ -28,7 +28,7 @@ internal class Program
         });
 
         // Set a cancellation token to cancel the extraction after 1 second
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         var token = cts.Token;
 
         // Best practice is to only use one progress reporter per ETL process. Using multiple progress reporters

--- a/examples/Net8.0/Example6-ReducingDuplicateCode/ConsoleColors.cs
+++ b/examples/Net8.0/Example6-ReducingDuplicateCode/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example6_ReducingDuplicateCode;
 
-internal class ConsoleColors
+internal static class ConsoleColors
 {
     public const string Green = "\e[32m";
     public const string Yellow = "\e[33m";

--- a/examples/Net8.0/Example6-ReducingDuplicateCode/Program.cs
+++ b/examples/Net8.0/Example6-ReducingDuplicateCode/Program.cs
@@ -57,7 +57,7 @@ internal class Program
         Console.WriteLine($"{ConsoleColors.Yellow} Starting ETL process wit cancellation...{ConsoleColors.Reset}\n\n");
 
         // Set a cancellation token to cancel the extraction after 1 second
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         var token = cts.Token;
 
         var extractor = new FibonacciExtractor();
@@ -108,7 +108,7 @@ internal class Program
         Console.WriteLine($"{ConsoleColors.Yellow} Starting ETL process wit cancellation...{ConsoleColors.Reset}\n\n");
 
         // Set a cancellation token to cancel the extraction after 1 second
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         var token = cts.Token;
 
         var progress = new Progress<EtlProgress>(p =>

--- a/examples/Net8.0/Example7-FluentPipeline/ConsoleColors.cs
+++ b/examples/Net8.0/Example7-FluentPipeline/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example7_FluentPipeline;
 
-internal class ConsoleColors
+internal static class ConsoleColors
 {
     public const string Green = "\e[32m";
     public const string Yellow = "\e[33m";

--- a/examples/Net8.0/Example7-FluentPipeline/Program.cs
+++ b/examples/Net8.0/Example7-FluentPipeline/Program.cs
@@ -3,7 +3,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example7_FluentPipeline;
 
-internal class Program
+internal static class Program
 {
     private static async Task Main()
     {

--- a/examples/Net8.0/Example8-EtlPipeline/ConsoleColors.cs
+++ b/examples/Net8.0/Example8-EtlPipeline/ConsoleColors.cs
@@ -1,6 +1,6 @@
 namespace Example8_EtlPipeline;
 
-internal class ConsoleColors
+internal static class ConsoleColors
 {
     public const string Green = "\e[32m";
     public const string Yellow = "\e[33m";

--- a/examples/Net8.0/Example8-EtlPipeline/Program.cs
+++ b/examples/Net8.0/Example8-EtlPipeline/Program.cs
@@ -3,7 +3,7 @@ using Wolfgang.Etl.Abstractions;
 
 namespace Example8_EtlPipeline;
 
-internal class Program
+internal static class Program
 {
     private static async Task Main()
     {


### PR DESCRIPTION
Stacked PR **6** on the Code Scanning cleanup — **example-code correctness**. Base: `fix/inspectcode-correctness-test-src` (PR #376).

## Fixes (also make the demos model better practice) — 68 alerts
- **`RCS1102` ×23** — const-only `ConsoleColors` / static-only helpers → `static class`.
- **`S2930` ×10** — `var cts = new CancellationTokenSource(...)` → **`using var`** so the examples demonstrate proper `CancellationTokenSource` disposal.
- **`RedundantExtendsListEntry` ×16 + `S1939` ×16** (same lines) — drop the redundant base interface from the base list (`IExtractWithProgressAsync<…>` already derives from `IExtractAsync<…>`, etc.).
- **`RedundantNullableDirective` ×3** — drop redundant file-level `#nullable`.

## Dismissed — false-positive / readability-preferred in a demo (65 alerts)
- **`AccessToModifiedClosure` ×36** — the timer/progress closure **intentionally** captures the live counter (`Volatile.Read(ref count)`); that's the whole pattern.
- **`S125` ×12** — deliberately illustrative commented code ("you can either throw… *or* handle gracefully").
- **`S4456` ×17** — the eager-validation split would add boilerplate that hurts example readability; the lazy validation is fine in a demo.

## Verification
Full-matrix `dotnet build` green (net462…net10.0). Diffs are surgical (50 files, +49/−52); behavior-preserving. Spot-checked: `internal static class ConsoleColors`, `using var cts`, `FibonacciExtractor : IExtractWithProgressAsync<int, EtlProgress>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
