### PR TITLE
chore(release): align all four PackageValidation baselines to 0.22.0

### DIFF
--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -11,7 +11,7 @@
          recorded in CompatibilitySuppressions.xml, regenerated with
          `dotnet pack /p:GenerateCompatibilitySuppressionFile=true`. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.20.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.22.0</PackageValidationBaselineVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Contains interfaces and base classes used to build ETL applications</Description>

--- a/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
+++ b/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
@@ -3,8 +3,11 @@
 	<TargetFrameworks>net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	<!-- Lockstep with Wolfgang.Etl.Abstractions: this package is built and released from the same
 	     repo under the same version and tag (like Wolfgang.Etl.TestKit + Wolfgang.Etl.TestKit.Xunit). -->
-    <!-- No EnablePackageValidation on the FIRST release: there is no previously-published baseline to
-         compare against. Enable it next cycle with PackageValidationBaselineVersion set to 0.21.0. -->
+    <!-- ABI / binary-compatibility gate. Skipped for the FIRST release (0.21.0) because there was no
+         previously-published baseline to compare against; enabled from 0.22.0 onward now that the
+         package has published history. Baseline tracks the last PUBLISHED version. -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.22.0</PackageValidationBaselineVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Ready-made item-error policies — skip, log, and dead-letter (to a collection or a channel) — assignable to the ErrorPolicy property of Wolfgang.Etl extractors, loaders, and transformers. Built on Wolfgang.Etl.Abstractions.</Description>

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -12,7 +12,7 @@
          is live on NuGet (otherwise pack fails NU1102). Intentional breaks in a
          MAJOR bump are recorded via a generated CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.13.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.22.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit.Xunit</Title>
     <Description>Abstract xUnit contract test base classes for verifying custom ETL extractors, transformers, and loaders built on Wolfgang.Etl.Abstractions.</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -12,7 +12,7 @@
          is live on NuGet (otherwise pack fails NU1102). Intentional breaks in a
          MAJOR bump are recorded via a generated CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.13.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.22.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit</Title>
     <Description>An implementation of Extractor, Transformer and Loader for use in ETL examples and benchmarks. Built on Wolfgang.Etl.Abstractions.</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>


### PR DESCRIPTION
Post-release chore following v0.22.0 — and a correction of two pre-existing gaps that a routine one-step bump would have missed.

| package | before | after |
| --- | --- | --- |
| `Wolfgang.Etl.Abstractions` | 0.20.0 | **0.22.0** |
| `Wolfgang.Etl.TestKit` | **0.13.0** | **0.22.0** |
| `Wolfgang.Etl.TestKit.Xunit` | **0.13.0** | **0.22.0** |
| `Wolfgang.Etl.ErrorPolicies` | *validation disabled* | **enabled @ 0.22.0** |

`PackageValidationBaselineVersion` tracks the last **published** version — deliberately left alone during release prep, advanced afterwards. But three of these were not simply one release behind:

- **Abstractions missed the 0.21.0 post-release bump**, so it sat two versions back.
- **The TestKit pair still carried 0.13.0** — the baseline from the *standalone* `ETL-Test-Kit` repository's own version line, which came across unchanged in the fold (#356). Those packages now version in lockstep with this repo, so 0.13.0 is not a meaningful comparison point; they were validating **nine versions back**.
- **ErrorPolicies shipped 0.21.0 with validation off**, correctly — there was no published baseline for a first release. The csproj comment said to enable it "next cycle with `PackageValidationBaselineVersion` set to 0.21.0"; that cycle came and went, so it is enabled here against the now-correct 0.22.0.

## Verification

All four pack Release with PackageValidation green against the 0.22.0 baseline — no CP-series errors. ErrorPolicies is the one worth noting, since enabling validation for the first time is where a genuine ABI finding would surface; it came back clean.

Worth being precise about what that proves: this run compares 0.22.0 against **itself**, so it confirms the baselines resolve and the gate is wired correctly. The gate does real work from the **next** release onward.

No source or public API changes — four csproj lines.