### PR TITLE
chore: reconcile main into vNext (post-0.22.0)

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -27,7 +27,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'csharp' ]
+        # 'csharp' analyses the compiled library (needs a build); 'actions'
+        # analyses the workflow files themselves (build-mode none, no build).
+        language: [ 'csharp', 'actions' ]
 
     steps:
     - name: Checkout repository
@@ -37,6 +39,7 @@ jobs:
 
     - name: Check for C# source code
       id: check-csharp
+      if: matrix.language == 'csharp'
       shell: pwsh
       run: |
         Write-Host "=== CodeQL C# Source Code Detection ===" -ForegroundColor Cyan
@@ -76,7 +79,7 @@ jobs:
         Write-Host "========================================" -ForegroundColor Cyan
 
     - name: Initialize CodeQL
-      if: steps.check-csharp.outputs.has-csharp == 'true'
+      if: matrix.language == 'actions' || steps.check-csharp.outputs.has-csharp == 'true'
       uses: github/codeql-action/init@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
       with:
         languages: ${{ matrix.language }}
@@ -85,13 +88,13 @@ jobs:
         queries: security-extended
 
     - name: Setup .NET
-      if: steps.check-csharp.outputs.has-csharp == 'true'
+      if: matrix.language == 'csharp' && steps.check-csharp.outputs.has-csharp == 'true'
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
       with:
         dotnet-version: '10.0.x'
 
     - name: Restore .NET workloads
-      if: steps.check-csharp.outputs.has-csharp == 'true'
+      if: matrix.language == 'csharp' && steps.check-csharp.outputs.has-csharp == 'true'
       shell: pwsh
       run: |
         # Skip entirely if no csproj declares a workload-bearing TFM (android/ios/
@@ -120,7 +123,7 @@ jobs:
 
     - name: Build for CodeQL Analysis
       id: build
-      if: steps.check-csharp.outputs.has-csharp == 'true'
+      if: matrix.language == 'csharp' && steps.check-csharp.outputs.has-csharp == 'true'
       shell: pwsh
       run: |
         Write-Host "Building solution for CodeQL analysis..."
@@ -158,7 +161,7 @@ jobs:
 
     - name: Perform CodeQL Analysis
       id: perform-codeql-analysis
-      if: steps.check-csharp.outputs.has-csharp == 'true'
+      if: matrix.language == 'actions' || steps.check-csharp.outputs.has-csharp == 'true'
       uses: github/codeql-action/analyze@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
       with:
         category: "/language:${{matrix.language}}"
@@ -167,36 +170,37 @@ jobs:
       if: always()
       shell: pwsh
       run: |
-        Write-Host "=== CodeQL Security Scan Complete ===" -ForegroundColor Cyan
-        
+        Write-Host "=== CodeQL Security Scan Complete ($env:MATRIX_LANGUAGE) ===" -ForegroundColor Cyan
+
         # Check the outcome of previous steps
+        $language = "$env:MATRIX_LANGUAGE"
         $checkCsharpOutcome = "${{ steps.check-csharp.outcome }}"
         $hasCsharp = "${{ steps.check-csharp.outputs.has-csharp }}"
         $buildOutcome = "${{ steps.build.outcome }}"
         $codeqlOutcome = "${{ steps.perform-codeql-analysis.outcome }}"
-        
+
         # Determine overall status
         $hasFailure = $false
         $failureMessages = @()
-        
-        # Check if check-csharp step failed
+
+        # Check if check-csharp step failed (csharp leg only)
         if ($checkCsharpOutcome -eq "failure") {
           $hasFailure = $true
           $failureMessages += "❌ C# source code detection failed"
         }
-        
+
         # Check if build step failed (only relevant if C# code exists)
         if ($hasCsharp -eq "true" -and $buildOutcome -eq "failure") {
           $hasFailure = $true
           $failureMessages += "❌ Build failed during CodeQL analysis"
         }
