### PR TITLE
build: gate PublicApiAnalyzers (protected-only PR ahead of the vNext cleanup stack)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -65,14 +65,17 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- A1: PublicApiAnalyzers — track public API surface for breaking-change
-         detection. AdditionalFiles below are opt-in PER PROJECT via Exists():
-         drop PublicAPI.Shipped.txt + PublicAPI.Unshipped.txt into a src
-         project directory and the analyzer activates for that project only.
-         Library projects under src/ should opt in; test / example /
-         benchmark projects should not. Per-repo enablement is tracked as a
-         follow-up maintenance issue. -->
+  <!-- A1: PublicApiAnalyzers — track public API surface for breaking-change
+       detection. Both the analyzer package AND its AdditionalFiles baseline are
+       gated on Exists('PublicAPI.Shipped.txt'), so the analyzer only runs in a
+       project that actually tracks a public-API baseline (the packable src
+       libraries). Without this gate the analyzer loads everywhere but finds no
+       baseline in test / example / benchmark projects, emitting RS0016 / RS0037
+       / RS0036 for every public symbol as (non-error) warnings — invisible in
+       the build but flooding the code-scanning dashboard. Gating the reference
+       is the correct fix: PublicAPI tracking does not apply to non-shipped
+       assemblies. -->
+  <ItemGroup Condition="Exists('PublicAPI.Shipped.txt')">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
**Protected-only PR** — extracts the single protected file (`Directory.Build.props`) from the vNext code-scanning-cleanup stack (originally #370) so the eventual `vNext → main` release PR won't need a full-diff admin bypass.

## The change
Gate `Microsoft.CodeAnalysis.PublicApiAnalyzers` on `Exists('PublicAPI.Shipped.txt')` (same condition as its `AdditionalFiles` baseline) → the analyzer only runs where a public-API baseline exists (the 4 packable src libraries), instead of flooding `RS0016`/`RS0037`/`RS0036` in test/example/benchmark projects.

## Why protected-only
`Directory.Build.props` is a protected file → `Detect .NET Projects` will fail (expected). Admin-bypass this small one-file PR after eyeballing the diff, rather than bypassing the whole stack at release. Everything else should be green; Stage 1/2/3 will show SKIPPED because they depend on the guard.

After this merges, I'll merge `main → vNext` (the protected delta vanishes) and re-base the stack so the rest merges normally.

Related: #369 (the other protected-only-to-main PR — CodeQL actions leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
