### PR TITLE
chore: clear redundant/dead-code InspectCode findings (tests + contract bases)

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/EtlScenarioOfT.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/EtlScenarioOfT.cs
@@ -23,8 +23,8 @@ public sealed class EtlScenario<T>
     where T : notnull
 {
     private readonly T[] _items;
-    private (int Index, System.Exception Exception, bool Skip)? _extractorFault;
-    private (int Index, System.Exception Exception, bool Skip)? _loaderFault;
+    private (int Index, Exception Exception, bool Skip)? _extractorFault;
+    private (int Index, Exception Exception, bool Skip)? _loaderFault;
     private TransformerBase<T, T, Report>? _transformer;
 
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAndCancellationAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAndCancellationAsyncContractTests.cs
@@ -204,7 +204,7 @@ public abstract class ExtractWithProgressAndCancellationAsyncContractTests<TSut,
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.ExtractAsync((IProgress<TProgress>)null!);
+            _ = sut.ExtractAsync(null!);
         });
 
         Assert.Equal("progress", ex.ParamName);
@@ -282,7 +282,7 @@ public abstract class ExtractWithProgressAndCancellationAsyncContractTests<TSut,
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.ExtractAsync((IProgress<TProgress>)null!, CancellationToken.None);
+            _ = sut.ExtractAsync(null!, CancellationToken.None);
         });
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAsyncContractTests.cs
@@ -91,7 +91,7 @@ public abstract class ExtractWithProgressAsyncContractTests<TSut, TItem, TProgre
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             // The exception is thrown when the method is called, before enumeration starts.
-            _ = sut.ExtractAsync((IProgress<TProgress>)null!);
+            _ = sut.ExtractAsync(null!);
         });
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
@@ -328,7 +328,7 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.ExtractAsync((IProgress<TProgress>)null!);
+            _ = sut.ExtractAsync(null!);
         });
 
         Assert.Equal("progress", ex.ParamName);
@@ -443,7 +443,7 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.ExtractAsync((IProgress<TProgress>)null!, CancellationToken.None);
+            _ = sut.ExtractAsync(null!, CancellationToken.None);
         });
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAndCancellationAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAndCancellationAsyncContractTests.cs
@@ -213,7 +213,7 @@ public abstract class LoadWithProgressAndCancellationAsyncContractTests<TSut, TI
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>
         (
-            () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!)
+            () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), null!)
         ).ConfigureAwait(false);
 
         Assert.Equal("progress", ex.ParamName);
@@ -292,7 +292,7 @@ public abstract class LoadWithProgressAndCancellationAsyncContractTests<TSut, TI
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>
         (
-            () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!, CancellationToken.None)
+            () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), null!, CancellationToken.None)
         ).ConfigureAwait(false);
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAsyncContractTests.cs
@@ -76,7 +76,7 @@ public abstract class LoadWithProgressAsyncContractTests<TSut, TItem, TProgress>
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>
         (
-            () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!)
+            () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), null!)
         ).ConfigureAwait(false);
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
@@ -143,7 +143,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var sut = CreateSut();
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            sut.LoadAsync((IAsyncEnumerable<TItem>)null!)).ConfigureAwait(false);
+            sut.LoadAsync(null!)).ConfigureAwait(false);
 
         Assert.Equal("items", ex.ParamName);
     }
@@ -217,7 +217,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var sut = CreateSut();
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            sut.LoadAsync((IAsyncEnumerable<TItem>)null!, CancellationToken.None)).ConfigureAwait(false);
+            sut.LoadAsync(null!, CancellationToken.None)).ConfigureAwait(false);
 
         Assert.Equal("items", ex.ParamName);
     }
@@ -338,7 +338,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var progress = new SynchronousProgress<TProgress>(_ => { });
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            sut.LoadAsync((IAsyncEnumerable<TItem>)null!, progress)).ConfigureAwait(false);
+            sut.LoadAsync(null!, progress)).ConfigureAwait(false);
 
         Assert.Equal("items", ex.ParamName);
     }
@@ -353,7 +353,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var sut = CreateSut();
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            sut.LoadAsync(CreateInputItemsAsync(), (IProgress<TProgress>)null!)).ConfigureAwait(false);
+            sut.LoadAsync(CreateInputItemsAsync(), null!)).ConfigureAwait(false);
 
         Assert.Equal("progress", ex.ParamName);
     }
