### PR TITLE
chore(cleanup): remove redundant code across test-helper libs (~90 InspectCode findings)

### DIFF
--- a/benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/BenchmarkComponents.cs
+++ b/benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/BenchmarkComponents.cs
@@ -155,6 +155,7 @@ internal sealed class SinkLoader : ILoadAsync<int>
     {
         await foreach (var _ in items)
         {
+            // Drain the stream — the benchmark measures throughput, not per-item work.
         }
     }
 }

--- a/benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/BenchmarkComponents.cs
+++ b/benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/BenchmarkComponents.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Wolfgang.Etl.Abstractions;
 
 namespace Wolfgang.Etl.Abstractions.Benchmarks;
 

--- a/benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/ExtractorBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/ExtractorBenchmarks.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
-using Wolfgang.Etl.Abstractions;
 
 namespace Wolfgang.Etl.Abstractions.Benchmarks;
 

--- a/benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/PipelineBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/PipelineBenchmarks.cs
@@ -1,6 +1,5 @@
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
-using Wolfgang.Etl.Abstractions;
 
 namespace Wolfgang.Etl.Abstractions.Benchmarks;
 

--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -5,8 +5,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-
-
 namespace Wolfgang.Etl.Abstractions;
 
 /// <summary>
@@ -310,7 +308,7 @@ public abstract class ExtractorBase<TSource, TProgress>
 
     // Test seam: when set, CreateProgressTimer builds its SystemProgressTimer over this timer core
     // (a deterministic fake) instead of a real System.Threading.Timer.
-    internal Func<System.Threading.TimerCallback, ITimerCore>? TimerCoreFactory;
+    internal Func<TimerCallback, ITimerCore>? TimerCoreFactory;
 
 
 

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -5,8 +5,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-
-
 namespace Wolfgang.Etl.Abstractions;
 
 /// <summary>
@@ -317,7 +315,7 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
 
     // Test seam: when set, CreateProgressTimer builds its SystemProgressTimer over this timer core
     // (a deterministic fake) instead of a real System.Threading.Timer.
-    internal Func<System.Threading.TimerCallback, ITimerCore>? TimerCoreFactory;
+    internal Func<TimerCallback, ITimerCore>? TimerCoreFactory;
 
 
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/EtlScenarioOfT.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/EtlScenarioOfT.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit;
@@ -24,8 +23,8 @@ public sealed class EtlScenario<T>
     where T : notnull
 {
     private readonly T[] _items;
-    private (int Index, Exception Exception, bool Skip)? _extractorFault;
-    private (int Index, Exception Exception, bool Skip)? _loaderFault;
+    private (int Index, System.Exception Exception, bool Skip)? _extractorFault;
+    private (int Index, System.Exception Exception, bool Skip)? _loaderFault;
     private TransformerBase<T, T, Report>? _transformer;
 
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAndCancellationAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAndCancellationAsyncContractTests.cs
@@ -10,7 +10,7 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 
 /// <summary>
 /// Abstract base class providing xUnit contract tests for any type that implements
-/// <see cref="IExtractWithProgressAndCancellationAsync{TSource, TProgress}"/>.
+/// <see cref="IExtractWithProgressAndCancellationAsync{TSource,TProgress}"/>.
 /// </summary>
 /// <typeparam name="TSut">
 /// The type under test. Must implement

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAsyncContractTests.cs
@@ -9,7 +9,7 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 
 /// <summary>
 /// Abstract base class providing xUnit contract tests for any type that implements
-/// <see cref="IExtractWithProgressAsync{TSource, TProgress}"/>.
+/// <see cref="IExtractWithProgressAsync{TSource,TProgress}"/>.
 /// </summary>
 /// <typeparam name="TSut">
 /// The type under test. Must implement

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
@@ -896,6 +896,7 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
         }
         catch (OperationCanceledException)
         {
+            // Expected: cancellation is the scenario under test; the assertion below verifies the pull count.
         }
 
         Assert.True(counter.Count <= 4, $"Expected at most 4 upstream reads, saw {counter.Count}.");

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
@@ -4,14 +4,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit;
 
 /// <summary>
 /// Abstract base class providing xUnit contract tests for any type that inherits
-/// from <see cref="ExtractorBase{TSource, TProgress}"/>.
+/// from <see cref="ExtractorBase{TSource,TProgress}"/>.
 /// </summary>
 /// <typeparam name="TSut">
 /// The type under test. Must inherit from

