### PR TITLE
test: fix broken XML-doc cref + triage the InspectCode long-tail

### DIFF
--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/TestDoubles.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/TestDoubles.cs
@@ -33,7 +33,7 @@ internal sealed class CollectingLoader<T> : LoaderBase<T, EtlProgress>
 
 /// <summary>
 /// Minimal <see cref="ExtractorBase{TSource, TProgress}"/> that yields a fixed sequence, for
-/// exercising <see cref="EtlPipeline.From{T, TProgress}(ExtractorBase{T, TProgress})"/>.
+/// exercising <see cref="EtlPipelineSourceExtensions.From{T, TProgress}(EtlPipeline, ExtractorBase{T, TProgress})"/>.
 /// </summary>
 internal sealed class SeededExtractor<T> : ExtractorBase<T, EtlProgress>
     where T : notnull


### PR DESCRIPTION
Stacked PR **7** (final) on the Code Scanning cleanup — the misc long-tail. Base: `fix/inspectcode-correctness-examples` (PR #377).

## Fix — 1 real issue
`InvalidXmlDocComment` in `EtlPipelineTests/TestDoubles.cs`: `EtlPipeline.From{T,TProgress}(...)` didn't resolve because `From` is an **extension method** on `EtlPipelineSourceExtensions`, not a member of `EtlPipeline`. Repointed the cref at the extensions class (with the `this` param type).

## The rest of the long-tail — dismissed (false-positive / won't-fix)
After a fresh `jb inspectcode` on the fully-fixed branch, the remaining dashboard findings were triaged; 14 are code-correct / warning-wrong or platform-constrained and dismissed in code scanning:
- `S1215 ×2` — `GC.Collect()` is required in an allocation-measurement test before `GC.GetTotalAllocatedBytes`.
- `S1994 ×3` — intentional infinite `for(;;)` / `while(true)` (infinite generators, retry-until-exhausted).
- `S6966 ×2` — `cts.Cancel()` required; `CancelAsync()` is net8+ only, base targets net462+.
- `MA0158` — `System.Threading.Lock` is net9+; multi-TFM type keeps `object` lock.
- `S5034` — `ValueTask` blocked in CsCheck's synchronous fuzz callback (can't be async).
- `S3267` — loop kept to avoid LINQ allocation on the middleware-chain path.
- `RCS1194` / `S4487` / `S6608` — test-only boilerplate / scaffolding / immaterial micro-opt.
- `InvalidXmlDocComment` (benchmark) — `<see cref="Pipeline"/>` resolves in code (ReSharper FP).

Not in this PR (already fixed upstream in the stack, clear at release): `StaticMemberInGenericType ×3` + `S2699 ×2` (#376).

## Verification
Test project builds green (net8.0); doc-comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