@@ -473,7 +473,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var progress = new SynchronousProgress<TProgress>(_ => { });
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            sut.LoadAsync((IAsyncEnumerable<TItem>)null!, progress, CancellationToken.None)).ConfigureAwait(false);
+            sut.LoadAsync(null!, progress, CancellationToken.None)).ConfigureAwait(false);
 
         Assert.Equal("items", ex.ParamName);
     }
@@ -488,7 +488,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var sut = CreateSut();
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            sut.LoadAsync(CreateInputItemsAsync(), (IProgress<TProgress>)null!, CancellationToken.None)).ConfigureAwait(false);
+            sut.LoadAsync(CreateInputItemsAsync(), null!, CancellationToken.None)).ConfigureAwait(false);
 
         Assert.Equal("progress", ex.ParamName);
     }

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAndCancellationAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAndCancellationAsyncContractTests.cs
@@ -205,7 +205,7 @@ public abstract class TransformWithProgressAndCancellationAsyncContractTests<TSu
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!);
+            _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), null!);
         });
 
         Assert.Equal("progress", ex.ParamName);
@@ -282,7 +282,7 @@ public abstract class TransformWithProgressAndCancellationAsyncContractTests<TSu
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!, CancellationToken.None);
+            _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), null!, CancellationToken.None);
         });
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAsyncContractTests.cs
@@ -76,7 +76,7 @@ public abstract class TransformWithProgressAsyncContractTests<TSut, TItem, TProg
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!);
+            _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), null!);
         });
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
@@ -170,7 +170,7 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync((IAsyncEnumerable<TItem>)null!);
+            _ = sut.TransformAsync(null!);
         });
 
         Assert.Equal("items", ex.ParamName);
@@ -244,7 +244,7 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync((IAsyncEnumerable<TItem>)null!, CancellationToken.None);
+            _ = sut.TransformAsync(null!, CancellationToken.None);
         });
 
         Assert.Equal("items", ex.ParamName);
@@ -363,7 +363,7 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync((IAsyncEnumerable<TItem>)null!, progress);
+            _ = sut.TransformAsync(null!, progress);
         });
 
         Assert.Equal("items", ex.ParamName);
@@ -380,7 +380,7 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync(CreateInputItemsAsync(), (IProgress<TProgress>)null!);
+            _ = sut.TransformAsync(CreateInputItemsAsync(), null!);
         });
 
         Assert.Equal("progress", ex.ParamName);
@@ -496,7 +496,7 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync((IAsyncEnumerable<TItem>)null!, progress, CancellationToken.None);
+            _ = sut.TransformAsync(null!, progress, CancellationToken.None);
         });
 
         Assert.Equal("items", ex.ParamName);