--- a/src/Wolfgang.Etl.TestKit.Xunit/IdempotentTransformerContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/IdempotentTransformerContractTests.cs
@@ -8,7 +8,7 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 
 /// <summary>
 /// Abstract base class providing opt-in xUnit idempotency contract tests for any type that
-/// implements <see cref="ITransformAsync{TSource, TDestination}"/>.
+/// implements <see cref="ITransformAsync{TSource,TDestination}"/>.
 /// </summary>
 /// <typeparam name="TSut">
 /// The type under test. Must implement <see cref="ITransformAsync{TSource, TDestination}"/>.

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAndCancellationAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAndCancellationAsyncContractTests.cs
@@ -10,7 +10,7 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 
 /// <summary>
 /// Abstract base class providing xUnit contract tests for any type that implements
-/// <see cref="ILoadWithProgressAndCancellationAsync{TDestination, TProgress}"/>.
+/// <see cref="ILoadWithProgressAndCancellationAsync{TDestination,TProgress}"/>.
 /// </summary>
 /// <typeparam name="TSut">
 /// The type under test. Must implement

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAsyncContractTests.cs
@@ -9,7 +9,7 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 
 /// <summary>
 /// Abstract base class providing xUnit contract tests for any type that implements
-/// <see cref="ILoadWithProgressAsync{TDestination, TProgress}"/>.
+/// <see cref="ILoadWithProgressAsync{TDestination,TProgress}"/>.
 /// </summary>
 /// <typeparam name="TSut">
 /// The type under test. Must implement

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
@@ -4,14 +4,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit;
 
 /// <summary>
 /// Abstract base class providing xUnit contract tests for any type that inherits
-/// from <see cref="LoaderBase{TDestination, TProgress}"/>.
+/// from <see cref="LoaderBase{TDestination,TProgress}"/>.
 /// </summary>
 /// <typeparam name="TSut">
 /// The type under test. Must inherit from

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
@@ -945,6 +945,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         }
         catch (OperationCanceledException)
         {
+            // Expected: cancellation is the scenario under test; the assertion below verifies the pull count.
         }
 
         Assert.True(counter.Count <= 4, $"Expected at most 4 upstream reads, saw {counter.Count}.");

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAndCancellationAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAndCancellationAsyncContractTests.cs
@@ -10,7 +10,7 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 
 /// <summary>
 /// Abstract base class providing xUnit contract tests for any type that implements
-/// <see cref="ITransformWithProgressAndCancellationAsync{TSource, TDestination, TProgress}"/>.
+/// <see cref="ITransformWithProgressAndCancellationAsync{TSource,TDestination,TProgress}"/>.
 /// </summary>
 /// <typeparam name="TSut">
 /// The type under test. Must implement

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAsyncContractTests.cs
@@ -9,7 +9,7 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 
 /// <summary>
 /// Abstract base class providing xUnit contract tests for any type that implements
-/// <see cref="ITransformWithProgressAsync{TSource, TDestination, TProgress}"/>.
+/// <see cref="ITransformWithProgressAsync{TSource,TDestination,TProgress}"/>.
 /// </summary>
 /// <typeparam name="TSut">
 /// The type under test. Must implement

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
@@ -983,6 +983,7 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
         }
         catch (OperationCanceledException)
         {
+            // Expected: cancellation is the scenario under test; the assertion below verifies the pull count.
         }
 
         Assert.True(counter.Count <= 4, $"Expected at most 4 upstream reads, saw {counter.Count}.");

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
@@ -4,14 +4,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
-using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit;
 
 /// <summary>
 /// Abstract base class providing xUnit contract tests for any type that inherits
-/// from <see cref="TransformerBase{TSource, TDestination, TProgress}"/>.
+/// from <see cref="TransformerBase{TSource,TDestination,TProgress}"/>.
 /// </summary>
 /// <typeparam name="TSut">
 /// The type under test. Must inherit from

--- a/src/Wolfgang.Etl.TestKit/DelayingExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/DelayingExtractor.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Wolfgang.Etl.TestKit/RecordingMiddleware.cs
+++ b/src/Wolfgang.Etl.TestKit/RecordingMiddleware.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;

--- a/src/Wolfgang.Etl.TestKit/RetryingExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/RetryingExtractor.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading;

