### PR TITLE
security(ci): close .DotSettings gap in pr.yaml protected-file guard

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -120,6 +120,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )
@@ -200,14 +201,16 @@ jobs:
             fi
           done
           
-          # Check .globalconfig, .ruleset, and workflow files using the same git diff approach
+          # Check .globalconfig, .ruleset, .DotSettings, and workflow files using
+          # the same git diff approach.
           # --diff-filter=AMRCD: Added, Modified, Renamed, Copied, Deleted.
           # Including D so a PR that *deletes* a protected file (workflow,
-          # .globalconfig, .ruleset) also triggers the maintainer-review gate
-          # — a silent deletion is just as security-relevant as a silent edit.
+          # .globalconfig, .ruleset, .DotSettings) also triggers the
+          # maintainer-review gate — a silent deletion is just as
+          # security-relevant as a silent edit.
           while IFS= read -r file; do
             changed_files+=("$file")
-          done < <(git diff --name-only --diff-filter=AMRCD main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
+          done < <(git diff --name-only --diff-filter=AMRCD main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset|DotSettings)|^\.github/workflows/.*\.ya?ml)$' || true)
           
           if [ ${#changed_files[@]} -gt 0 ]; then
             echo ""
@@ -302,6 +305,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )
@@ -455,6 +459,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )
@@ -870,7 +875,7 @@ jobs:
           }
           
           # Handle glob patterns for .globalconfig, .ruleset, and workflow files
-          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
+          $globPatterns = @("*.globalconfig", "*.ruleset", "*.DotSettings", ".github/workflows/*.yml", ".github/workflows/*.yaml")
           foreach ($pattern in $globPatterns) {
             $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
             foreach ($file in $files) {
@@ -1167,6 +1172,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )
@@ -1554,6 +1560,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )


### PR DESCRIPTION
## Summary

- The InspectCode job's own comment already flags `.DotSettings` as a protected-config vector:
  > a malicious PR could ship a permissive .editorconfig / BannedSymbols.txt / **.DotSettings** that would silence InspectCode findings on the PR's own code.
- But `*.DotSettings` was missing from every `config_files=(...)` array — so the code did not do what the comment said. A PR could therefore ship its own `.DotSettings` suppression file and InspectCode would honor it, since InspectCode's noise floor is tuned via `.DotSettings` at the repo root (see #378).
- Adds `*.DotSettings` to all five bash arrays plus the Windows-stage pwsh `$globPatterns`, and extends the `Detect protected configuration file changes` regex so a PR that touches its own `.DotSettings` gets the same maintainer-review gate as `.editorconfig` / `.globalconfig` / `.ruleset` / workflow files already do.

## Notes for merge

- This PR modifies a workflow file, so `Detect .NET Projects` will fail with the "protected config file changed" gate. **Admin bypass required** — the pattern is a one-file protected-file-PR-split; this PR *is* the split (nothing else in it).
- Once merged, the fleet's canonical `pr.yaml` in `Chris-Wolfgang/repo-template` needs the same edit so downstream repos pick it up on the next template-drift sweep (follow-up).

## Test plan

- [ ] Admin-bypass merge to main
- [ ] On the next PR that touches `.DotSettings` (e.g. a follow-up to #378), confirm `Detect .NET Projects` fails with `.DotSettings` in the changed-files list
- [ ] Confirm InspectCode job logs show `✓ Copying <file>.DotSettings from main branch` on any PR where main has a `.DotSettings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)