@@ -513,7 +513,7 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync(CreateInputItemsAsync(), (IProgress<TProgress>)null!, CancellationToken.None);
+            _ = sut.TransformAsync(CreateInputItemsAsync(), null!, CancellationToken.None);
         });
 
         Assert.Equal("progress", ex.ParamName);

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ClockSeamTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ClockSeamTests.cs
@@ -164,7 +164,7 @@ public class ClockSeamTests
 
         protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
         {
-            await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+            await foreach (var _ in items.WithCancellation(token).ConfigureAwait(false))
             {
                 IncrementCurrentItemCount();
             }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/RetrySeamTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/RetrySeamTests.cs
@@ -240,7 +240,7 @@ public class RetrySeamTests
             SeamCallCount++;
             if (WorkerRuns == 1)
             {
-                await foreach (var item in base.WrapWorkerExecution(workerFactory, token).WithCancellation(token))
+                await foreach (var item in base.WrapWorkerExecution(workerFactory, token))
                 {
                     yield return item;
                 }
@@ -427,7 +427,7 @@ public class RetrySeamTests
             SeamCallCount++;
             if (WorkerRuns == 1)
             {
-                await foreach (var item in base.WrapWorkerExecution(workerFactory, token).WithCancellation(token))
+                await foreach (var item in base.WrapWorkerExecution(workerFactory, token))
                 {
                     yield return item;
                 }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/SystemProgressTimerTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/SystemProgressTimerTests.cs
@@ -97,12 +97,10 @@ public class SystemProgressTimerTests
     public async Task Timer_callback_fires_during_extraction()
     {
         var elapsedCount = 0;
-        IProgressTimer? capturedTimer = null;
 
         var sut = new CapturingExtractor(
             onTimerCreated: t =>
             {
-                capturedTimer = t;
                 t.Elapsed += () => Interlocked.Increment(ref elapsedCount);
             },
             intervalMs: 30,

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/AggregateErrorsTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/AggregateErrorsTests.cs
@@ -219,7 +219,7 @@ public class AggregateErrorsTests
 
         protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
         {
-            await foreach (var item in items.WithCancellation(token))
+            await foreach (var _ in items.WithCancellation(token))
             {
                 IncrementCurrentItemCount();
             }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
@@ -314,7 +314,7 @@ public class EtlPipelineCoreTests
     {
         Assert.Throws<ArgumentNullException>(() => EtlPipeline
             .Create()
-            .From<int>((IAsyncEnumerable<int>)null!));
+            .From<int>(null!));
     }
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/NullGuardOnChainedStagesTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/NullGuardOnChainedStagesTests.cs
@@ -70,7 +70,7 @@ public class NullGuardOnChainedStagesTests
     {
         Assert.Throws<ArgumentNullException>
         (
-            () => MidChainStage().Load((ILoadWithCancellationAsync<int>)null!)
+            () => MidChainStage().Load(null!)
         );
     }
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/PipelineBehaviorTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/PipelineBehaviorTests.cs
@@ -113,7 +113,7 @@ public class PipelineBehaviorTests
     public void CancelOnly_Load_when_loader_is_null_throws()
     {
         var stage = Pipeline.Extract(new BareExtractor<int>(new[] { 1 }));
-        Assert.Throws<ArgumentNullException>(() => stage.Load((ILoadWithCancellationAsync<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => stage.Load(null!));
     }
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Extractors.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Extractors.cs
@@ -199,10 +199,10 @@ internal sealed class FullExtractor<T, TProgress> : IExtractWithProgressAndCance
     }
 
 
-    public async IAsyncEnumerable<T> ExtractAsync
+    public IAsyncEnumerable<T> ExtractAsync
     (
         IProgress<TProgress> progress,
-        [EnumeratorCancellation] CancellationToken token
+        CancellationToken token
     )
     {
         if (progress is null)
@@ -210,6 +210,18 @@ internal sealed class FullExtractor<T, TProgress> : IExtractWithProgressAndCance
             throw new ArgumentNullException(nameof(progress));
         }
 
+        // Split so the null check runs eagerly at call time rather than being
+        // deferred to the first MoveNextAsync of the iterator (S4456).
+        return ExtractFullCoreAsync(progress, token);
+    }
+
+
+    private async IAsyncEnumerable<T> ExtractFullCoreAsync
+    (
+        IProgress<TProgress> progress,
+        [EnumeratorCancellation] CancellationToken token
+    )
+    {
         FullOverloadWasCalled = true;
         LastReceivedProgress = progress;
         LastReceivedToken = token;

--- a/tests/Wolfgang.Etl.TestKit.Tests.DocExamples/DocExampleCompilationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.DocExamples/DocExampleCompilationTests.cs
@@ -228,7 +228,7 @@ public sealed class DocExampleCompilationTests
         var tree = CSharpSyntaxTree.ParseText
         (
             source,
-            new CSharpParseOptions(LanguageVersion.Latest, DocumentationMode.Parse)
+            new CSharpParseOptions(LanguageVersion.Latest)
         );
 
         var docComments = tree.GetRoot()

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
@@ -28,7 +28,7 @@ public class DelayingExtractorTests
     {
         Assert.Throws<ArgumentNullException>
         (
-            () => new DelayingExtractor<int>(new[] { 1 }, (Func<int, TimeSpan>)null!)
+            () => new DelayingExtractor<int>(new[] { 1 }, null!)
         );
     }
 

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorTests.cs
@@ -757,7 +757,7 @@ public class TestExtractorTests
     {
         var ex = Assert.Throws<ArgumentNullException>
         (
-            () => new TestExtractorWithTimer((Func<int, int>)(i => i), null!)
+            () => new TestExtractorWithTimer(i => i, null!)
         );
 
         Assert.Equal("timer", ex.ParamName);
@@ -785,7 +785,7 @@ public class TestExtractorTests
         using var timer = new ManualProgressTimer();
         var ex = Assert.Throws<ArgumentOutOfRangeException>
         (
-            () => new TestExtractorWithTimer((Func<int, int>)(i => i), -1, timer)
+            () => new TestExtractorWithTimer(i => i, -1, timer)
         );
 
         Assert.Equal("count", ex.ParamName);
@@ -798,7 +798,7 @@ public class TestExtractorTests
     {
         var ex = Assert.Throws<ArgumentNullException>
         (
-            () => new TestExtractorWithTimer((Func<int, int>)(i => i), 3, null!)
+            () => new TestExtractorWithTimer(i => i, 3, null!)
         );
 
         Assert.Equal("timer", ex.ParamName);

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressAssertTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressAssertTests.cs
@@ -261,7 +261,7 @@ public class ProgressAssertTests
         var capture = new ProgressCapture<int>();
 
         Assert.Throws<ArgumentNullException>(() =>
-            ProgressAssert.FinalReportSatisfies<int>(capture, null!));
+            ProgressAssert.FinalReportSatisfies(capture, null!));
     }
 
 
@@ -331,7 +331,7 @@ public class ProgressAssertTests
         var capture = new ProgressCapture<int>();
 
         Assert.Throws<ArgumentNullException>(() =>
-            ProgressAssert.AllReportsSatisfy<int>(capture, null!));
+            ProgressAssert.AllReportsSatisfy(capture, null!));
     }
 
 

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/RetryingExtractorRetryContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/RetryingExtractorRetryContractTests.cs
@@ -25,7 +25,7 @@ public sealed class RetryingExtractorRetryContractTests
     private static async Task<RetryOutcome> DriveAsync(RetryingExtractor<int> sut)
     {
         var itemCount = 0;
-        var succeeded = false;
+        bool succeeded;
 
         try
         {


### PR DESCRIPTION
Clears the InspectCode code-scanning findings the post-0.23.0 **main** scan surfaced (67 total): fixes the genuinely-redundant/dead ones, dismisses the rest as false-positives or intentional test patterns. Fix-first per the agreed approach.

## Fixed (~43, this PR)
- **RedundantCast ×30** — removed `(IProgress<TProgress>)` / `(IAsyncEnumerable<TItem>)` casts on `null!` null-guard args, plus lambda/ctor casts. Each verified not to change overload resolution (the only alternative overloads add a non-nullable `CancellationToken`, which `null` can't bind).
- **RedundantTypeArgumentsOfMethod, RedundantNameQualifier, RedundantWithCancellation, RedundantArgumentDefaultValue, RedundantAssignment** — removed.
- **UnusedVariable / NotAccessedVariable** — discarded unused `await foreach` vars; removed a write-only `capturedTimer` (kept the `Elapsed` subscription).
- **S4456** — split the two-arg `ExtractAsync(progress, token)` test double into an eager-validating wrapper + iterator core (matches `RetryingExtractor`).

## Dismissed on the dashboard (24 — code is correct)
- **`!` after `Assert.NotNull` ×8** — required on net462/netstandard2.0 (xUnit 2.9 lacks `[NotNull]`); redundant only on net8.0+.
- **`using` ×5 in `AllocationRegressionTests`** — whole file is inside `#if NET6_0_OR_GREATER`; needed by the net6+ body.
- **S6966 ×2** — wants `CancelAsync`, which is net8+ only; library targets down to net462.
- **MA0055 ×3** — `FinalizationSuppressionTests` finalizers are the subject under test.
- **S3877 ×2** — `ThrowingDisposable*` doubles throw from `Dispose` on purpose.
- **S3871 ×1** — internal test-double sentinel exception, never crosses an assembly boundary.
- **GenericEnumeratorNotDisposed ×2 + its RedundantCast ×1** — casts assert both interface `GetEnumerator`s return self.

## Verification
- Full-matrix Release build (net462…net10, warnings-as-errors): **green**.
- **1072** net8.0 tests pass (contract tests assert *which* overload is called, so a silent binding change would fail them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
