### PR TITLE
chore: bump PackageValidation baselines to 0.23.0 (no version change)

### DIFF
--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -11,7 +11,7 @@
          recorded in CompatibilitySuppressions.xml, regenerated with
          `dotnet pack /p:GenerateCompatibilitySuppressionFile=true`. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.22.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.23.0</PackageValidationBaselineVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Contains interfaces and base classes used to build ETL applications</Description>

--- a/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
+++ b/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
@@ -7,7 +7,7 @@
          previously-published baseline to compare against; enabled from 0.22.0 onward now that the
          package has published history. Baseline tracks the last PUBLISHED version. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.22.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.23.0</PackageValidationBaselineVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Ready-made item-error policies — skip, log, and dead-letter (to a collection or a channel) — assignable to the ErrorPolicy property of Wolfgang.Etl extractors, loaders, and transformers. Built on Wolfgang.Etl.Abstractions.</Description>

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -12,7 +12,7 @@
          is live on NuGet (otherwise pack fails NU1102). Intentional breaks in a
          MAJOR bump are recorded via a generated CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.22.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.23.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit.Xunit</Title>
     <Description>Abstract xUnit contract test base classes for verifying custom ETL extractors, transformers, and loaders built on Wolfgang.Etl.Abstractions.</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -12,7 +12,7 @@
          is live on NuGet (otherwise pack fails NU1102). Intentional breaks in a
          MAJOR bump are recorded via a generated CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.22.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.23.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit</Title>
     <Description>An implementation of Extractor, Transformer and Loader for use in ETL examples and benchmarks. Built on Wolfgang.Etl.Abstractions.</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>


### PR DESCRIPTION
Post-release housekeeping: point all four `PackageValidationBaselineVersion` at the just-published **0.23.0** so the next pack validates ABI against the last release.

## Changes
- `PackageValidationBaselineVersion` **0.22.0 → 0.23.0** in Abstractions, ErrorPolicies, TestKit, TestKit.Xunit.
- **No `<Version>` change** — we're not opening a new development version yet; that bump happens when the next cycle actually starts.

## Notes
- Safe now that 0.23.0 is live on NuGet (bumping earlier would fail restore with NU1102).
- vNext PR, so the protected-file guard doesn't run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