-        
-        # Check if CodeQL analysis step failed (only relevant if C# code exists)
-        if ($hasCsharp -eq "true" -and $codeqlOutcome -eq "failure") {
+
+        # Check if CodeQL analysis step failed (either language leg)
+        if ($codeqlOutcome -eq "failure") {
           $hasFailure = $true
-          $failureMessages += "❌ CodeQL analysis failed"
+          $failureMessages += "❌ CodeQL analysis failed ($language)"
         }
-        
+
         # Display results based on actual step outcomes
         if ($hasFailure) {
           Write-Host "❌ Security scan completed with errors:" -ForegroundColor Red
@@ -204,14 +208,16 @@ jobs:
             Write-Host "   $msg" -ForegroundColor Red
           }
           exit 1
-        } elseif ($hasCsharp -eq "true") {
-          Write-Host "✅ CodeQL analysis completed successfully." -ForegroundColor Green
+        } elseif ($codeqlOutcome -eq "success") {
+          Write-Host "✅ CodeQL analysis completed successfully ($language)." -ForegroundColor Green
           Write-Host "   Results have been uploaded to GitHub Security." -ForegroundColor Green
         } elseif ($hasCsharp -eq "false") {
           Write-Host "✅ Security scan completed successfully (no C# code to analyze)." -ForegroundColor Green
           Write-Host "   This job ran successfully and reports a passing status to branch protection." -ForegroundColor Green
         } else {
-          Write-Host "✅ Security scan job completed." -ForegroundColor Green
+          Write-Host "✅ Security scan job completed ($language)." -ForegroundColor Green
           Write-Host "   Job status reported to branch protection." -ForegroundColor Green
         }
         Write-Host "========================================" -ForegroundColor Cyan
+      env:
+        MATRIX_LANGUAGE: ${{ matrix.language }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -120,6 +120,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )
@@ -200,14 +201,16 @@ jobs:
             fi
           done
           
-          # Check .globalconfig, .ruleset, and workflow files using the same git diff approach
+          # Check .globalconfig, .ruleset, .DotSettings, and workflow files using
+          # the same git diff approach.
           # --diff-filter=AMRCD: Added, Modified, Renamed, Copied, Deleted.
           # Including D so a PR that *deletes* a protected file (workflow,
-          # .globalconfig, .ruleset) also triggers the maintainer-review gate
-          # — a silent deletion is just as security-relevant as a silent edit.
+          # .globalconfig, .ruleset, .DotSettings) also triggers the
+          # maintainer-review gate — a silent deletion is just as
+          # security-relevant as a silent edit.
           while IFS= read -r file; do
             changed_files+=("$file")
-          done < <(git diff --name-only --diff-filter=AMRCD main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
+          done < <(git diff --name-only --diff-filter=AMRCD main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset|DotSettings)|^\.github/workflows/.*\.ya?ml)$' || true)
           
           if [ ${#changed_files[@]} -gt 0 ]; then
             echo ""
@@ -302,6 +305,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )
@@ -455,6 +459,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )
@@ -870,7 +875,7 @@ jobs:
           }
           
           # Handle glob patterns for .globalconfig, .ruleset, and workflow files
-          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
+          $globPatterns = @("*.globalconfig", "*.ruleset", "*.DotSettings", ".github/workflows/*.yml", ".github/workflows/*.yaml")
           foreach ($pattern in $globPatterns) {
             $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
             foreach ($file in $files) {
@@ -1167,6 +1172,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )
@@ -1554,6 +1560,7 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            "*.DotSettings"
             ".github/workflows/*.yml"
             ".github/workflows/*.yaml"
           )

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -65,14 +65,17 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- A1: PublicApiAnalyzers — track public API surface for breaking-change
-         detection. AdditionalFiles below are opt-in PER PROJECT via Exists():
-         drop PublicAPI.Shipped.txt + PublicAPI.Unshipped.txt into a src
-         project directory and the analyzer activates for that project only.
-         Library projects under src/ should opt in; test / example /
-         benchmark projects should not. Per-repo enablement is tracked as a
-         follow-up maintenance issue. -->
+  <!-- A1: PublicApiAnalyzers — track public API surface for breaking-change
+       detection. Both the analyzer package AND its AdditionalFiles baseline are
+       gated on Exists('PublicAPI.Shipped.txt'), so the analyzer only runs in a
+       project that actually tracks a public-API baseline (the packable src
+       libraries). Without this gate the analyzer loads everywhere but finds no
+       baseline in test / example / benchmark projects, emitting RS0016 / RS0037
+       / RS0036 for every public symbol as (non-error) warnings — invisible in
+       the build but flooding the code-scanning dashboard. Gating the reference
+       is the correct fix: PublicAPI tracking does not apply to non-shipped
+       assemblies. -->
+  <ItemGroup Condition="Exists('PublicAPI.Shipped.txt')">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -11,7 +11,7 @@
          recorded in CompatibilitySuppressions.xml, regenerated with
          `dotnet pack /p:GenerateCompatibilitySuppressionFile=true`. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.20.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.22.0</PackageValidationBaselineVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Contains interfaces and base classes used to build ETL applications</Description>

