### PR TITLE
fix: mark examples/ and benchmarks/ non-packable (#362)

### DIFF
--- a/benchmarks/Directory.Build.props
+++ b/benchmarks/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <!-- Chain to the repo-root Directory.Build.props (analyzers, nullable, etc.),
+       then mark this whole tree non-packable so `dotnet pack` on the solution
+       never emits demo/benchmark nupkgs alongside the four real packages (#362). -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <!-- Chain to the repo-root Directory.Build.props (analyzers, nullable, etc.),
+       then mark this whole tree non-packable so `dotnet pack` on the solution
+       never emits demo/benchmark nupkgs alongside the four real packages (#362). -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Closes #362.

`dotnet pack ETL-Abstractions.sln -c Release` was emitting `Example*.nupkg` and `Wolfgang.Etl.Abstractions.Benchmarks.nupkg` alongside the four real packages — demo/benchmark noise that a whole-solution pack in the release pipeline could push to nuget.org.

## Fix
Directory-scoped `Directory.Build.props` in `examples/` and `benchmarks/` that chain to the repo-root props (so analyzers/nullable/etc. still apply) and set `IsPackable=false`. Covers all 18 example projects + the benchmark via the nearest-props rule — no per-csproj sprawl.

Nested `Directory.Build.props` isn't caught by the `Detect .NET Projects` guard (it exact-matches only the root path), so this is a normal-CI PR.

## Verification
`dotnet pack` now emits exactly `Abstractions`, `ErrorPolicies`, `TestKit`, `TestKit.Xunit` — zero example/benchmark leakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