--- a/src/Wolfgang.Etl.TestKit/TestLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/TestLoader.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.DocExamples/DocExampleSource.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.DocExamples/DocExampleSource.cs
@@ -91,7 +91,7 @@ public static class DocExampleSource
 
     private static IEnumerable<DocExample> ExtractFromFile(string file, string relative)
     {
-        var lines = System.IO.File.ReadAllLines(file);
+        var lines = File.ReadAllLines(file);
 
         var inExample = false;
         var inCode = false;
@@ -186,7 +186,7 @@ public static class DocExampleSource
         {
             var candidate = Path.Combine(directory.FullName, "src", "Wolfgang.Etl.Abstractions");
             if (Directory.Exists(candidate)
-                && System.IO.File.Exists(Path.Combine(candidate, "Wolfgang.Etl.Abstractions.csproj")))
+                && File.Exists(Path.Combine(candidate, "Wolfgang.Etl.Abstractions.csproj")))
             {
                 return candidate;
             }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/BaseClassTimingTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/BaseClassTimingTests.cs
@@ -24,9 +24,9 @@ public class BaseClassTimingTests
 
 
 
-        public System.DateTimeOffset? StartedAtForTest => StartedAt;
+        public DateTimeOffset? StartedAtForTest => StartedAt;
 
-        public System.TimeSpan ElapsedForTest => Elapsed;
+        public TimeSpan ElapsedForTest => Elapsed;
 
 
 
@@ -60,7 +60,7 @@ public class BaseClassTimingTests
         var sut = new TimedExtractor(3);
 
         Assert.Null(sut.StartedAtForTest);
-        Assert.Equal(System.TimeSpan.Zero, sut.ElapsedForTest);
+        Assert.Equal(TimeSpan.Zero, sut.ElapsedForTest);
     }
 
 
@@ -75,7 +75,7 @@ public class BaseClassTimingTests
         }
 
         Assert.NotNull(sut.StartedAtForTest);
-        Assert.True(sut.ElapsedForTest >= System.TimeSpan.Zero);
+        Assert.True(sut.ElapsedForTest >= TimeSpan.Zero);
     }
 
 
@@ -93,9 +93,9 @@ public class BaseClassTimingTests
 
     private sealed class TimedLoader : LoaderBase<int, EtlProgress>
     {
-        public System.DateTimeOffset? StartedAtForTest => StartedAt;
+        public DateTimeOffset? StartedAtForTest => StartedAt;
 
-        public System.TimeSpan ElapsedForTest => Elapsed;
+        public TimeSpan ElapsedForTest => Elapsed;
 
         protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
         {
@@ -111,9 +111,9 @@ public class BaseClassTimingTests
 
     private sealed class TimedTransformer : TransformerBase<int, int, EtlProgress>
     {
-        public System.DateTimeOffset? StartedAtForTest => StartedAt;
+        public DateTimeOffset? StartedAtForTest => StartedAt;
 
-        public System.TimeSpan ElapsedForTest => Elapsed;
+        public TimeSpan ElapsedForTest => Elapsed;
 
         protected override async IAsyncEnumerable<int> TransformWorkerAsync(IAsyncEnumerable<int> items, [EnumeratorCancellation] CancellationToken token)
         {
@@ -134,7 +134,7 @@ public class BaseClassTimingTests
         var sut = new TimedLoader();
 
         Assert.Null(sut.StartedAtForTest);
-        Assert.Equal(System.TimeSpan.Zero, sut.ElapsedForTest);
+        Assert.Equal(TimeSpan.Zero, sut.ElapsedForTest);
     }
 
 
@@ -146,7 +146,7 @@ public class BaseClassTimingTests
         await sut.LoadAsync(Range(5));
 
         Assert.NotNull(sut.StartedAtForTest);
-        Assert.True(sut.ElapsedForTest >= System.TimeSpan.Zero);
+        Assert.True(sut.ElapsedForTest >= TimeSpan.Zero);
     }
 
 
@@ -156,7 +156,7 @@ public class BaseClassTimingTests
         var sut = new TimedTransformer();
 
         Assert.Null(sut.StartedAtForTest);
-        Assert.Equal(System.TimeSpan.Zero, sut.ElapsedForTest);
+        Assert.Equal(TimeSpan.Zero, sut.ElapsedForTest);
     }
 
 
@@ -170,6 +170,6 @@ public class BaseClassTimingTests
         }
 
         Assert.NotNull(sut.StartedAtForTest);
