### PR TITLE
chore: pin build deps by hash — protected-file portion (split of #394)

### DIFF
--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -54,7 +54,8 @@ jobs:
           python-version: '3.13'
 
       - name: Install zizmor
-        run: pip install zizmor==1.26.1
+        # Hash-pinned install (OSSF Scorecard Pinned-Dependencies: pip not pinned by hash).
+        run: pip install --require-hashes -r .github/zizmor-requirements.txt
 
       - name: Run zizmor
         # --format=github emits inline PR annotations; a high-severity finding

--- a/.github/zizmor-requirements.txt
+++ b/.github/zizmor-requirements.txt
@@ -1,0 +1,14 @@
+# Hash-pinned for `pip install -r requirements.txt --require-hashes`.
+# zizmor has no Python dependencies (self-contained Rust wheel).
+zizmor==1.26.1 \
+    --hash=sha256:7ea21ca959c8e888de238fee81d73a1fdf89a82067eac75b8f1acdbd23e2eeaf \
+    --hash=sha256:78083b495593f8b0b9dec14036a0836a5afcddda8a40738336ff4e399476b741 \
+    --hash=sha256:bb7ebbe565a3742eb49a590352127ad549bb122b9b4ff9424ebab7525fa3b6b6 \
+    --hash=sha256:d3049010b6bd6f849413b6d20c28e0c677b90e0a5b2bc73cbee7f7bd86dc5828 \
+    --hash=sha256:6a958d8a0941d7e1d0de8436670b5cb7fc64c8028b4d16e3f519ccc77f953cef \
+    --hash=sha256:d2744cdf944436ca7a009ae8b626a017a40381ec990216abd6cf6b8beb23323a \
+    --hash=sha256:44099f426af9da750ff9f548a0084e11d7d83e0158fe1a2778672398d728efdd \
+    --hash=sha256:8313cc264dec792f00a7328eb7c8e89e7d62d54f950fc897d1e6a5a6e5762203 \
+    --hash=sha256:c96d7787d69fb298eae939e00dfdf7f534d7dfbd9cc17ab442c0650a56851415 \
+    --hash=sha256:0a05acf6068609fb6df3b137276cf18a686226a1e0e207941cb34a85929f16cf \
+    --hash=sha256:0c2cc575007a4db99d89d5acc6120cfa7b61504bc2394c3b50af348c73f1916e

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,10 @@
     
     <!-- Treat warnings as errors in Release builds -->
     <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
+
+    <!-- Pin NuGet dependencies by content hash via committed packages.lock.json
+         (OSSF Scorecard Pinned-Dependencies: "nugetCommand not pinned by hash"). -->
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Protected-file split of #394.** #394 mixed protected files with the 39 non-protected lockfiles, so the `Detect .NET Projects` guard would block it. This PR carries only the protected portion, to be **admin-bypass merged**; #394 then becomes lockfiles-only and passes normal CI.

## Files (protected trio)
- `Directory.Build.props` — `RestorePackagesWithLockFile=true`
- `.github/workflows/workflow-security.yaml` — `pip install --require-hashes -r .github/zizmor-requirements.txt`
- `.github/zizmor-requirements.txt` — zizmor 1.26.1 + all platform hashes (kept with the workflow so main never references a missing file)

## Sequencing
1. Admin-bypass merge this PR to main.
2. Merge main → #394's branch (`chore/scorecard-hardening`) so it drops these files from its diff.
3. #394 (39 lockfiles) then merges via normal CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