--- a/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
+++ b/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
@@ -3,8 +3,11 @@
 	<TargetFrameworks>net462;net472;net48;net481;netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	<!-- Lockstep with Wolfgang.Etl.Abstractions: this package is built and released from the same
 	     repo under the same version and tag (like Wolfgang.Etl.TestKit + Wolfgang.Etl.TestKit.Xunit). -->
-    <!-- No EnablePackageValidation on the FIRST release: there is no previously-published baseline to
-         compare against. Enable it next cycle with PackageValidationBaselineVersion set to 0.21.0. -->
+    <!-- ABI / binary-compatibility gate. Skipped for the FIRST release (0.21.0) because there was no
+         previously-published baseline to compare against; enabled from 0.22.0 onward now that the
+         package has published history. Baseline tracks the last PUBLISHED version. -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.22.0</PackageValidationBaselineVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Ready-made item-error policies — skip, log, and dead-letter (to a collection or a channel) — assignable to the ErrorPolicy property of Wolfgang.Etl extractors, loaders, and transformers. Built on Wolfgang.Etl.Abstractions.</Description>

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -12,7 +12,7 @@
          is live on NuGet (otherwise pack fails NU1102). Intentional breaks in a
          MAJOR bump are recorded via a generated CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.13.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.22.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit.Xunit</Title>
     <Description>Abstract xUnit contract test base classes for verifying custom ETL extractors, transformers, and loaders built on Wolfgang.Etl.Abstractions.</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -12,7 +12,7 @@
          is live on NuGet (otherwise pack fails NU1102). Intentional breaks in a
          MAJOR bump are recorded via a generated CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.13.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.22.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit</Title>
     <Description>An implementation of Extractor, Transformer and Loader for use in ETL examples and benchmarks. Built on Wolfgang.Etl.Abstractions.</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>


### PR DESCRIPTION
Merges post-release `main` into `vNext`, resolving the divergence that built up during the 0.22.0 release wave. Closes #368 — see below for why the plan changed.

## Why this replaces #368's plan

#368 said to **recreate `vNext` from `main`** and re-apply WorkerResilience (#348). That was correct when it was filed, while `vNext` was a stale 7-commit branch. It is no longer safe:

- `vNext` is now **22 commits ahead** of `main` and carries **eight merged InspectCode PRs** (#370–#380). Recreating it would discard all of them.
- `vNext` was also **8 commits behind** `main`, missing the v0.22.0 release commits, the CodeQL / PublicAPI CI work, and the baseline alignment from #384.

The concrete hazard: `main`'s PackageValidation baselines are `0.22.0`, but `vNext` still had the stale `0.13.0` / `0.20.0` values. **Merging `vNext` to `main` without this reconcile would have silently reverted #384.**

So the safe move is a merge, not a recreate — it preserves #348, the InspectCode work, and the baseline fix together.

## What the merge brought in

```
.github/workflows/codeql.yaml                          | 46 +++++++------
.github/workflows/pr.yaml                              | 17 ++++---
src/Wolfgang.Etl.Abstractions/...csproj                |  2 +-
src/Wolfgang.Etl.ErrorPolicies/...csproj               |  7 ++-
src/Wolfgang.Etl.TestKit.Xunit/...csproj               |  2 +-
src/Wolfgang.Etl.TestKit/...csproj                     |  2 +-
```

No conflicts.

## Verification

- **Baselines now `0.22.0`** across all four packages (was `0.13.0`/`0.20.0` on vNext); ErrorPolicies validation stays enabled.
- **WorkerResilience (#348) intact** in all three base stages — `ExtractorBase`, `LoaderBase`, `TransformerBase`.
- Release build with `-p:TreatWarningsAsErrors=true`: **0 warnings / 0 errors**.
- **1092 tests pass** on net10.0 across all 8 test projects.

## Note on #348

WorkerResilience remains unreleased and exists only on `vNext`. It is still the thing to protect — do not delete `vNext` until it has shipped or been carried elsewhere.