-        Assert.True(sut.ElapsedForTest >= System.TimeSpan.Zero);
+        Assert.True(sut.ElapsedForTest >= TimeSpan.Zero);
     }
 }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ItemErrorHandlingTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/ItemErrorHandlingTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using Wolfgang.Etl.Abstractions.Tests.Unit.BaseClassTests;
 using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
@@ -477,7 +478,7 @@ public sealed class ItemErrorHandlingTests
 
         public int OnItemErrorCallCount { get; private set; }
 
-        public System.DateTimeOffset? StartedAtForTest => StartedAt;
+        public DateTimeOffset? StartedAtForTest => StartedAt;
 
         public ItemErrorAction Handle(ItemErrorContext context) => HandleItemError(context);
 
@@ -540,7 +541,7 @@ public sealed class ItemErrorHandlingTests
                 int value;
                 try
                 {
-                    value = int.Parse(line, System.Globalization.CultureInfo.InvariantCulture);
+                    value = int.Parse(line, CultureInfo.InvariantCulture);
                 }
                 catch (FormatException ex)
                 {
@@ -599,7 +600,7 @@ public sealed class ItemErrorHandlingTests
 
         protected override ItemErrorAction OnItemError(ItemErrorContext context) => Policy;
 
-        public System.DateTimeOffset? StartedAtForTest => StartedAt;
+        public DateTimeOffset? StartedAtForTest => StartedAt;
 
         protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
         {
@@ -652,7 +653,7 @@ public sealed class ItemErrorHandlingTests
 
         protected override ItemErrorAction OnItemError(ItemErrorContext context) => Policy;
 
-        public System.DateTimeOffset? StartedAtForTest => StartedAt;
+        public DateTimeOffset? StartedAtForTest => StartedAt;
 
         protected override async IAsyncEnumerable<int> TransformWorkerAsync(
             IAsyncEnumerable<int> items, [EnumeratorCancellation] CancellationToken token)

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Extractors.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Extractors.cs
@@ -1,4 +1,6 @@
 
+using System.Runtime.CompilerServices;
+
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 
 /// <summary>
@@ -24,7 +26,7 @@ internal sealed class BareExtractor<T> : IExtractAsync<T>
         foreach (var item in _items)
         {
             yield return item;
-            await System.Threading.Tasks.Task.Yield();
+            await Task.Yield();
         }
     }
 }
@@ -57,7 +59,7 @@ internal sealed class CancelOnlyExtractor<T> : IExtractWithCancellationAsync<T>
 
     public async IAsyncEnumerable<T> ExtractAsync
     (
-        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken token
+        [EnumeratorCancellation] CancellationToken token
     )
     {
         TokenOverloadWasCalled = true;
@@ -66,7 +68,7 @@ internal sealed class CancelOnlyExtractor<T> : IExtractWithCancellationAsync<T>
         {
             token.ThrowIfCancellationRequested();
             yield return item;
-            await System.Threading.Tasks.Task.Yield();
+            await Task.Yield();
         }
     }
 }
@@ -101,7 +103,7 @@ internal sealed class ProgressOnlyExtractor<T, TProgress> : IExtractWithProgress
         foreach (var item in _items)
         {
             yield return item;
-            await System.Threading.Tasks.Task.Yield();
+            await Task.Yield();
         }
     }
 
@@ -119,7 +121,7 @@ internal sealed class ProgressOnlyExtractor<T, TProgress> : IExtractWithProgress
         {
             progress.Report(_reportValue);
             yield return item;
-            await System.Threading.Tasks.Task.Yield();
+            await Task.Yield();
         }
     }
 }
@@ -158,14 +160,14 @@ internal sealed class FullExtractor<T, TProgress> : IExtractWithProgressAndCance
         foreach (var item in _items)
         {
             yield return item;
-            await System.Threading.Tasks.Task.Yield();
+            await Task.Yield();
         }
     }
 
 
     public async IAsyncEnumerable<T> ExtractAsync
     (
-        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken token
+        [EnumeratorCancellation] CancellationToken token
     )
     {
         TokenOnlyOverloadWasCalled = true;
@@ -174,7 +176,7 @@ internal sealed class FullExtractor<T, TProgress> : IExtractWithProgressAndCance
         {
             token.ThrowIfCancellationRequested();
             yield return item;
-            await System.Threading.Tasks.Task.Yield();
+            await Task.Yield();
         }
     }
 
