### PR TITLE
fix: absolute-floor benchmark-regression gate (#367)

### DIFF
--- a/.github/workflows/pr-benchmarks.yaml
+++ b/.github/workflows/pr-benchmarks.yaml
@@ -104,6 +104,28 @@ jobs:
           comment-always: true
           comment-on-alert: true
           # 150% = a metric 1.5x worse than baseline. Deliberately loose because
-          # GitHub-hosted runners are noisy; tighten once the noise floor settles.
+          # GitHub-hosted runners are noisy. The action posts the comparison comment
+          # but does NOT fail the job (fail-on-alert:false) — a ratio-only gate
+          # false-positives on sub-millisecond benchmarks (#367). The absolute-floor
+          # gate below is the real pass/fail signal.
           alert-threshold: '150%'
-          fail-on-alert: true
+          fail-on-alert: false
+
+      - name: Fetch the gh-pages benchmark baseline
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin gh-pages
+          git show FETCH_HEAD:dev/bench/data.js > "$RUNNER_TEMP/baseline-data.js"
+
+      - name: Absolute-floor regression gate (#367)
+        # A ratio-only gate false-positives on sub-millisecond benchmarks on noisy
+        # shared runners (it blocked 0.22.0 on a 17 us blip). Fail only when a
+        # benchmark grew by BOTH >= 1.50x AND >= 50,000 ns (50 us): runner noise on
+        # a ~30 us benchmark clears the floor, but a genuine per-item regression —
+        # which also moves the 100,000-record cases by well over 50 us — still fails.
+        run: |
+          python3 benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/scripts/regression-gate.py \
+            "${{ steps.locate.outputs.report }}" \
+            "$RUNNER_TEMP/baseline-data.js" \
+            1.50 \
+            50000

--- a/benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/scripts/regression-gate.py
+++ b/benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/scripts/regression-gate.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Absolute-floor benchmark-regression gate (#367).
+
+The github-action-benchmark alert is ratio-only, so the smallest (sub-millisecond)
+benchmarks trip a 1.50x ratio on runner noise alone and block releases — the
+opposite of what the gate is for. A regression is only real if it is BOTH
+ratio-significant AND materially large in absolute terms, so this gate fails only
+when a benchmark's mean has grown by at least `ratio` x AND by at least `floor_ns`
+nanoseconds. A 17 us noise blip on a 30 us benchmark clears the floor check; a
+genuine per-item regression (which shows up at the large record counts too) does
+not.
+
+Usage:
+    regression-gate.py <current-bdn-report.json> <baseline-data.js> <ratio> <floor_ns>
+
+Exit codes: 0 = no real regression, 1 = at least one benchmark regressed past both
+thresholds, 2 = usage/parse error.
+"""
+import json
+import sys
+
+
+def load_current(path):
+    """BDN JSON report -> {full_name: mean_ns}."""
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    return {b["FullName"]: float(b["Statistics"]["Mean"]) for b in data.get("Benchmarks", [])}
+
+
+def load_baseline(path):
+    """gh-pages data.js (window.BENCHMARK_DATA = {...};) -> {name: value_ns} for the latest entry."""
+    with open(path, encoding="utf-8") as f:
+        text = f.read().strip()
+    prefix = "window.BENCHMARK_DATA"
+    if text.startswith(prefix):
+        text = text[text.index("=", len(prefix)) + 1:]
+    text = text.strip().rstrip(";").strip()
+    data = json.loads(text)
+    entries = data["entries"]["BenchmarkDotNet"]
+    latest = entries[-1]["benches"]
+    return {b["name"]: float(b["value"]) for b in latest}
+
+
+def main(argv):
+    if len(argv) != 5:
+        print(__doc__)
+        return 2
+    current = load_current(argv[1])
+    baseline = load_baseline(argv[2])
+    ratio_threshold = float(argv[3])
+    floor_ns = float(argv[4])
+
+    regressions = []
+    print(f"Gate: fail only if ratio >= {ratio_threshold:.2f}x AND abs delta >= {floor_ns:,.0f} ns\n")
+    print(f"{'benchmark':<70} {'current':>14} {'baseline':>14} {'ratio':>7} {'delta ns':>14}")
+    for name, cur in sorted(current.items()):
+        base = baseline.get(name)
+        if base is None or base <= 0:
+            continue
+        ratio = cur / base
+        delta = cur - base
+        flag = ""
+        if ratio >= ratio_threshold and delta >= floor_ns:
+            flag = "  <-- REGRESSION (ratio AND floor)"
+            regressions.append((name, ratio, delta))
+        elif ratio >= ratio_threshold:
+            flag = "  (ratio only - under floor, treated as noise)"
+        short = name.rsplit(".", 1)[-1]
+        print(f"{short:<70} {cur:>14,.0f} {base:>14,.0f} {ratio:>6.2f}x {delta:>14,.0f}{flag}")
+
+    print()
+    if regressions:
+        print(f"::error::{len(regressions)} benchmark(s) regressed past BOTH the ratio and the absolute floor.")
+        return 1
+    print("No benchmark cleared both the ratio and the absolute floor - gate passes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Closes #367.

The BDN delta gate was **ratio-only (1.50x, no absolute floor)**, so the smallest sub-millisecond benchmarks tripped it on shared-runner noise — it blocked 0.22.0 on a 17 us blip.

## Fix
`github-action-benchmark` can't do absolute floors, so it now runs **comment-only** (`fail-on-alert: false`) and a committed gate script is the real signal: a benchmark fails **only when its mean grew by BOTH ≥ 1.50x AND ≥ 50,000 ns (50 us)**. Runner noise on a ~30 us benchmark clears the floor; a genuine per-item regression — which also moves the 100,000-record cases by well over 50 us — still fails.

- `pr-benchmarks.yaml`: `fail-on-alert: false`; new steps fetch the gh-pages baseline and run the gate.
- `scripts/regression-gate.py`: ratio-AND-floor comparison, documented floor, prints a table.

## Verification (locally, against the issue's exact table)
| scenario | result |
|---|---|
| #357 noise: `NoProgress@1000` up **1.53x / +16,752 ns** | **PASS** (under floor → noise) |
| genuine +16.75 ns/item regression | **FAIL** on `NoProgress@100000` (**+1,675,000 ns, 1.54x** — clears both) |

Meets all three acceptance criteria: noise-scale moves pass, genuine per-item regressions still fail (at 100k), and the floor is documented next to the threshold.

> ⚠️ `pr-benchmarks.yaml` is a protected workflow file — admin-bypass on the eventual vNext→main merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
