### PR TITLE
fix: run the Coyote concurrency tests reliably (#364, #365)

### DIFF
--- a/.github/workflows/coyote.yaml
+++ b/.github/workflows/coyote.yaml
@@ -25,6 +25,7 @@ on:
     paths:
       - 'src/**/*.cs'
       - 'tests/Wolfgang.Etl.Abstractions.Tests.Concurrency/**'
+      - 'tests/Wolfgang.Etl.TestKit.Tests.Concurrency/**'
       - '.github/workflows/coyote.yaml'
   schedule:
     - cron: '0 5 * * 1' # weekly Monday 05:00 UTC
@@ -78,18 +79,34 @@ jobs:
           dll="bin/Release/net8.0/Wolfgang.Etl.Abstractions.Tests.Concurrency.dll"
           methods=(
             Concurrent_item_count_increments_never_lose_an_update
-            # Dispose_racing_enumeration_never_deadlocks is DISABLED (#364).
-            # Coyote 1.7.11 throws a NullReferenceException inside its own
-            # CoyoteRuntime.IsTaskUncontrolled when it meets the
-            # ConfiguredCancelableAsyncEnumerable awaiter that the ConfigureAwait(false)
-            # fix (#363) introduced in ExtractorBase.ExtractWithResetAsync. It is an
-            # instrumentation crash, not a race we found: "Found 1 bug" on iteration #1,
-            # 1 execution path explored, 0.096 sec. Coyote is dormant (1.7.11 is the
-            # newest on nuget.org; last upstream commit 2024-12-11), so there is no
-            # version to upgrade to. Re-enable via #364.
+            # Re-enabled (#364): the ExtractorBase/TransformerBase base classes now use a
+            # manual enumerator loop instead of `await foreach (... .ConfigureAwait(false))`,
+            # so the awaited type is a ConfiguredValueTaskAwaitable that Coyote 1.7.11 can
+            # classify — no more NullReferenceException in CoyoteRuntime.IsTaskUncontrolled.
+            Dispose_racing_enumeration_never_deadlocks
           )
           for m in "${methods[@]}"; do
             echo "::group::coyote test $m ($iterations iterations)"
             coyote test "$dll" --method "$m" --iterations "$iterations"
             echo "::endgroup::"
           done
+
+      # --- TestKit concurrency project (#365) ------------------------------------
+      # Unlike the Abstractions project (which exposes [Coyote Test] entry points run
+      # via `coyote test --method`), the TestKit scenarios run Coyote's TestingEngine
+      # programmatically inside xunit [Fact]s that early-return unless COYOTE_REWRITTEN=1.
+      # So the flow is: build -> `coyote rewrite` the assembly -> `dotnet test` with the
+      # env var set, which executes the engine against the rewritten scenarios. These
+      # only pass because of the base-class fix in #364.
+      - name: Build the TestKit concurrency project (Release)
+        run: dotnet build "tests/Wolfgang.Etl.TestKit.Tests.Concurrency/Wolfgang.Etl.TestKit.Tests.Concurrency.csproj" -c Release
+
+      - name: Rewrite the TestKit concurrency assembly
+        working-directory: tests/Wolfgang.Etl.TestKit.Tests.Concurrency
+        run: coyote rewrite rewrite.coyote.json
+
+      - name: Run the TestKit concurrency tests (rewritten)
+        working-directory: tests/Wolfgang.Etl.TestKit.Tests.Concurrency
+        env:
+          COYOTE_REWRITTEN: "1"
+        run: dotnet test -c Release --no-build

--- a/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/ExtractorBase.cs
@@ -320,9 +320,22 @@ public abstract class ExtractorBase<TSource, TProgress>
     {
         ResetRunState();
 
-        await foreach (var item in WrapWorkerExecution(ExtractWorkerAsync, token).ConfigureAwait(false))
+        // Manual enumerator loop rather than `await foreach` (#364): the awaited type here is a
+        // ConfiguredCancelableAsyncEnumerable, which Microsoft.Coyote 1.7.11 cannot classify and
+        // which derails the controlled scheduler. Awaiting MoveNextAsync().ConfigureAwait(false)
+        // produces a ConfiguredValueTaskAwaitable the scheduler does control. Behaviour is
+        // identical to the foreach.
+        var enumerator = WrapWorkerExecution(ExtractWorkerAsync, token).GetAsyncEnumerator(token);
+        try
         {
-            yield return item;
+            while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+            {
+                yield return enumerator.Current;
+            }
+        }
+        finally
+        {
+            await enumerator.DisposeAsync().ConfigureAwait(false);
         }
     }
 
@@ -338,9 +351,18 @@ public abstract class ExtractorBase<TSource, TProgress>
 
         try
         {
-            await foreach (var item in WrapWorkerExecution(ExtractWorkerAsync, token).ConfigureAwait(false))
+            // Manual enumerator loop rather than `await foreach` — see ExtractWithResetAsync (#364).
+            var enumerator = WrapWorkerExecution(ExtractWorkerAsync, token).GetAsyncEnumerator(token);
+            try
             {
-                yield return item;
+                while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+                {
+                    yield return enumerator.Current;
+                }
+            }
+            finally
+            {
+                await enumerator.DisposeAsync().ConfigureAwait(false);
             }
         }
         finally

--- a/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
+++ b/src/Wolfgang.Etl.Abstractions/TransformerBase.cs
@@ -328,9 +328,20 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
     {
         ResetRunState();
 
-        await foreach (var item in WrapWorkerExecution(ct => TransformWorkerAsync(items, ct), token).ConfigureAwait(false))
+        // Manual enumerator loop rather than `await foreach` (#364): keeps the ConfigureAwait(false)
+        // semantics while producing a ConfiguredValueTaskAwaitable that Microsoft.Coyote 1.7.11 can
+        // control (it cannot classify the ConfiguredCancelableAsyncEnumerable the foreach awaits).
+        var enumerator = WrapWorkerExecution(ct => TransformWorkerAsync(items, ct), token).GetAsyncEnumerator(token);
+        try
         {
-            yield return item;
+            while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+            {
+                yield return enumerator.Current;
+            }
+        }
+        finally
+        {
+            await enumerator.DisposeAsync().ConfigureAwait(false);
         }
     }
 
@@ -346,9 +357,18 @@ public abstract class TransformerBase<TSource, TDestination, TProgress>
 
         try
         {
-            await foreach (var item in WrapWorkerExecution(ct => TransformWorkerAsync(items, ct), token).ConfigureAwait(false))
+            // Manual enumerator loop rather than `await foreach` — see TransformWithResetAsync (#364).
+            var enumerator = WrapWorkerExecution(ct => TransformWorkerAsync(items, ct), token).GetAsyncEnumerator(token);
+            try
             {
-                yield return item;
+                while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+                {
+                    yield return enumerator.Current;
+                }
+            }
+            finally
+            {
+                await enumerator.DisposeAsync().ConfigureAwait(false);
             }
         }
         finally


### PR DESCRIPTION
Closes #364, Closes #365 — makes the Coyote systematic-concurrency tests actually run and pass.

## #364 — base-class fix
`ExtractorBase`/`TransformerBase` enumerated the worker with `await foreach (WrapWorkerExecution(...).ConfigureAwait(false))`. The awaited `ConfiguredCancelableAsyncEnumerable` is something **Microsoft.Coyote 1.7.11 cannot classify** — its controlled scheduler derailed (originally an NRE in `IsTaskUncontrolled`; now a *false deadlock*). Replaced the **4 sites** (reset + progress paths in both base classes) with a manual `GetAsyncEnumerator` / `MoveNextAsync().ConfigureAwait(false)` loop. Same `ConfigureAwait(false)` semantics, but the awaiter is a `ConfiguredValueTaskAwaitable` Coyote controls. Behaviour is identical.

Re-enabled `Dispose_racing_enumeration_never_deadlocks` in `coyote.yaml`.

## #365 — wire the TestKit project in
The TestKit concurrency project never executed in CI (nothing set `COYOTE_REWRITTEN`). It uses a different model from the Abstractions project — Coyote's `TestingEngine` runs *programmatically inside `[Fact]`s* rather than via `coyote test --method` — so `coyote.yaml` now builds it, `coyote rewrite`s it, and runs it via `dotnet test` with `COYOTE_REWRITTEN=1`.

## Verification (Coyote 1.7.11, locally)
- **Abstractions:** both methods **0 bugs**, exploring **340–370 unique interleavings**. `Dispose_racing…` went **deadlock → clean** — proof the test is load-bearing (it responds to a real code change), not vacuously green.
- **TestKit:** both `[Fact]`s **pass** under `dotnet test` + `COYOTE_REWRITTEN=1` — and only because of the #364 base-class fix (without it they crash/deadlock).
- **Full-matrix Release build** (net462…net10, warnings-as-errors) green; **1072** net8 tests pass — no behaviour change from the enumerator refactor.

Note: the injected-race check on the *counter* test isn't catchable by Coyote (it preempts at await points, not mid-statement, so a non-atomic `++` is invisible to it) — that's expected; the deadlock→clean transition is the load-bearing evidence instead.

> ⚠️ `coyote.yaml` is a protected workflow file — on the eventual vNext→main merge this needs admin-bypass, as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