@@ -192,7 +194,7 @@ internal sealed class FullExtractor<T, TProgress> : IExtractWithProgressAndCance
         {
             progress.Report(_reportValue);
             yield return item;
-            await System.Threading.Tasks.Task.Yield();
+            await Task.Yield();
         }
     }
 
@@ -200,7 +202,7 @@ internal sealed class FullExtractor<T, TProgress> : IExtractWithProgressAndCance
     public async IAsyncEnumerable<T> ExtractAsync
     (
         IProgress<TProgress> progress,
-        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken token
+        [EnumeratorCancellation] CancellationToken token
     )
     {
         if (progress is null)
@@ -216,7 +218,7 @@ internal sealed class FullExtractor<T, TProgress> : IExtractWithProgressAndCance
             token.ThrowIfCancellationRequested();
             progress.Report(_reportValue);
             yield return item;
-            await System.Threading.Tasks.Task.Yield();
+            await Task.Yield();
         }
     }
 }

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -352,8 +353,8 @@ public class TestExtractorTests
     {
         var enumerator = new TrackingEnumerator<int>(new[] { 1, 2, 3 });
 
-        Assert.Same(enumerator, ((System.Collections.Generic.IEnumerable<int>)enumerator).GetEnumerator());
-        Assert.Same(enumerator, ((System.Collections.IEnumerable)enumerator).GetEnumerator());
+        Assert.Same(enumerator, ((IEnumerable<int>)enumerator).GetEnumerator());
+        Assert.Same(enumerator, ((IEnumerable)enumerator).GetEnumerator());
     }
 
     [Fact]
@@ -366,7 +367,7 @@ public class TestExtractorTests
         enumerator.MoveNext();
 
         Assert.Equal(1, enumerator.Current);
-        Assert.Equal(1, ((System.Collections.IEnumerator)enumerator).Current);
+        Assert.Equal(1, ((IEnumerator)enumerator).Current);
     }
 
 
@@ -910,10 +911,10 @@ public class TestExtractorTests
         // Returns this so TestExtractor disposes the TrackingEnumerator itself,
         // not a compiler-generated wrapper, enabling the ownership tests above.
         public IEnumerator<T> GetEnumerator() => this;
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this;
+        IEnumerator IEnumerable.GetEnumerator() => this;
 
         public T Current => _inner.Current;
-        object? System.Collections.IEnumerator.Current => ((System.Collections.IEnumerator)_inner).Current;
+        object? IEnumerator.Current => ((IEnumerator)_inner).Current;
         public bool MoveNext() => _inner.MoveNext();
         public void Reset() => _inner.Reset();
 


### PR DESCRIPTION
Clears the InspectCode **`Redundant*` long-tail** (~90 findings) that survived the earlier cleanup — the redundant usings / name-qualifiers / casts / type-args in the **TestKit / TestKit.Xunit source** + tests/examples/benchmarks that the trimmed `.DotSettings` deliberately doesn't suppress (fixable, not structural-FP).

## How
A redundancy-only `jb cleanupcode` profile (`CSRemoveCodeRedundancies` + `CSShortenReferences` + `CSOptimizeUsings`, no reformat/reorder), scoped to just the 41 flagged files.

## Safety
- **Full-matrix `dotnet build` (net462…net10.0) green.** It caught one multi-TFM hazard: cleanupcode dropped `using System;` from `AllocationBudgetContractTests.cs` (redundant on the netfx TFM where the `GC`/`Math` body is `#if NET6_0_OR_GREATER`-gated) but **required on net6+** — **reverted**; that one is a false-positive to dismiss, not remove.
- `TestKit.Xunit.Tests.Unit` (313) pass on net8.0. Behaviour-preserving.

## Scope note
ReSharper's `ShortenReferences` also normalized cref generic-arg spacing (`{T, U}` → `{T,U}`, ~20 doc-comment lines) as a side effect — cosmetic, harmless, bundled here.

## Not in this PR
The remaining ~15 non-`Redundant*` findings (`S108`, `S2326`) and the intentional patterns already dismissed per-instance (`S1994`, `S1215`, `MA0055`, `S3877`, `S3871`) — those aren't redundancies; a small follow-up can fix `S108`/`S2326` if wanted.

Targets vNext — you control whether it rides 0.23.0 (merge before #387) or starts 0.24.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
