### PR TITLE
Release 0.23.1

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -85,6 +85,12 @@ jobs:
           }' "${reports[@]}" > benchmarks-result.json
           echo "report=benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
 
+      - name: Reset build-time lockfile churn before the gh-pages switch
+        # `dotnet restore`/`build` above can rewrite packages.lock.json (RestorePackagesWithLockFile,
+        # #394). The publish action below runs `git switch gh-pages`, which aborts on a dirty tree.
+        # Revert tracked-file churn; the untracked benchmark outputs are preserved.
+        run: git checkout -- .
+
       - name: Publish chart to gh-pages
         # Pinned to v1.22.1 commit per repo convention (third-party actions
         # publishing to gh-pages are pinned by SHA, not mutable tag).

--- a/.github/workflows/pr-benchmarks.yaml
+++ b/.github/workflows/pr-benchmarks.yaml
@@ -104,6 +104,28 @@ jobs:
           comment-always: true
           comment-on-alert: true
           # 150% = a metric 1.5x worse than baseline. Deliberately loose because
-          # GitHub-hosted runners are noisy; tighten once the noise floor settles.
+          # GitHub-hosted runners are noisy. The action posts the comparison comment
+          # but does NOT fail the job (fail-on-alert:false) — a ratio-only gate
+          # false-positives on sub-millisecond benchmarks (#367). The absolute-floor
+          # gate below is the real pass/fail signal.
           alert-threshold: '150%'
-          fail-on-alert: true
+          fail-on-alert: false
+
+      - name: Fetch the gh-pages benchmark baseline
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin gh-pages
+          git show FETCH_HEAD:dev/bench/data.js > "$RUNNER_TEMP/baseline-data.js"
+
+      - name: Absolute-floor regression gate (#367)
+        # A ratio-only gate false-positives on sub-millisecond benchmarks on noisy
+        # shared runners (it blocked 0.22.0 on a 17 us blip). Fail only when a
+        # benchmark grew by BOTH >= 1.50x AND >= 50,000 ns (50 us): runner noise on
+        # a ~30 us benchmark clears the floor, but a genuine per-item regression —
+        # which also moves the 100,000-record cases by well over 50 us — still fails.
+        run: |
+          python3 benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/scripts/regression-gate.py \
+            "${{ steps.locate.outputs.report }}" \
+            "$RUNNER_TEMP/baseline-data.js" \
+            1.50 \
+            50000

--- a/.github/workflows/pr-benchmarks.yaml
+++ b/.github/workflows/pr-benchmarks.yaml
@@ -86,6 +86,13 @@ jobs:
           }' "${reports[@]}" > benchmarks-result.json
           echo "report=benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
 
+      - name: Reset build-time lockfile churn before the gh-pages switch
+        # `dotnet restore`/`build` above can rewrite packages.lock.json (RestorePackagesWithLockFile,
+        # #394). The compare action below runs `git switch gh-pages`, which aborts on a dirty tree.
+        # Revert tracked-file churn; the untracked benchmark outputs (benchmarks-result.json,
+        # BenchmarkDotNet.Artifacts/) are preserved.
+        run: git checkout -- .
+
       - name: Compare against baseline & comment
         # Same action + SHA pin as benchmarks.yaml. Compares the PR result against
         # the gh-pages baseline (latest main data point) WITHOUT pushing:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.23.1] - 2026-08-16
+
+### Changed
+
+- `dotnet pack` on the solution no longer emits demo/benchmark packages (`Example*.nupkg`,
+  `Wolfgang.Etl.Abstractions.Benchmarks.nupkg`) — the `examples/` and `benchmarks/` trees are marked
+  non-packable (#362). No change to the four shipped packages.
+
+### Security
+
+- **Reproducible, hash-pinned dependency restore (#394):** `RestorePackagesWithLockFile` is enabled and
+  `packages.lock.json` is committed for every project, so `dotnet restore` validates the full dependency
+  graph by content hash (CI restores in locked mode). Clears the OSSF Scorecard "nugetCommand not pinned
+  by hash" findings.
+- **Pinned SAST/lint tooling (#395):** the Semgrep workflow runs from a digest-pinned container and the
+  workflow-security lint installs zizmor via `--require-hashes`, removing unpinned `pip install`s.
+
+### Internal
+
+- Test-code hardening: test assemblies are now instrumented for coverage (all unit projects at 100% line
+  coverage, #386), the TestKit fault-injection doubles' mutation score raised from 76% to ~99% (#346),
+  the per-PR benchmark gate gained an absolute-delta floor to stop sub-millisecond false positives (#367),
+  and redundant-code analyzer findings were cleared across the test/contract-base code (#393). No change
+  to the shipped public API.
+
 ## [0.23.0] - 2026-08-15
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -76,7 +76,7 @@
        is the correct fix: PublicAPI tracking does not apply to non-shipped
        assemblies. -->
   <ItemGroup Condition="Exists('PublicAPI.Shipped.txt')">
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" Condition="Exists('PublicAPI.Shipped.txt') or Exists('PublicAPI.Unshipped.txt')">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -100,7 +100,7 @@
     <!-- Single source of truth for the package version. All four packages are lockstep-versioned
          with the repository; bump this one value per release. (Per-csproj <Version> is intentionally
          absent so the versions can never drift out of sync.) -->
-    <Version>0.23.0</Version>
+    <Version>0.23.1</Version>
     <!-- AssemblyVersion is pinned to a fixed binding-stability baseline so consumers do not need to
          recompile / add binding redirects on every minor/patch bump — bump only on a deliberate
          breaking API change. FileVersion (and the auto-derived InformationalVersion) carry the actual

--- a/benchmarks/Directory.Build.props
+++ b/benchmarks/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <!-- Chain to the repo-root Directory.Build.props (analyzers, nullable, etc.),
+       then mark this whole tree non-packable so `dotnet pack` on the solution
+       never emits demo/benchmark nupkgs alongside the four real packages (#362). -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/scripts/regression-gate.py
+++ b/benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/scripts/regression-gate.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Absolute-floor benchmark-regression gate (#367).
+
+The github-action-benchmark alert is ratio-only, so the smallest (sub-millisecond)
+benchmarks trip a 1.50x ratio on runner noise alone and block releases — the
+opposite of what the gate is for. A regression is only real if it is BOTH
+ratio-significant AND materially large in absolute terms, so this gate fails only
+when a benchmark's mean has grown by at least `ratio` x AND by at least `floor_ns`
+nanoseconds. A 17 us noise blip on a 30 us benchmark clears the floor check; a
+genuine per-item regression (which shows up at the large record counts too) does
+not.
+
+Usage:
+    regression-gate.py <current-bdn-report.json> <baseline-data.js> <ratio> <floor_ns>
+
+Exit codes: 0 = no real regression, 1 = at least one benchmark regressed past both
+thresholds, 2 = usage/parse error.
+"""
+import json
+import sys
+
+
+def load_current(path):
+    """BDN JSON report -> {full_name: mean_ns}."""
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    return {b["FullName"]: float(b["Statistics"]["Mean"]) for b in data.get("Benchmarks", [])}
+
+
+def load_baseline(path):
+    """gh-pages data.js (window.BENCHMARK_DATA = {...};) -> {name: value_ns} for the latest entry."""
+    with open(path, encoding="utf-8") as f:
+        text = f.read().strip()
+    prefix = "window.BENCHMARK_DATA"
+    if text.startswith(prefix):
+        text = text[text.index("=", len(prefix)) + 1:]
+    text = text.strip().rstrip(";").strip()
+    data = json.loads(text)
+    entries = data["entries"]["BenchmarkDotNet"]
+    latest = entries[-1]["benches"]
+    return {b["name"]: float(b["value"]) for b in latest}
+
+
+def main(argv):
+    if len(argv) != 5:
+        print(__doc__)
+        return 2
+    current = load_current(argv[1])
+    baseline = load_baseline(argv[2])
+    ratio_threshold = float(argv[3])
+    floor_ns = float(argv[4])
+
+    regressions = []
+    print(f"Gate: fail only if ratio >= {ratio_threshold:.2f}x AND abs delta >= {floor_ns:,.0f} ns\n")
+    print(f"{'benchmark':<70} {'current':>14} {'baseline':>14} {'ratio':>7} {'delta ns':>14}")
+    for name, cur in sorted(current.items()):
+        base = baseline.get(name)
+        if base is None or base <= 0:
+            continue
+        ratio = cur / base
+        delta = cur - base
+        flag = ""
+        if ratio >= ratio_threshold and delta >= floor_ns:
+            flag = "  <-- REGRESSION (ratio AND floor)"
+            regressions.append((name, ratio, delta))
+        elif ratio >= ratio_threshold:
+            flag = "  (ratio only - under floor, treated as noise)"
+        short = name.rsplit(".", 1)[-1]
+        print(f"{short:<70} {cur:>14,.0f} {base:>14,.0f} {ratio:>6.2f}x {delta:>14,.0f}{flag}")
+
+    print()
+    if regressions:
+        print(f"::error::{len(regressions)} benchmark(s) regressed past BOTH the ratio and the absolute floor.")
+        return 1
+    print("No benchmark cleared both the ratio and the absolute floor - gate passes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -5,7 +5,12 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <ExcludeByFile>**/bin/**/*.cs;**/obj/**/*.cs</ExcludeByFile>
+          <IncludeTestAssembly>true</IncludeTestAssembly>
+          <!-- Exclude the SDK-injected test-host entry point (Microsoft.NET.Test.Sdk's
+               generated Main). It lives in the NuGet cache, is regenerated each build,
+               is never executed under the VSTest host, and can't carry an attribute —
+               so it's a permanent 1-line gap in every test assembly (#386). -->
+          <ExcludeByFile>**/bin/**/*.cs;**/obj/**/*.cs;**/Microsoft.NET.Test.Sdk.Program.cs</ExcludeByFile>
           <ExcludeByAttribute>ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <!-- Chain to the repo-root Directory.Build.props (analyzers, nullable, etc.),
+       then mark this whole tree non-packable so `dotnet pack` on the solution
+       never emits demo/benchmark nupkgs alongside the four real packages (#362). -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Wolfgang.Etl.TestKit.Xunit/EtlScenarioOfT.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/EtlScenarioOfT.cs
@@ -23,8 +23,8 @@ public sealed class EtlScenario<T>
     where T : notnull
 {
     private readonly T[] _items;
-    private (int Index, System.Exception Exception, bool Skip)? _extractorFault;
-    private (int Index, System.Exception Exception, bool Skip)? _loaderFault;
+    private (int Index, Exception Exception, bool Skip)? _extractorFault;
+    private (int Index, Exception Exception, bool Skip)? _loaderFault;
     private TransformerBase<T, T, Report>? _transformer;
 
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAndCancellationAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAndCancellationAsyncContractTests.cs
@@ -204,7 +204,7 @@ public abstract class ExtractWithProgressAndCancellationAsyncContractTests<TSut,
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.ExtractAsync((IProgress<TProgress>)null!);
+            _ = sut.ExtractAsync(null!);
         });
 
         Assert.Equal("progress", ex.ParamName);
@@ -282,7 +282,7 @@ public abstract class ExtractWithProgressAndCancellationAsyncContractTests<TSut,
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.ExtractAsync((IProgress<TProgress>)null!, CancellationToken.None);
+            _ = sut.ExtractAsync(null!, CancellationToken.None);
         });
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAsyncContractTests.cs
@@ -91,7 +91,7 @@ public abstract class ExtractWithProgressAsyncContractTests<TSut, TItem, TProgre
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             // The exception is thrown when the method is called, before enumeration starts.
-            _ = sut.ExtractAsync((IProgress<TProgress>)null!);
+            _ = sut.ExtractAsync(null!);
         });
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
@@ -328,7 +328,7 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.ExtractAsync((IProgress<TProgress>)null!);
+            _ = sut.ExtractAsync(null!);
         });
 
         Assert.Equal("progress", ex.ParamName);
@@ -443,7 +443,7 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.ExtractAsync((IProgress<TProgress>)null!, CancellationToken.None);
+            _ = sut.ExtractAsync(null!, CancellationToken.None);
         });
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAndCancellationAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAndCancellationAsyncContractTests.cs
@@ -213,7 +213,7 @@ public abstract class LoadWithProgressAndCancellationAsyncContractTests<TSut, TI
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>
         (
-            () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!)
+            () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), null!)
         ).ConfigureAwait(false);
 
         Assert.Equal("progress", ex.ParamName);
@@ -292,7 +292,7 @@ public abstract class LoadWithProgressAndCancellationAsyncContractTests<TSut, TI
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>
         (
-            () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!, CancellationToken.None)
+            () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), null!, CancellationToken.None)
         ).ConfigureAwait(false);
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAsyncContractTests.cs
@@ -76,7 +76,7 @@ public abstract class LoadWithProgressAsyncContractTests<TSut, TItem, TProgress>
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>
         (
-            () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!)
+            () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), null!)
         ).ConfigureAwait(false);
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
@@ -143,7 +143,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var sut = CreateSut();
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            sut.LoadAsync((IAsyncEnumerable<TItem>)null!)).ConfigureAwait(false);
+            sut.LoadAsync(null!)).ConfigureAwait(false);
 
         Assert.Equal("items", ex.ParamName);
     }
@@ -217,7 +217,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var sut = CreateSut();
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            sut.LoadAsync((IAsyncEnumerable<TItem>)null!, CancellationToken.None)).ConfigureAwait(false);
+            sut.LoadAsync(null!, CancellationToken.None)).ConfigureAwait(false);
 
         Assert.Equal("items", ex.ParamName);
     }
@@ -338,7 +338,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var progress = new SynchronousProgress<TProgress>(_ => { });
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            sut.LoadAsync((IAsyncEnumerable<TItem>)null!, progress)).ConfigureAwait(false);
+            sut.LoadAsync(null!, progress)).ConfigureAwait(false);
 
         Assert.Equal("items", ex.ParamName);
     }
@@ -353,7 +353,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var sut = CreateSut();
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            sut.LoadAsync(CreateInputItemsAsync(), (IProgress<TProgress>)null!)).ConfigureAwait(false);
+            sut.LoadAsync(CreateInputItemsAsync(), null!)).ConfigureAwait(false);
 
         Assert.Equal("progress", ex.ParamName);
     }
@@ -473,7 +473,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var progress = new SynchronousProgress<TProgress>(_ => { });
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            sut.LoadAsync((IAsyncEnumerable<TItem>)null!, progress, CancellationToken.None)).ConfigureAwait(false);
+            sut.LoadAsync(null!, progress, CancellationToken.None)).ConfigureAwait(false);
 
         Assert.Equal("items", ex.ParamName);
     }
@@ -488,7 +488,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var sut = CreateSut();
 
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            sut.LoadAsync(CreateInputItemsAsync(), (IProgress<TProgress>)null!, CancellationToken.None)).ConfigureAwait(false);
+            sut.LoadAsync(CreateInputItemsAsync(), null!, CancellationToken.None)).ConfigureAwait(false);
 
         Assert.Equal("progress", ex.ParamName);
     }

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAndCancellationAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAndCancellationAsyncContractTests.cs
@@ -205,7 +205,7 @@ public abstract class TransformWithProgressAndCancellationAsyncContractTests<TSu
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!);
+            _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), null!);
         });
 
         Assert.Equal("progress", ex.ParamName);
@@ -282,7 +282,7 @@ public abstract class TransformWithProgressAndCancellationAsyncContractTests<TSu
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!, CancellationToken.None);
+            _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), null!, CancellationToken.None);
         });
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAsyncContractTests.cs
@@ -76,7 +76,7 @@ public abstract class TransformWithProgressAsyncContractTests<TSut, TItem, TProg
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!);
+            _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), null!);
         });
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
@@ -170,7 +170,7 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync((IAsyncEnumerable<TItem>)null!);
+            _ = sut.TransformAsync(null!);
         });
 
         Assert.Equal("items", ex.ParamName);
@@ -244,7 +244,7 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync((IAsyncEnumerable<TItem>)null!, CancellationToken.None);
+            _ = sut.TransformAsync(null!, CancellationToken.None);
         });
 
         Assert.Equal("items", ex.ParamName);
@@ -363,7 +363,7 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync((IAsyncEnumerable<TItem>)null!, progress);
+            _ = sut.TransformAsync(null!, progress);
         });
 
         Assert.Equal("items", ex.ParamName);
@@ -380,7 +380,7 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync(CreateInputItemsAsync(), (IProgress<TProgress>)null!);
+            _ = sut.TransformAsync(CreateInputItemsAsync(), null!);
         });
 
         Assert.Equal("progress", ex.ParamName);
@@ -496,7 +496,7 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync((IAsyncEnumerable<TItem>)null!, progress, CancellationToken.None);
+            _ = sut.TransformAsync(null!, progress, CancellationToken.None);
         });
 
         Assert.Equal("items", ex.ParamName);
@@ -513,7 +513,7 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         var ex = Assert.Throws<ArgumentNullException>(() =>
         {
-            _ = sut.TransformAsync(CreateInputItemsAsync(), (IProgress<TProgress>)null!, CancellationToken.None);
+            _ = sut.TransformAsync(CreateInputItemsAsync(), null!, CancellationToken.None);
         });
 
         Assert.Equal("progress", ex.ParamName);

--- a/src/Wolfgang.Etl.TestKit/DelayingExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/DelayingExtractor.cs
@@ -132,6 +132,9 @@ public class DelayingExtractor<T> : ExtractorBase<T, Report>
                 yield break;
             }
 
+            // Stryker disable once Boolean : ConfigureAwait(false) is required on
+            // net462/netstandard2.0; (true) is behaviourally identical under the test host
+            // (no synchronization context), so that mutant is equivalent and unkillable.
             await Task.Delay(_delaySelector(index), token).ConfigureAwait(false);
 
             IncrementCurrentItemCount();

--- a/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
@@ -315,6 +315,10 @@ public class FaultyTransformer<T> : TransformerBase<T, T, Report>
     /// </param>
     protected override void Dispose(bool disposing)
     {
+        // Stryker disable once Logical : equivalent. `_elapsedHandler` is non-null only when
+        // `_progressTimer` is non-null, so the extra states an `&&`->`||` flip would enter execute
+        // only `_progressTimer.Elapsed -= null` (a harmless no-op) or differ solely on the
+        // untestable finalizer (disposing == false) path — no observable behaviour changes.
         if (disposing && _progressTimer is not null && _elapsedHandler is not null)
         {
             _progressTimer.Elapsed -= _elapsedHandler;

--- a/src/Wolfgang.Etl.TestKit/RetryingExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/RetryingExtractor.cs
@@ -112,6 +112,9 @@ public class RetryingExtractor<T> : ExtractorBase<T, Report>
 
         token.ThrowIfCancellationRequested();
 
+        // Stryker disable once Statement : Task.Yield only forces the continuation to run
+        // asynchronously; removing it changes scheduling, not observable behaviour, so the
+        // statement-removal mutant is equivalent and unkillable.
         await Task.Yield();
 
         if (attempt <= _failFirstAttempts)
@@ -187,6 +190,7 @@ public class RetryingExtractor<T> : ExtractorBase<T, Report>
                 {
                     try
                     {
+                        // Stryker disable once Boolean : ConfigureAwait(false) vs (true) is equivalent under the test host.
                         if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
                         {
                             break;
@@ -200,6 +204,8 @@ public class RetryingExtractor<T> : ExtractorBase<T, Report>
                     catch (Exception ex)
                     {
                         failure = ExceptionDispatchInfo.Capture(ex);
+                        // Stryker disable once Statement : the worker only faults at stream start, so its iterator is
+                        // already done here; dropping this break just costs one MoveNextAsync that returns false.
                         break;
                     }
 #pragma warning restore CA1031
@@ -209,6 +215,8 @@ public class RetryingExtractor<T> : ExtractorBase<T, Report>
             }
             finally
             {
+                // Stryker disable once Statement,Boolean : the iterator is always completed here so DisposeAsync
+                // is a no-op; ConfigureAwait(false) vs (true) is equivalent under the test host. Both unkillable.
                 await enumerator.DisposeAsync().ConfigureAwait(false);
             }
 

--- a/src/Wolfgang.Etl.TestKit/SnapshotTestLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/SnapshotTestLoader.cs
@@ -140,6 +140,9 @@ public class SnapshotTestLoader<T> : LoaderBase<T, Report>
 
         _buffer.Clear();
 
+        // Stryker disable once Boolean : ConfigureAwait(false) is required on net462/netstandard2.0;
+        // (true) is behaviourally identical under the test host (no synchronization context), so the
+        // mutant is equivalent and unkillable.
         await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
         {
             token.ThrowIfCancellationRequested();

--- a/src/Wolfgang.Etl.TestKit/TestExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/TestExtractor.cs
@@ -538,6 +538,8 @@ public class TestExtractor<T> : ExtractorBase<T, Report>
         // yield-break) and to give callers an asynchronous hop. Placing it here
         // rather than after the loop keeps it reachable regardless of how the
         // loop terminates.
+        // Stryker disable once Statement : equivalent — Task.Yield is a scheduling hop only; removing
+        // it changes no observable extraction result (the source is synchronous).
         await Task.Yield();
 
         var enumerator     = (_enumerator ?? _enumerable!.GetEnumerator())!;

--- a/src/Wolfgang.Etl.TestKit/TestLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/TestLoader.cs
@@ -178,6 +178,10 @@ public class TestLoader<T> : LoaderBase<T, Report>, ISupportDryRun
     /// </param>
     protected override void Dispose(bool disposing)
     {
+        // Stryker disable once Logical : equivalent. `_elapsedHandler` is non-null only when
+        // `_progressTimer` is non-null, so the extra states an `&&`->`||` flip would enter execute
+        // only `_progressTimer.Elapsed -= null` (a harmless no-op) or differ solely on the
+        // untestable finalizer (disposing == false) path — no observable behaviour changes.
         if (disposing && _progressTimer is not null && _elapsedHandler is not null)
         {
             _progressTimer.Elapsed -= _elapsedHandler;

--- a/src/Wolfgang.Etl.TestKit/TestTransformer.cs
+++ b/src/Wolfgang.Etl.TestKit/TestTransformer.cs
@@ -138,6 +138,8 @@ public class TestTransformer<T> : TransformerBase<T, T, Report>
 
         try
         {
+            // Stryker disable once Boolean : equivalent — ConfigureAwait(false) vs (true) has no
+            // observable effect on the transformed sequence in these single-threaded tests.
             await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
             {
                 token.ThrowIfCancellationRequested();

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/AsyncDisposableTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/AsyncDisposableTests.cs
@@ -42,6 +42,16 @@ public class AsyncDisposableTests
     }
 
 
+    // Synchronous progress sink so the final CreateProgressReport() report is captured
+    // deterministically (Progress<T> would dispatch asynchronously).
+    private sealed class ListProgress : IProgress<EtlProgress>
+    {
+        public List<EtlProgress> Reports { get; } = new();
+
+        public void Report(EtlProgress value) => Reports.Add(value);
+    }
+
+
     [Fact]
     public void Base_classes_implement_the_disposal_interfaces()
     {
@@ -203,5 +213,59 @@ public class AsyncDisposableTests
         await sut.DisposeAsync();
 
         Assert.Equal(1, sut.DisposeCount);
+    }
+
+
+    [Fact]
+    public async Task PlainExtractor_runs_and_reports_progress()
+    {
+        var sut = new PlainExtractor();
+        var progress = new ListProgress();
+
+        await foreach (var _ in sut.ExtractAsync(progress))
+        {
+        }
+
+        Assert.NotEmpty(progress.Reports);
+    }
+
+
+    [Fact]
+    public async Task ResourceOwningExtractor_runs_and_reports_progress()
+    {
+        var sut = new ResourceOwningExtractor();
+        var progress = new ListProgress();
+
+        await foreach (var _ in sut.ExtractAsync(progress))
+        {
+        }
+
+        Assert.NotEmpty(progress.Reports);
+    }
+
+
+    [Fact]
+    public async Task ResourceOwningLoader_runs_and_reports_progress()
+    {
+        var sut = new ResourceOwningLoader();
+        var progress = new ListProgress();
+
+        await sut.LoadAsync(AsyncEnumerable.Empty<int>(), progress);
+
+        Assert.NotEmpty(progress.Reports);
+    }
+
+
+    [Fact]
+    public async Task ResourceOwningTransformer_runs_and_reports_progress()
+    {
+        var sut = new ResourceOwningTransformer();
+        var progress = new ListProgress();
+
+        await foreach (var _ in sut.TransformAsync(AsyncEnumerable.Empty<int>(), progress))
+        {
+        }
+
+        Assert.NotEmpty(progress.Reports);
     }
 }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/BaseClassTimingTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/BaseClassTimingTests.cs
@@ -70,7 +70,7 @@ public class BaseClassTimingTests
     {
         var sut = new TimedExtractor(5);
 
-        await foreach (var _ in sut.ExtractAsync())
+        await foreach (var _ in sut.ExtractAsync(new Progress<EtlProgress>()))
         {
         }
 
@@ -143,7 +143,7 @@ public class BaseClassTimingTests
     {
         var sut = new TimedLoader();
 
-        await sut.LoadAsync(Range(5));
+        await sut.LoadAsync(Range(5), new Progress<EtlProgress>());
 
         Assert.NotNull(sut.StartedAtForTest);
         Assert.True(sut.ElapsedForTest >= TimeSpan.Zero);
@@ -165,7 +165,7 @@ public class BaseClassTimingTests
     {
         var sut = new TimedTransformer();
 
-        await foreach (var _ in sut.TransformAsync(Range(5)))
+        await foreach (var _ in sut.TransformAsync(Range(5), new Progress<EtlProgress>()))
         {
         }
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ClockSeamTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ClockSeamTests.cs
@@ -164,7 +164,7 @@ public class ClockSeamTests
 
         protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
         {
-            await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+            await foreach (var _ in items.WithCancellation(token).ConfigureAwait(false))
             {
                 IncrementCurrentItemCount();
             }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ClockSeamTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ClockSeamTests.cs
@@ -20,7 +20,7 @@ public class ClockSeamTests
         var clock = new FakeTimeSource();
         var sut = new ClockExtractor { TimeSource = clock };
 
-        await Drain(sut.ExtractAsync(CancellationToken.None));   // first item captures start
+        await Drain(sut.ExtractAsync(new Progress<EtlProgress>(), CancellationToken.None));   // first item captures start
 
         Assert.Equal(Start, sut.PeekStartedAt);
         Assert.Equal(TimeSpan.Zero, sut.PeekElapsed);
@@ -38,7 +38,7 @@ public class ClockSeamTests
         var clock = new FakeTimeSource();
         var sut = new ClockLoader { TimeSource = clock };
 
-        await sut.LoadAsync(AsyncSource(1), CancellationToken.None);
+        await sut.LoadAsync(AsyncSource(1), new Progress<EtlProgress>(), CancellationToken.None);
         clock.Advance(TimeSpan.FromSeconds(2));
 
         Assert.Equal(Start, sut.PeekStartedAt);
@@ -52,7 +52,7 @@ public class ClockSeamTests
         var clock = new FakeTimeSource();
         var sut = new ClockTransformer { TimeSource = clock };
 
-        await Drain(sut.TransformAsync(AsyncSource(1), CancellationToken.None));
+        await Drain(sut.TransformAsync(AsyncSource(1), new Progress<EtlProgress>(), CancellationToken.None));
         clock.Advance(TimeSpan.FromSeconds(9));
 
         Assert.Equal(Start, sut.PeekStartedAt);

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ExtractorBaseTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ExtractorBaseTests.cs
@@ -22,13 +22,6 @@ public class ExtractorBaseTests
 
 
 
-    protected override SequenceExtractor CreateSutWithTimer(IProgressTimer timer)
-    {
-        return new SequenceExtractor(5, timer);
-    }
-
-
-
     [Fact]
     public void ReportingInterval_default_value_is_1000()
     {

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/LoaderBaseTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/LoaderBaseTests.cs
@@ -21,13 +21,6 @@ public class LoaderBaseTests
 
 
 
-    protected override ListLoader CreateSutWithTimer(IProgressTimer timer)
-    {
-        return new ListLoader(timer);
-    }
-
-
-
     [Fact]
     public void ReportingInterval_default_value_is_1000()
     {

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ResetRunStateTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/ResetRunStateTests.cs
@@ -87,7 +87,7 @@ public class ResetRunStateTests
         await DrainAsync(sut.ExtractAsync());
         Assert.Equal(5, sut.CurrentItemCount);
 
-        await DrainAsync(sut.ExtractAsync());
+        await DrainAsync(sut.ExtractAsync(new Progress<EtlProgress>()));
         Assert.Equal(5, sut.CurrentItemCount);
     }
 
@@ -100,7 +100,7 @@ public class ResetRunStateTests
         await sut.LoadAsync(Range(5));
         Assert.Equal(5, sut.CurrentItemCount);
 
-        await sut.LoadAsync(Range(5));
+        await sut.LoadAsync(Range(5), new Progress<EtlProgress>());
         Assert.Equal(5, sut.CurrentItemCount);
     }
 
@@ -113,7 +113,7 @@ public class ResetRunStateTests
         await DrainAsync(sut.TransformAsync(Range(5)));
         Assert.Equal(5, sut.CurrentItemCount);
 
-        await DrainAsync(sut.TransformAsync(Range(5)));
+        await DrainAsync(sut.TransformAsync(Range(5), new Progress<EtlProgress>()));
         Assert.Equal(5, sut.CurrentItemCount);
     }
 }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/RetrySeamTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/RetrySeamTests.cs
@@ -240,7 +240,7 @@ public class RetrySeamTests
             SeamCallCount++;
             if (WorkerRuns == 1)
             {
-                await foreach (var item in base.WrapWorkerExecution(workerFactory, token).WithCancellation(token))
+                await foreach (var item in base.WrapWorkerExecution(workerFactory, token))
                 {
                     yield return item;
                 }
@@ -427,7 +427,7 @@ public class RetrySeamTests
             SeamCallCount++;
             if (WorkerRuns == 1)
             {
-                await foreach (var item in base.WrapWorkerExecution(workerFactory, token).WithCancellation(token))
+                await foreach (var item in base.WrapWorkerExecution(workerFactory, token))
                 {
                     yield return item;
                 }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/SystemProgressTimerTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/SystemProgressTimerTests.cs
@@ -97,12 +97,10 @@ public class SystemProgressTimerTests
     public async Task Timer_callback_fires_during_extraction()
     {
         var elapsedCount = 0;
-        IProgressTimer? capturedTimer = null;
 
         var sut = new CapturingExtractor(
             onTimerCreated: t =>
             {
-                capturedTimer = t;
                 t.Elapsed += () => Interlocked.Increment(ref elapsedCount);
             },
             intervalMs: 30,

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/SystemProgressTimerTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/SystemProgressTimerTests.cs
@@ -182,6 +182,26 @@ public class SystemProgressTimerTests
 
 
 
+    /// <summary>
+    /// Directly exercises <see cref="WaitUntilStable"/>'s reset branch: while the observed value
+    /// keeps changing, the stability window must restart rather than return early. The value
+    /// climbs for the first few reads, then settles, so the method returns the settled value.
+    /// </summary>
+    [Fact]
+    public async Task WaitUntilStable_restarts_the_window_while_the_value_keeps_changing()
+    {
+        var reads = 0;
+
+        // Returns 1, 2, 3, then a constant 3 — the changing reads drive the window reset.
+        int Read() => Math.Min(++reads, 3);
+
+        var result = await WaitUntilStable(Read, stableForMs: 100, pollMs: 5);
+
+        Assert.Equal(3, result);
+    }
+
+
+
     // ------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TransformerBaseTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/BaseClassTests/TransformerBaseTests.cs
@@ -22,13 +22,6 @@ public class TransformerBaseTests
 
 
 
-    protected override IdentityTransformer CreateSutWithTimer(IProgressTimer timer)
-    {
-        return new IdentityTransformer(timer);
-    }
-
-
-
     [Fact]
     public void ReportingInterval_default_value_is_1000()
     {

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/DisposedGuardTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/DisposedGuardTests.cs
@@ -13,13 +13,6 @@ namespace Wolfgang.Etl.Abstractions.Tests.Unit;
 /// </summary>
 public sealed class DisposedGuardTests
 {
-    private static async IAsyncEnumerable<int> Empty()
-    {
-        await Task.CompletedTask;
-        yield break;
-    }
-
-
     private static readonly IProgress<EtlProgress> Progress = new NoOpProgress();
 
 
@@ -29,10 +22,10 @@ public sealed class DisposedGuardTests
         var loader = new NoOpLoader();
         loader.Dispose();
 
-        Assert.Throws<ObjectDisposedException>(() => { _ = loader.LoadAsync(Empty()); });
-        Assert.Throws<ObjectDisposedException>(() => { _ = loader.LoadAsync(Empty(), CancellationToken.None); });
-        Assert.Throws<ObjectDisposedException>(() => { _ = loader.LoadAsync(Empty(), Progress); });
-        Assert.Throws<ObjectDisposedException>(() => { _ = loader.LoadAsync(Empty(), Progress, CancellationToken.None); });
+        Assert.Throws<ObjectDisposedException>(() => { _ = loader.LoadAsync(AsyncEnumerable.Empty<int>()); });
+        Assert.Throws<ObjectDisposedException>(() => { _ = loader.LoadAsync(AsyncEnumerable.Empty<int>(), CancellationToken.None); });
+        Assert.Throws<ObjectDisposedException>(() => { _ = loader.LoadAsync(AsyncEnumerable.Empty<int>(), Progress); });
+        Assert.Throws<ObjectDisposedException>(() => { _ = loader.LoadAsync(AsyncEnumerable.Empty<int>(), Progress, CancellationToken.None); });
     }
 
 
@@ -42,7 +35,7 @@ public sealed class DisposedGuardTests
         var loader = new NoOpLoader();
         await loader.DisposeAsync();
 
-        Assert.Throws<ObjectDisposedException>(() => { _ = loader.LoadAsync(Empty()); });
+        Assert.Throws<ObjectDisposedException>(() => { _ = loader.LoadAsync(AsyncEnumerable.Empty<int>()); });
     }
 
 
@@ -75,10 +68,10 @@ public sealed class DisposedGuardTests
         var transformer = new NoOpTransformer();
         transformer.Dispose();
 
-        Assert.Throws<ObjectDisposedException>(() => transformer.TransformAsync(Empty()));
-        Assert.Throws<ObjectDisposedException>(() => transformer.TransformAsync(Empty(), CancellationToken.None));
-        Assert.Throws<ObjectDisposedException>(() => transformer.TransformAsync(Empty(), Progress));
-        Assert.Throws<ObjectDisposedException>(() => transformer.TransformAsync(Empty(), Progress, CancellationToken.None));
+        Assert.Throws<ObjectDisposedException>(() => transformer.TransformAsync(AsyncEnumerable.Empty<int>()));
+        Assert.Throws<ObjectDisposedException>(() => transformer.TransformAsync(AsyncEnumerable.Empty<int>(), CancellationToken.None));
+        Assert.Throws<ObjectDisposedException>(() => transformer.TransformAsync(AsyncEnumerable.Empty<int>(), Progress));
+        Assert.Throws<ObjectDisposedException>(() => transformer.TransformAsync(AsyncEnumerable.Empty<int>(), Progress, CancellationToken.None));
     }
 
 
@@ -88,7 +81,7 @@ public sealed class DisposedGuardTests
         var transformer = new NoOpTransformer();
         await transformer.DisposeAsync();
 
-        Assert.Throws<ObjectDisposedException>(() => transformer.TransformAsync(Empty()));
+        Assert.Throws<ObjectDisposedException>(() => transformer.TransformAsync(AsyncEnumerable.Empty<int>()));
     }
 
 
@@ -111,7 +104,7 @@ public sealed class DisposedGuardTests
         // inverted): a freshly-constructed, undisposed loader must accept a call.
         var loader = new NoOpLoader();
 
-        var exception = Record.Exception(() => { _ = loader.LoadAsync(Empty()); });
+        var exception = Record.Exception(() => { _ = loader.LoadAsync(AsyncEnumerable.Empty<int>()); });
 
         Assert.Null(exception);
     }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/AggregateErrorsTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/AggregateErrorsTests.cs
@@ -96,6 +96,43 @@ public class AggregateErrorsTests
     }
 
 
+    [Fact]
+    public async Task ErroringExtractor_reports_component_progress_when_run_standalone()
+    {
+        var sut = new ErroringExtractor(good: 3, errors: 0);
+
+        await foreach (var _ in sut.ExtractAsync(new Progress<EtlProgress>()))
+        {
+        }
+
+        Assert.Equal(3, sut.CurrentItemCount);
+    }
+
+
+    [Fact]
+    public async Task ErroringTransformer_reports_component_progress_when_run_standalone()
+    {
+        var sut = new ErroringTransformer(errors: 0);
+
+        await foreach (var _ in sut.TransformAsync(AsyncSource(1, 2), new Progress<EtlProgress>()))
+        {
+        }
+
+        Assert.Equal(2, sut.CurrentItemCount);
+    }
+
+
+    [Fact]
+    public async Task ErroringLoader_reports_component_progress_when_run_standalone()
+    {
+        var sut = new ErroringLoader(errors: 0);
+
+        await sut.LoadAsync(AsyncSource(1, 2, 3), new Progress<EtlProgress>());
+
+        Assert.Equal(3, sut.CurrentItemCount);
+    }
+
+
     // ---------- helpers ----------
 
     private static async IAsyncEnumerable<int> AsyncSource(params int[] items)

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/AggregateErrorsTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/AggregateErrorsTests.cs
@@ -219,7 +219,7 @@ public class AggregateErrorsTests
 
         protected override async Task LoadWorkerAsync(IAsyncEnumerable<int> items, CancellationToken token)
         {
-            await foreach (var item in items.WithCancellation(token))
+            await foreach (var _ in items.WithCancellation(token))
             {
                 IncrementCurrentItemCount();
             }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/EtlPipelineTests.cs
@@ -314,7 +314,7 @@ public class EtlPipelineCoreTests
     {
         Assert.Throws<ArgumentNullException>(() => EtlPipeline
             .Create()
-            .From<int>((IAsyncEnumerable<int>)null!));
+            .From<int>(null!));
     }
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/TestDoubleCoverageTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/EtlPipelineTests/TestDoubleCoverageTests.cs
@@ -1,0 +1,46 @@
+using Wolfgang.Etl.Abstractions.Tests.Unit.Models;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.EtlPipelineTests;
+
+/// <summary>
+/// Directly exercises members of the shared <c>EtlPipeline</c> test doubles that the pipeline binding
+/// path does not reach: the component-level progress report and the parameterless transform overload.
+/// </summary>
+public class TestDoubleCoverageTests
+{
+    [Fact]
+    public async Task SeededExtractor_reports_component_progress_when_run_standalone()
+    {
+        var sut = new SeededExtractor<int>(new[] { 1, 2, 3 });
+
+        await foreach (var _ in sut.ExtractAsync(new Progress<EtlProgress>()))
+        {
+        }
+
+        Assert.Equal(3, sut.CurrentItemCount);
+    }
+
+
+    [Fact]
+    public async Task CollectingLoader_reports_component_progress_when_run_standalone()
+    {
+        var sut = new CollectingLoader<int>();
+
+        await sut.LoadAsync(new[] { 1, 2, 3 }.ToAsyncEnumerable(), new Progress<EtlProgress>());
+
+        Assert.Equal(new[] { 1, 2, 3 }, sut.Loaded);
+        Assert.Equal(3, sut.CurrentItemCount);
+    }
+
+
+    [Fact]
+    public async Task TokenRecordingTransformer_parameterless_overload_forwards_no_cancellation()
+    {
+        var sut = new TokenRecordingTransformer<int>();
+
+        var result = await sut.TransformAsync(new[] { 1, 2, 3 }.ToAsyncEnumerable()).ToListAsync();
+
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+        Assert.Equal(CancellationToken.None, sut.LastToken);
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Performance/AllocationFreeTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/Performance/AllocationFreeTests.cs
@@ -2,6 +2,7 @@
 // suite compiles on net48+ / netcoreapp3.1+ / net5.0+ but not net462/net472. The
 // allocation behaviour under test is TFM-agnostic, so the modern targets cover it.
 #if !NET462 && !NET472
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.Performance;
@@ -122,9 +123,14 @@ public sealed class AllocationFreeTests
 
         public void IncrementSkipped() => IncrementCurrentSkippedItemCount();
 
+        // The harness only surfaces the protected counter increments; extraction is never run,
+        // so this required override cannot execute.
+        [ExcludeFromCodeCoverage]
         protected override IAsyncEnumerable<int> ExtractWorkerAsync(CancellationToken token)
             => throw new NotSupportedException();
 
+        // Required override to instantiate the harness; progress is never reported in the probes.
+        [ExcludeFromCodeCoverage]
         protected override Report CreateProgressReport() => new(CurrentItemCount);
     }
 }

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/DisposeStagesTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/DisposeStagesTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests;
 
@@ -68,6 +69,9 @@ public class DisposeStagesTests
             }
         }
 
+        // The async disposal path is always preferred, so this IDisposable member is asserted
+        // never-called (see DisposeStagesOnCompletion_prefers_DisposeAsync_over_Dispose).
+        [ExcludeFromCodeCoverage]
         public void Dispose() => DisposeCalled = true;
 
         public ValueTask DisposeAsync()
@@ -401,6 +405,24 @@ public class DisposeStagesTests
         Assert.Equal(2, ex.InnerExceptions.Count);
         Assert.Contains(ex.InnerExceptions, e => string.Equals(e.Message, "extractor dispose failed", StringComparison.Ordinal));
         Assert.Contains(ex.InnerExceptions, e => string.Equals(e.Message, "dispose failed", StringComparison.Ordinal));
+    }
+
+
+    [Fact]
+    public async Task Tracking_extractor_doubles_yield_the_sequence_from_the_overloads_the_pipeline_skips()
+    {
+        // The pipeline binds one overload per extractor interface; the remaining interface-required
+        // overloads must still produce the sequence. Exercises the overloads the disposal path skips.
+        var expected = new[] { 0, 1 };
+
+        Assert.Equal(expected, await new TrackingCancellableExtractor(2).ExtractAsync().ToListAsync());
+
+        Assert.Equal(expected, await new TrackingProgressExtractor(2).ExtractAsync(new Progress<string>()).ToListAsync());
+
+        var pc = new TrackingProgressCancellableExtractor(2);
+        Assert.Equal(expected, await pc.ExtractAsync().ToListAsync());
+        Assert.Equal(expected, await pc.ExtractAsync(new Progress<string>()).ToListAsync());
+        Assert.Equal(expected, await pc.ExtractAsync(new Progress<string>(), CancellationToken.None).ToListAsync());
     }
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/NullGuardOnChainedStagesTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/NullGuardOnChainedStagesTests.cs
@@ -70,7 +70,7 @@ public class NullGuardOnChainedStagesTests
     {
         Assert.Throws<ArgumentNullException>
         (
-            () => MidChainStage().Load((ILoadWithCancellationAsync<int>)null!)
+            () => MidChainStage().Load(null!)
         );
     }
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/OverloadDoubleCoverageTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/OverloadDoubleCoverageTests.cs
@@ -1,0 +1,136 @@
+using Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
+
+namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests;
+
+/// <summary>
+/// Directly exercises the interface-required overloads (and their argument-null guards) on the
+/// multi-capability pipeline test doubles that a bound pipeline path never routes to, so every
+/// overload each double must implement is verified rather than left dead.
+/// </summary>
+public class OverloadDoubleCoverageTests
+{
+    private static readonly int[] Items = { 1, 2, 3 };
+
+    private static IAsyncEnumerable<int> Source() => Items.ToAsyncEnumerable();
+
+
+    // ------------------------------------------------------------------
+    // Extractors
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task FullExtractor_yields_the_sequence_from_the_overloads_the_pipeline_skips()
+    {
+        var sut = new FullExtractor<int, string>(Items, "p");
+
+        Assert.Equal(Items, await sut.ExtractAsync().ToListAsync());
+        Assert.True(sut.ParameterlessOverloadWasCalled);
+
+        Assert.Equal(Items, await sut.ExtractAsync(new Progress<string>()).ToListAsync());
+        Assert.True(sut.ProgressOnlyOverloadWasCalled);
+    }
+
+
+    [Fact]
+    public async Task FullExtractor_progress_overloads_reject_null_progress()
+    {
+        var sut = new FullExtractor<int, string>(Items, "p");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await sut.ExtractAsync((IProgress<string>)null!).ToListAsync());
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await sut.ExtractAsync((IProgress<string>)null!, CancellationToken.None).ToListAsync());
+    }
+
+
+    [Fact]
+    public async Task ProgressOnlyExtractor_progress_overload_rejects_null_progress()
+    {
+        var sut = new ProgressOnlyExtractor<int, string>(Items, "p");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await sut.ExtractAsync((IProgress<string>)null!).ToListAsync());
+    }
+
+
+    // ------------------------------------------------------------------
+    // Loaders
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task FullLoader_loads_from_the_overloads_the_pipeline_skips()
+    {
+        var sut = new FullLoader<int, string>("p");
+
+        await sut.LoadAsync(Source());
+        Assert.True(sut.ParameterlessOverloadWasCalled);
+
+        var progressLoader = new FullLoader<int, string>("p");
+        await progressLoader.LoadAsync(Source(), new Progress<string>());
+        Assert.True(progressLoader.ProgressOnlyOverloadWasCalled);
+    }
+
+
+    [Fact]
+    public async Task FullLoader_progress_overloads_reject_null_progress()
+    {
+        var sut = new FullLoader<int, string>("p");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await sut.LoadAsync(Source(), (IProgress<string>)null!));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await sut.LoadAsync(Source(), (IProgress<string>)null!, CancellationToken.None));
+    }
+
+
+    [Fact]
+    public async Task ProgressOnlyLoader_progress_overload_rejects_null_progress()
+    {
+        var sut = new ProgressOnlyLoader<int, string>("p");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await sut.LoadAsync(Source(), (IProgress<string>)null!));
+    }
+
+
+    // ------------------------------------------------------------------
+    // Transformers
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task FullTransformer_transforms_from_the_overloads_the_pipeline_skips()
+    {
+        var sut = new FullTransformer<int, int, string>(x => x, "p");
+
+        Assert.Equal(Items, await sut.TransformAsync(Source()).ToListAsync());
+        Assert.True(sut.ParameterlessOverloadWasCalled);
+
+        Assert.Equal(Items, await sut.TransformAsync(Source(), new Progress<string>()).ToListAsync());
+        Assert.True(sut.ProgressOnlyOverloadWasCalled);
+    }
+
+
+    [Fact]
+    public async Task FullTransformer_progress_overloads_reject_null_progress()
+    {
+        var sut = new FullTransformer<int, int, string>(x => x, "p");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await sut.TransformAsync(Source(), (IProgress<string>)null!).ToListAsync());
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await sut.TransformAsync(Source(), (IProgress<string>)null!, CancellationToken.None).ToListAsync());
+    }
+
+
+    [Fact]
+    public async Task ProgressOnlyTransformer_progress_overload_rejects_null_progress()
+    {
+        var sut = new ProgressOnlyTransformer<int, int, string>(x => x, "p");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await sut.TransformAsync(Source(), (IProgress<string>)null!).ToListAsync());
+    }
+}

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/PipelineBehaviorTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/PipelineBehaviorTests.cs
@@ -113,7 +113,7 @@ public class PipelineBehaviorTests
     public void CancelOnly_Load_when_loader_is_null_throws()
     {
         var stage = Pipeline.Extract(new BareExtractor<int>(new[] { 1 }));
-        Assert.Throws<ArgumentNullException>(() => stage.Load((ILoadWithCancellationAsync<int>)null!));
+        Assert.Throws<ArgumentNullException>(() => stage.Load(null!));
     }
 
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Extractors.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Extractors.cs
@@ -1,4 +1,5 @@
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
@@ -51,6 +52,9 @@ internal sealed class CancelOnlyExtractor<T> : IExtractWithCancellationAsync<T>
     }
 
 
+    // Negative-routing guard: throws to prove the pipeline never binds the parameterless overload
+    // for a cancellation-only extractor. Never executed on a green run, so it cannot be covered.
+    [ExcludeFromCodeCoverage]
     public IAsyncEnumerable<T> ExtractAsync() => throw new WrongOverloadCalledException
     (
         "CancelOnlyExtractor<T>.ExtractAsync()"

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Extractors.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Extractors.cs
@@ -199,10 +199,10 @@ internal sealed class FullExtractor<T, TProgress> : IExtractWithProgressAndCance
     }
 
 
-    public async IAsyncEnumerable<T> ExtractAsync
+    public IAsyncEnumerable<T> ExtractAsync
     (
         IProgress<TProgress> progress,
-        [EnumeratorCancellation] CancellationToken token
+        CancellationToken token
     )
     {
         if (progress is null)
@@ -210,6 +210,18 @@ internal sealed class FullExtractor<T, TProgress> : IExtractWithProgressAndCance
             throw new ArgumentNullException(nameof(progress));
         }
 
+        // Split so the null check runs eagerly at call time rather than being
+        // deferred to the first MoveNextAsync of the iterator (S4456).
+        return ExtractFullCoreAsync(progress, token);
+    }
+
+
+    private async IAsyncEnumerable<T> ExtractFullCoreAsync
+    (
+        IProgress<TProgress> progress,
+        [EnumeratorCancellation] CancellationToken token
+    )
+    {
         FullOverloadWasCalled = true;
         LastReceivedProgress = progress;
         LastReceivedToken = token;

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Loaders.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Loaders.cs
@@ -1,4 +1,6 @@
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 
 /// <summary>
@@ -33,6 +35,9 @@ internal sealed class CancelOnlyLoader<T> : ILoadWithCancellationAsync<T>
     public bool TokenOverloadWasCalled { get; private set; }
 
 
+    // Negative-routing guard: throws to prove the pipeline never binds the parameterless overload
+    // for a cancellation-only loader. Never executed on a green run, so it cannot be covered.
+    [ExcludeFromCodeCoverage]
     public Task LoadAsync(IAsyncEnumerable<T> items)
         => throw new WrongOverloadCalledException("CancelOnlyLoader<T>.LoadAsync(items)");
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Transformers.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/Transformers.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
@@ -51,6 +52,9 @@ internal sealed class CancelOnlyTransformer<TSource, TDestination>
     }
 
 
+    // Negative-routing guard: throws to prove the pipeline never binds the parameterless overload
+    // for a cancellation-only transformer. Never executed on a green run, so it cannot be covered.
+    [ExcludeFromCodeCoverage]
     public IAsyncEnumerable<TDestination> TransformAsync(IAsyncEnumerable<TSource> items)
         => throw new WrongOverloadCalledException("CancelOnlyTransformer<TSource, TDestination>.TransformAsync(items)");
 

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/WrongOverloadCalledException.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/TestDoubles/WrongOverloadCalledException.cs
@@ -1,4 +1,6 @@
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 
 /// <summary>
@@ -7,6 +9,8 @@ namespace Wolfgang.Etl.Abstractions.Tests.Unit.PipelineTests.TestDoubles;
 /// dedicated type instead of a plain <see cref="InvalidOperationException"/> makes accidental
 /// routing regressions easy to diagnose in test failure output.
 /// </summary>
+// Only constructed by the never-executed negative-routing guards, so it cannot be covered.
+[ExcludeFromCodeCoverage]
 internal sealed class WrongOverloadCalledException : Exception
 {
     public WrongOverloadCalledException(string overloadSignature)

--- a/tests/Wolfgang.Etl.ErrorPolicies.Tests.Unit/ItemErrorPolicyTests.cs
+++ b/tests/Wolfgang.Etl.ErrorPolicies.Tests.Unit/ItemErrorPolicyTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using Wolfgang.Etl.Abstractions;
@@ -192,6 +193,8 @@ public sealed class ItemErrorPolicyTests
 
         public EventId LastEventId { get; private set; }
 
+        // ILogger-required member; the policies under test log warnings but never open a scope, so this is never called.
+        [ExcludeFromCodeCoverage]
         public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
 
         public bool IsEnabled(LogLevel logLevel) => true;
@@ -214,6 +217,8 @@ public sealed class ItemErrorPolicyTests
 
 
 
+        // Only ever returned by the never-called BeginScope above, so its members are unreachable in tests.
+        [ExcludeFromCodeCoverage]
         private sealed class NullScope : IDisposable
         {
             public static readonly NullScope Instance = new();

--- a/tests/Wolfgang.Etl.TestKit.Tests.DocExamples/DocExampleCompilationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.DocExamples/DocExampleCompilationTests.cs
@@ -228,7 +228,7 @@ public sealed class DocExampleCompilationTests
         var tree = CSharpSyntaxTree.ParseText
         (
             source,
-            new CSharpParseOptions(LanguageVersion.Latest, DocumentationMode.Parse)
+            new CSharpParseOptions(LanguageVersion.Latest)
         );
 
         var docComments = tree.GetRoot()

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/CountingProgressTimer.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/CountingProgressTimer.cs
@@ -1,0 +1,53 @@
+using System;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// A test <see cref="IProgressTimer"/> that fires <see cref="Elapsed"/> on demand via
+/// <see cref="Fire"/> and records how often <see cref="StopTimer"/> and <see cref="Dispose"/>
+/// are called. Unlike <c>ManualProgressTimer</c>, <see cref="Dispose"/> does <b>not</b> clear
+/// the subscriber list, so a single injected instance can survive the base class's
+/// per-run <c>timer.Dispose()</c> and still be inspected across multiple runs — which is
+/// exactly what the duplicate-subscription guard tests need.
+/// </summary>
+internal sealed class CountingProgressTimer : IProgressTimer
+{
+    public event Action? Elapsed;
+
+
+
+    /// <summary>The number of delegates currently subscribed to <see cref="Elapsed"/>.</summary>
+    public int SubscriberCount => Elapsed?.GetInvocationList().Length ?? 0;
+
+
+
+    /// <summary>How many times <see cref="StopTimer"/> has been called.</summary>
+    public int StopTimerCallCount { get; private set; }
+
+
+
+    /// <summary>How many times <see cref="Dispose"/> has been called.</summary>
+    public int DisposeCallCount { get; private set; }
+
+
+
+    /// <summary>Raises <see cref="Elapsed"/> synchronously on the calling thread.</summary>
+    public void Fire() => Elapsed?.Invoke();
+
+
+
+    public void Start(int intervalMilliseconds)
+    {
+    }
+
+
+
+    public void StopTimer() => StopTimerCallCount++;
+
+
+
+    // Deliberately does not clear Elapsed: the caller owns the injected timer, and the
+    // subscriber list must remain observable after the base class disposes it per run.
+    public void Dispose() => DisposeCallCount++;
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
@@ -247,4 +247,57 @@ public class DelayingExtractorTests
             $"Expected the extractor to actually delay; elapsed only {sw.ElapsedMilliseconds} ms."
         );
     }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_cancelling_during_skip_stops_at_the_in_loop_check()
+    {
+        // With a large SkipItemCount, the per-item ThrowIfCancellationRequested is the ONLY
+        // cancellation check reached while skipping — the Task.Delay (which also observes the token)
+        // runs only for non-skipped items. The source cancels the token as its 6th item is pulled;
+        // the in-loop check must throw right then, having skipped only a handful of items. Without
+        // that check, skipping would race ahead to the full SkipItemCount before the delay finally
+        // noticed cancellation — so a small skipped count proves the in-loop check fired.
+        using var cts = new CancellationTokenSource();
+        var sut = new DelayingExtractor<int>
+        (
+            CancelAt(cts, cancelIndex: 5, total: 5000),
+            TimeSpan.FromMilliseconds(20)
+        )
+        { SkipItemCount = 1000 };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.ExtractAsync(cts.Token))
+                {
+                }
+            }
+        );
+
+        Assert.True
+        (
+            sut.CurrentSkippedItemCount < 100,
+            $"Expected a prompt in-loop cancel while skipping, but skipped {sut.CurrentSkippedItemCount} items."
+        );
+    }
+
+
+
+    // A sequence that cancels the supplied source as a chosen item is produced, letting the token
+    // flip mid-skip so only the in-loop cancellation check can catch it.
+    private static IEnumerable<int> CancelAt(CancellationTokenSource cts, int cancelIndex, int total)
+    {
+        for (var i = 0; i < total; i++)
+        {
+            if (i == cancelIndex)
+            {
+                cts.Cancel();
+            }
+
+            yield return i;
+        }
+    }
 }

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,10 +39,12 @@ public class DelayingExtractorTests
     [Fact]
     public void Constructor_when_delay_is_negative_throws_ArgumentOutOfRangeException()
     {
-        Assert.Throws<ArgumentOutOfRangeException>
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
         (
             () => new DelayingExtractor<int>(new[] { 1 }, TimeSpan.FromMilliseconds(-1))
         );
+
+        Assert.Contains("must not be negative", ex.Message);
     }
 
 
@@ -149,5 +153,98 @@ public class DelayingExtractorTests
 
         // Stopped near the cancel point rather than draining all 100.
         Assert.True(processed <= 4, $"Expected a prompt stop (≤ 4), but processed {processed}.");
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Mutation-hardening (#346)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_with_no_items_and_a_pre_cancelled_token_still_throws()
+    {
+        // The pre-loop ThrowIfCancellationRequested is the only cancellation check that
+        // runs when the source is empty (the in-loop check never executes), so an empty
+        // source with an already-cancelled token must still throw.
+        var sut = new DelayingExtractor<int>(Array.Empty<int>(), TimeSpan.Zero);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.ExtractAsync(cts.Token))
+                {
+                }
+            }
+        );
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_advances_the_delay_index_across_skipped_items()
+    {
+        // The zero-based index handed to the delay selector must keep advancing through
+        // skipped items, so a yielded item is delayed for its true position — not 0.
+        var seen = new List<int>();
+        var sut = new DelayingExtractor<int>
+        (
+            new[] { 1, 2, 3, 4 },
+            i => { seen.Add(i); return TimeSpan.Zero; }
+        )
+        { SkipItemCount = 2 };
+
+        await foreach (var _ in sut.ExtractAsync())
+        {
+        }
+
+        // Items 0 and 1 are skipped (the selector is only consulted for yielded items);
+        // the two yielded items are queried at their real indices 2 and 3.
+        Assert.Equal(new[] { 2, 3 }, seen);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_advances_the_delay_index_for_each_yielded_item()
+    {
+        var seen = new List<int>();
+        var sut = new DelayingExtractor<int>
+        (
+            new[] { 10, 20, 30 },
+            i => { seen.Add(i); return TimeSpan.Zero; }
+        );
+
+        await foreach (var _ in sut.ExtractAsync())
+        {
+        }
+
+        Assert.Equal(new[] { 0, 1, 2 }, seen);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_actually_waits_the_delay_before_yielding()
+    {
+        // Dropping the Task.Delay would make extraction effectively instantaneous.
+        var sut = new DelayingExtractor<int>(new[] { 1, 2, 3 }, TimeSpan.FromMilliseconds(30));
+
+        var sw = Stopwatch.StartNew();
+        await foreach (var _ in sut.ExtractAsync())
+        {
+        }
+        sw.Stop();
+
+        // 3 items x 30 ms = ~90 ms nominal; a 45 ms floor is far above the no-delay case
+        // (~0 ms) yet loose enough to stay reliable on shared CI runners.
+        Assert.True
+        (
+            sw.ElapsedMilliseconds >= 45,
+            $"Expected the extractor to actually delay; elapsed only {sw.ElapsedMilliseconds} ms."
+        );
     }
 }

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
@@ -28,7 +28,7 @@ public class DelayingExtractorTests
     {
         Assert.Throws<ArgumentNullException>
         (
-            () => new DelayingExtractor<int>(new[] { 1 }, (Func<int, TimeSpan>)null!)
+            () => new DelayingExtractor<int>(new[] { 1 }, null!)
         );
     }
 

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyExtractorMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyExtractorMutationTests.cs
@@ -1,0 +1,377 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit.Xunit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Mutation-hardening tests (#346) for <see cref="FaultyExtractor{T}"/> — each targets a
+/// specific surviving mutant that the behavioural tests do not otherwise pin down.
+/// </summary>
+public class FaultyExtractorMutationTests
+{
+    // ------------------------------------------------------------------
+    // OnItemError ternary (base-vs-policy) — L285
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void OnItemError_when_no_policy_configured_falls_back_to_base_abort()
+    {
+        // With no policy the ternary must take the base branch (Abort). The always-true
+        // conditional mutant would instead invoke the null policy delegate and throw.
+        var probe = new OnItemErrorProbe();
+
+        var action = probe.Probe(new ItemErrorContext(1, new IOException("boom")));
+
+        Assert.Equal(ItemErrorAction.Abort, action);
+    }
+
+
+
+    [Fact]
+    public void OnItemError_when_policy_configured_uses_the_policy_result()
+    {
+        var probe = new OnItemErrorProbe();
+        probe.SkipErrors();
+
+        var action = probe.Probe(new ItemErrorContext(1, new IOException("boom")));
+
+        Assert.Equal(ItemErrorAction.Skip, action);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // HandleInjectedFault — Abort path must not count the item — L306
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_when_policy_returns_Abort_does_not_count_the_failing_item()
+    {
+        // With a policy present and an Abort decision, the throw fires BEFORE the fail-fast
+        // IncrementCurrentItemCount. Removing that throw would fall through to the counting
+        // path, so the count would be one higher.
+        var sut = new FaultyExtractor<int>(new[] { 1, 2, 3, 4, 5 })
+            .ThrowAt(2, new IOException("fatal"))
+            .HandleErrorsWith(_ => ItemErrorAction.Abort);
+
+        await Assert.ThrowsAsync<IOException>
+        (
+            async () => await sut.ExtractAsync().ToListAsync()
+        );
+
+        // Items at index 0 and 1 were counted; the index-2 fault aborts without counting.
+        Assert.Equal(2, sut.CurrentItemCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Progress-timer wiring seam — L321 / L323 / L325
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_firing_the_injected_timer_reports_progress_before_completion()
+    {
+        // The base always reports once on completion, so asserting a report exists is not
+        // enough. Capture the count immediately after Fire() — before the run finishes — so
+        // only a wired Elapsed handler can satisfy it. Kills the "never wire" (!wired -> wired)
+        // and the "-=" (subscribe -> unsubscribe) mutants.
+        using var timer = new ManualProgressTimer();
+        var sut = new TimerProbe(new List<int> { 1, 2, 3 }, timer);
+        var reports = 0;
+        var progress = new SynchronousProgress<Report>(_ => reports++);
+
+        var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
+        await enumerator.MoveNextAsync();
+        timer.Fire();
+        var afterFire = reports;
+
+        Assert.True(afterFire >= 1, $"Firing the injected timer must report progress; saw {afterFire}.");
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_wires_the_elapsed_handler_only_once_across_runs()
+    {
+        // The _progressTimerWired guard prevents a duplicate Elapsed subscription when the
+        // timer is reused. Start two overlapping runs on one instance so CreateProgressTimer
+        // runs twice against the same (undisposed) timer: with the guard, exactly one handler
+        // is subscribed, so one Fire() yields one report. The "wired = false" mutant subscribes
+        // twice, yielding two.
+        using var timer = new ManualProgressTimer();
+        var sut = new TimerProbe(new List<int> { 1, 2, 3 }, timer);
+        var reports = 0;
+        var progress = new SynchronousProgress<Report>(_ => reports++);
+
+        var first = sut.ExtractAsync(progress).GetAsyncEnumerator();
+        await first.MoveNextAsync();
+        var second = sut.ExtractAsync(progress).GetAsyncEnumerator();
+        await second.MoveNextAsync();
+
+        reports = 0;
+        timer.Fire();
+
+        Assert.Equal(1, reports);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Dispose(bool) unsubscribe guard — L343
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Dispose_with_disposing_false_does_not_unsubscribe_the_handler()
+    {
+        // The guard requires disposing == true. The logical-operator mutants make it true on
+        // the finalizer path (disposing == false), which would unsubscribe the handler and
+        // silence subsequent timer reports.
+        using var timer = new ManualProgressTimer();
+        var sut = new TimerProbe(new List<int> { 1, 2, 3 }, timer);
+        var reports = 0;
+        var progress = new SynchronousProgress<Report>(_ => reports++);
+
+        var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
+        await enumerator.MoveNextAsync();
+
+        sut.CallDispose(disposing: false);
+        reports = 0;
+        timer.Fire();
+
+        Assert.Equal(1, reports);
+    }
+
+
+
+    [Fact]
+    public void Dispose_when_no_timer_was_injected_does_not_throw()
+    {
+        // Without an injected timer the guard is false and the body is skipped. A mutant that
+        // ignores the null-timer operand would dereference the null timer and throw.
+        var sut = new FaultyExtractor<int>(new[] { 1, 2, 3 });
+
+        var exception = Record.Exception(() => sut.Dispose());
+
+        Assert.Null(exception);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Cancellation checks — L370 (pre-loop) / L384 (in-loop, skip phase)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_with_no_items_and_a_pre_cancelled_token_still_throws()
+    {
+        // With an empty source the in-loop check never runs, so only the pre-loop
+        // ThrowIfCancellationRequested can observe the cancellation.
+        var sut = new FaultyExtractor<int>(Array.Empty<int>());
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.ExtractAsync(cts.Token))
+                {
+                }
+            }
+        );
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_cancelling_during_the_skip_phase_throws_promptly()
+    {
+        // Skip everything, and have the source cancel the token mid-skip. The token is NOT
+        // cancelled at method entry, so the pre-loop check passes; only the in-loop check at
+        // the top of the loop can catch it during the skip run.
+        using var cts = new CancellationTokenSource();
+
+        IEnumerable<int> Source()
+        {
+            yield return 1;    // skipped
+            yield return 2;    // skipped
+            cts.Cancel();      // still in the skip phase
+            yield return 3;    // in-loop check throws before the skip branch
+            yield return 4;
+        }
+
+        var sut = new FaultyExtractor<int>(Source()) { SkipItemCount = 10 };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.ExtractAsync(cts.Token))
+                {
+                }
+            }
+        );
+
+        // Only the first two were reached before the cancel; a dropped in-loop check would
+        // instead skip all four and complete without throwing.
+        Assert.Equal(2, sut.CurrentSkippedItemCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // DuplicateAt boundary against MaximumItemCount — L410
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_when_duplicate_would_exceed_MaximumItemCount_suppresses_it()
+    {
+        // After yielding item at index 1, CurrentItemCount == MaximumItemCount (2). The guard
+        // uses strict "<", so the duplicate is suppressed. The "<="/"off-by-one" mutant would
+        // emit a third item.
+        var sut = new FaultyExtractor<int>(new[] { 1, 2, 3 })
+            .DuplicateAt(1);
+        sut.MaximumItemCount = 2;
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(new[] { 1, 2 }, results);
+        Assert.Equal(2, sut.CurrentItemCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // finally block — StopTimer (L421) and enumerator.Dispose (L422)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_stops_the_injected_timer_in_the_finally()
+    {
+        var timer = new RecordingProgressTimer();
+        var sut = new TimerProbe(new List<int> { 1, 2, 3 }, timer);
+
+        await sut.ExtractAsync().ToListAsync();
+
+        Assert.True(timer.StopTimerCallCount >= 1, "The worker's finally must call StopTimer.");
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_disposes_the_source_enumerator_in_the_finally()
+    {
+        var source = new DisposeTrackingEnumerable<int>(new[] { 1, 2, 3 });
+        var sut = new FaultyExtractor<int>(source);
+
+        await sut.ExtractAsync().ToListAsync();
+
+        Assert.True(source.EnumeratorDisposed, "The worker's finally must dispose the source enumerator.");
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Test doubles
+    // ------------------------------------------------------------------
+
+    private sealed class OnItemErrorProbe : FaultyExtractor<int>
+    {
+        public OnItemErrorProbe() : base(new[] { 1 }) { }
+
+
+        public ItemErrorAction Probe(ItemErrorContext context) => OnItemError(context);
+    }
+
+
+
+    private sealed class TimerProbe : FaultyExtractor<int>
+    {
+        public TimerProbe(IEnumerable<int> items, IProgressTimer timer) : base(items, timer) { }
+
+
+        public void CallDispose(bool disposing) => Dispose(disposing);
+    }
+
+
+
+    private sealed class RecordingProgressTimer : IProgressTimer
+    {
+        public int StopTimerCallCount { get; private set; }
+
+
+#pragma warning disable CS0067 // Elapsed is never fired by this recording double.
+        public event Action? Elapsed;
+#pragma warning restore CS0067
+
+
+        public void Start(int intervalMilliseconds) { }
+
+
+        public void StopTimer() => StopTimerCallCount++;
+
+
+        public void Dispose() { }
+    }
+
+
+
+    private sealed class DisposeTrackingEnumerable<T> : IEnumerable<T>
+    {
+        private readonly IEnumerable<T> _inner;
+
+
+        public DisposeTrackingEnumerable(IEnumerable<T> inner) => _inner = inner;
+
+
+        public bool EnumeratorDisposed { get; private set; }
+
+
+        public IEnumerator<T> GetEnumerator() => new TrackingEnumerator(this, _inner.GetEnumerator());
+
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+
+        private sealed class TrackingEnumerator : IEnumerator<T>
+        {
+            private readonly DisposeTrackingEnumerable<T> _owner;
+            private readonly IEnumerator<T> _inner;
+
+
+            public TrackingEnumerator(DisposeTrackingEnumerable<T> owner, IEnumerator<T> inner)
+            {
+                _owner = owner;
+                _inner = inner;
+            }
+
+
+            public T Current => _inner.Current;
+
+
+            object? IEnumerator.Current => Current;
+
+
+            public bool MoveNext() => _inner.MoveNext();
+
+
+            public void Reset() => _inner.Reset();
+
+
+            public void Dispose()
+            {
+                _owner.EnumeratorDisposed = true;
+                _inner.Dispose();
+            }
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyExtractorMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyExtractorMutationTests.cs
@@ -374,4 +374,20 @@ public class FaultyExtractorMutationTests
             }
         }
     }
+
+
+
+    [Fact]
+    public async Task Dispose_marks_the_extractor_disposed_so_a_later_ExtractAsync_throws()
+    {
+        // Removing base.Dispose(disposing) leaves _disposed unset, so the use-after-dispose
+        // guard on ExtractAsync would no longer fire.
+        var extractor = new FaultyExtractor<int>(new[] { 1 });
+        extractor.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>
+        (
+            async () => await extractor.ExtractAsync().ToListAsync()
+        );
+    }
 }

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyLoaderMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyLoaderMutationTests.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit.Xunit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Mutation-hardening tests (#346) for <see cref="FaultyLoader{T}"/> — each targets a
+/// specific surviving mutant that the behavioural tests do not otherwise pin down.
+/// </summary>
+public class FaultyLoaderMutationTests
+{
+    // ------------------------------------------------------------------
+    // GetCollectedItems ternary — L123
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void GetCollectedItems_when_collectItems_is_false_returns_null()
+    {
+        // The always-true conditional mutant returns an (empty) array instead of null.
+        var loader = new FaultyLoader<int>(collectItems: false);
+
+        Assert.Null(loader.GetCollectedItems());
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // OnItemError ternary (base-vs-policy) — L296
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void OnItemError_when_no_policy_configured_falls_back_to_base_abort()
+    {
+        var probe = new OnItemErrorProbe();
+
+        var action = probe.Probe(new ItemErrorContext(1, new IOException("boom")));
+
+        Assert.Equal(ItemErrorAction.Abort, action);
+    }
+
+
+
+    [Fact]
+    public void OnItemError_when_policy_configured_uses_the_policy_result()
+    {
+        var probe = new OnItemErrorProbe();
+        probe.SkipErrors();
+
+        var action = probe.Probe(new ItemErrorContext(1, new IOException("boom")));
+
+        Assert.Equal(ItemErrorAction.Skip, action);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // HandleInjectedFault — Abort path must not count the item — L317
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_when_policy_returns_Abort_does_not_count_the_failing_item()
+    {
+        var loader = new FaultyLoader<int>(collectItems: false)
+            .ThrowAt(2, new IOException("fatal"))
+            .HandleErrorsWith(_ => ItemErrorAction.Abort);
+
+        await Assert.ThrowsAsync<IOException>
+        (
+            async () => await loader.LoadAsync(Enumerable.Range(1, 5).ToAsyncEnumerable())
+        );
+
+        Assert.Equal(2, loader.CurrentItemCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Progress-timer wiring seam — L332 / L334 / L336
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_firing_the_injected_timer_reports_progress_before_completion()
+    {
+        // Capture the report count while the load is still gated, so only a wired Elapsed
+        // handler (not the forced completion report) can satisfy it. Kills the "never wire"
+        // and "-=" mutants.
+        using var timer = new ManualProgressTimer();
+        var loader = new LoaderTimerProbe(collectItems: false, timer);
+        var reports = 0;
+        var progress = new SynchronousProgress<Report>(_ => reports++);
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var task = loader.LoadAsync(GatedSourceAsync(gate), progress);
+        timer.Fire();
+        var afterFire = reports;
+        gate.SetResult(true);
+        await task;
+
+        Assert.True(afterFire >= 1, $"Firing the injected timer must report progress; saw {afterFire}.");
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_wires_the_elapsed_handler_only_once_across_runs()
+    {
+        // Two overlapping loads on one instance make CreateProgressTimer run twice against the
+        // same (undisposed) timer. With the _progressTimerWired guard exactly one handler is
+        // subscribed, so one Fire() yields one report; the "wired = false" mutant subscribes
+        // twice, yielding two.
+        using var timer = new ManualProgressTimer();
+        var loader = new LoaderTimerProbe(collectItems: false, timer);
+        var reports = 0;
+        var progress = new SynchronousProgress<Report>(_ => reports++);
+        var g1 = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var g2 = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var t1 = loader.LoadAsync(GatedSourceAsync(g1), progress);
+        var t2 = loader.LoadAsync(GatedSourceAsync(g2), progress);
+
+        reports = 0;
+        timer.Fire();
+        var afterFire = reports;
+
+        g1.SetResult(true);
+        g2.SetResult(true);
+        await Task.WhenAll(t1, t2);
+
+        Assert.Equal(1, afterFire);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Dispose(bool) unsubscribe guard — L354 / L356
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Dispose_with_disposing_true_unsubscribes_the_handler()
+    {
+        // A completed-then-disposed loader must not report again when the timer fires. Kills the
+        // negate/equality mutants that leave the handler subscribed, and the "+=" mutant that
+        // subscribes a second time.
+        using var timer = new ManualProgressTimer();
+        var loader = new LoaderTimerProbe(collectItems: false, timer);
+        var reports = 0;
+        var progress = new SynchronousProgress<Report>(_ => reports++);
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var task = loader.LoadAsync(GatedSourceAsync(gate), progress);
+        loader.Dispose();
+        reports = 0;
+        timer.Fire();
+        var afterFire = reports;
+
+        gate.SetResult(true);
+        await task;
+
+        Assert.Equal(0, afterFire);
+    }
+
+
+
+    [Fact]
+    public async Task Dispose_with_disposing_false_does_not_unsubscribe_the_handler()
+    {
+        // The guard requires disposing == true; the logical-operator mutants make it true on the
+        // finalizer path (disposing == false), which would unsubscribe and silence reports.
+        using var timer = new ManualProgressTimer();
+        var loader = new LoaderTimerProbe(collectItems: false, timer);
+        var reports = 0;
+        var progress = new SynchronousProgress<Report>(_ => reports++);
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var task = loader.LoadAsync(GatedSourceAsync(gate), progress);
+        loader.CallDispose(disposing: false);
+        reports = 0;
+        timer.Fire();
+        var afterFire = reports;
+
+        gate.SetResult(true);
+        await task;
+
+        Assert.Equal(1, afterFire);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // base.Dispose(disposing) is invoked — L360
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Dispose_marks_the_loader_disposed_so_a_later_LoadAsync_throws()
+    {
+        // Removing base.Dispose(disposing) leaves _disposed unset, so the use-after-dispose
+        // guard on LoadAsync would no longer fire.
+        var loader = new FaultyLoader<int>(collectItems: false);
+        loader.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>
+        (
+            async () => await loader.LoadAsync(new[] { 1 }.ToAsyncEnumerable())
+        );
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Cancellation checks — L378 (pre-loop) / L388 (in-loop, skip phase)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_with_no_items_and_a_pre_cancelled_token_still_throws()
+    {
+        var loader = new FaultyLoader<int>(collectItems: false);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () => await loader.LoadAsync(EmptyIgnoringTokenAsync(), cts.Token)
+        );
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_cancelling_during_the_skip_phase_throws_promptly()
+    {
+        using var cts = new CancellationTokenSource();
+        var loader = new FaultyLoader<int>(collectItems: false);
+        loader.SkipItemCount = 10;
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () => await loader.LoadAsync(CancellingSkipSourceAsync(cts), cts.Token)
+        );
+
+        Assert.Equal(2, loader.CurrentSkippedItemCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // _buffer.Clear() between runs — L380
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_clears_the_buffer_between_runs()
+    {
+        var loader = new FaultyLoader<int>(collectItems: true);
+
+        await loader.LoadAsync(new[] { 1, 2 }.ToAsyncEnumerable());
+        await loader.LoadAsync(new[] { 3, 4 }.ToAsyncEnumerable());
+
+        // Without the clear, the second run's buffer would still hold the first run's items.
+        Assert.Equal(new[] { 3, 4 }, loader.GetCollectedItems());
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // DuplicateAt boundary against MaximumItemCount — L415
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_when_duplicate_would_exceed_MaximumItemCount_suppresses_it()
+    {
+        var loader = new FaultyLoader<int>(collectItems: true).DuplicateAt(1);
+        loader.MaximumItemCount = 2;
+
+        await loader.LoadAsync(new[] { 1, 2, 3 }.ToAsyncEnumerable());
+
+        Assert.Equal(new[] { 1, 2 }, loader.GetCollectedItems());
+        Assert.Equal(2, loader.CurrentItemCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // finally block — StopTimer — L430
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_stops_the_injected_timer_in_the_finally()
+    {
+        var timer = new RecordingProgressTimer();
+        var loader = new LoaderTimerProbe(collectItems: false, timer);
+
+        await loader.LoadAsync(new[] { 1, 2, 3 }.ToAsyncEnumerable());
+
+        Assert.True(timer.StopTimerCallCount >= 1, "The worker's finally must call StopTimer.");
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static async IAsyncEnumerable<int> GatedSourceAsync(TaskCompletionSource<bool> gate)
+    {
+        yield return 1;
+        await gate.Task.ConfigureAwait(false);
+        yield return 2;
+        yield return 3;
+    }
+
+
+
+    private static async IAsyncEnumerable<int> EmptyIgnoringTokenAsync
+    (
+        [EnumeratorCancellation] CancellationToken token = default
+    )
+    {
+        // Ignores the token so only the loader's own pre-loop check can observe cancellation.
+        _ = token;
+        await Task.CompletedTask.ConfigureAwait(false);
+        yield break;
+    }
+
+
+
+    private static async IAsyncEnumerable<int> CancellingSkipSourceAsync
+    (
+        CancellationTokenSource cts,
+        [EnumeratorCancellation] CancellationToken token = default
+    )
+    {
+        // Ignores the incoming token; cancels the source's own CTS mid-skip so only the loader's
+        // in-loop check can observe it.
+        _ = token;
+        yield return 1;    // skipped
+        yield return 2;    // skipped
+        cts.Cancel();      // still in the skip phase
+        yield return 3;    // in-loop check throws before the skip branch
+        yield return 4;
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Test doubles
+    // ------------------------------------------------------------------
+
+    private sealed class OnItemErrorProbe : FaultyLoader<int>
+    {
+        public OnItemErrorProbe() : base(collectItems: false) { }
+
+
+        public ItemErrorAction Probe(ItemErrorContext context) => OnItemError(context);
+    }
+
+
+
+    private sealed class LoaderTimerProbe : FaultyLoader<int>
+    {
+        public LoaderTimerProbe(bool collectItems, IProgressTimer timer) : base(collectItems, timer) { }
+
+
+        public void CallDispose(bool disposing) => Dispose(disposing);
+    }
+
+
+
+    private sealed class RecordingProgressTimer : IProgressTimer
+    {
+        public int StopTimerCallCount { get; private set; }
+
+
+#pragma warning disable CS0067 // Elapsed is never fired by this recording double.
+        public event Action? Elapsed;
+#pragma warning restore CS0067
+
+
+        public void Start(int intervalMilliseconds) { }
+
+
+        public void StopTimer() => StopTimerCallCount++;
+
+
+        public void Dispose() { }
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyTransformerMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyTransformerMutationTests.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit.Xunit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Targeted tests that kill Stryker mutation survivors in <see cref="FaultyTransformer{T}"/>
+/// (issue #346). Each test names the survivor it pins.
+/// </summary>
+public class FaultyTransformerMutationTests
+{
+    // ------------------------------------------------------------------
+    // OnItemError policy ternary (Conditional)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void OnItemError_when_no_policy_configured_returns_base_Abort()
+    {
+        // Kills Conditional(true): forcing the ternary condition true would invoke the
+        // null policy delegate and throw NullReferenceException instead of returning base.
+        var transformer = new ExposedFaultyTransformer();
+
+        var action = transformer.CallOnItemError
+        (
+            new ItemErrorContext(1, new InvalidOperationException())
+        );
+
+        Assert.Equal(ItemErrorAction.Abort, action);
+    }
+
+
+
+    [Fact]
+    public void OnItemError_when_policy_configured_returns_policy_result()
+    {
+        // Kills Conditional(false): forcing the condition false would return base.Abort
+        // rather than the configured policy's Skip.
+        var transformer = new ExposedFaultyTransformer();
+        transformer.HandleErrorsWith(_ => ItemErrorAction.Skip);
+
+        var action = transformer.CallOnItemError
+        (
+            new ItemErrorContext(1, new InvalidOperationException())
+        );
+
+        Assert.Equal(ItemErrorAction.Skip, action);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // HandleInjectedFault — Abort branch throws (Statement)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task TransformAsync_when_policy_returns_Abort_throws_without_counting_the_failing_item()
+    {
+        // Kills the `throw exception` Statement in the Abort branch: removing it would fall
+        // through to the no-policy path, which counts the failing item before throwing.
+        var expected    = new InvalidOperationException("abort");
+        var extractor   = new FaultyExtractor<int>(new[] { 1, 2, 3, 4, 5 });
+        var transformer = new FaultyTransformer<int>()
+            .HandleErrorsWith(_ => ItemErrorAction.Abort)
+            .ThrowAt(2, expected);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await transformer.TransformAsync(extractor.ExtractAsync()).ToListAsync()
+        );
+
+        Assert.Same(expected, actual);
+
+        // Items 0 and 1 were processed; the Abort branch throws before counting item 2.
+        Assert.Equal(2, transformer.CurrentItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_policy_returns_Skip_discards_the_failing_item_and_continues()
+    {
+        // Kills the `return true` Statement and the `== Skip` equality: the failing item is
+        // dropped, counted as an error, and the run continues.
+        var extractor   = new FaultyExtractor<int>(new[] { 10, 20, 30 });
+        var transformer = new FaultyTransformer<int>()
+            .SkipErrors()
+            .ThrowAt(1, new InvalidOperationException("boom"));
+
+        var results = await transformer.TransformAsync(extractor.ExtractAsync()).ToListAsync();
+
+        Assert.Equal(new[] { 10, 30 }, results);
+        Assert.Equal(1, transformer.CurrentErrorItemCount);
+        Assert.Single(transformer.CapturedErrors);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Progress-timer wiring seam (CreateProgressTimer)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateProgressTimer_across_two_runs_wires_the_Elapsed_handler_exactly_once()
+    {
+        // Kills the wiring seam: `!_progressTimerWired` (never wire), `_progressTimerWired = true`
+        // (re-wire every run -> two subscriptions), and `Elapsed +=` -> `-=` (never subscribe).
+        using var timer = new CountingProgressTimer();
+        var transformer = new TimedFaultyTransformer(timer);
+        var reportCount = 0;
+        var progress    = new SynchronousProgress<Report>(_ => reportCount++);
+
+        await transformer
+            .TransformAsync(new FaultyExtractor<int>(new[] { 1, 2, 3 }).ExtractAsync(), progress)
+            .ToListAsync();
+        await transformer
+            .TransformAsync(new FaultyExtractor<int>(new[] { 4, 5, 6 }).ExtractAsync(), progress)
+            .ToListAsync();
+
+        // The guard latches after the first run, so exactly one handler is subscribed.
+        Assert.Equal(1, timer.SubscriberCount);
+
+        reportCount = 0;
+        timer.Fire();
+
+        Assert.Equal(1, reportCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Worker finally — StopTimer (Statement)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task TransformAsync_stops_the_injected_timer_when_the_worker_completes()
+    {
+        // Kills the `_progressTimer?.StopTimer()` Statement in the worker's finally.
+        using var timer = new CountingProgressTimer();
+        var transformer = new TimedFaultyTransformer(timer);
+
+        await transformer
+            .TransformAsync(new FaultyExtractor<int>(new[] { 1, 2, 3 }).ExtractAsync())
+            .ToListAsync();
+
+        Assert.Equal(1, timer.StopTimerCallCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Cancellation — pre-loop and in-loop ThrowIfCancellationRequested
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task TransformAsync_with_empty_source_and_pre_cancelled_token_still_throws()
+    {
+        // Kills the pre-loop ThrowIfCancellationRequested Statement: with an empty source the
+        // in-loop check never runs, so only the pre-loop check can throw. The source ignores
+        // the token, isolating the transformer's own check.
+        var transformer = new FaultyTransformer<int>();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in transformer.TransformAsync(EmptyIgnoringCancellationAsync(), cts.Token))
+                {
+                }
+            }
+        );
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_cancelling_mid_stream_throws_and_stops_promptly()
+    {
+        // Kills the in-loop ThrowIfCancellationRequested Statement: the source ignores the
+        // token, so only the transformer's per-iteration check can stop the stream.
+        var transformer = new FaultyTransformer<int>();
+        using var cts = new CancellationTokenSource();
+        var processed = 0;
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in transformer.TransformAsync(CountingSourceIgnoringCancellationAsync(), cts.Token))
+                {
+                    processed++;
+                    if (processed == 3)
+                    {
+#pragma warning disable CA1849, VSTHRD103 // sync Cancel() — CancelAsync is net8+ only
+                        cts.Cancel();
+#pragma warning restore CA1849, VSTHRD103
+                    }
+                }
+            }
+        );
+
+        Assert.Equal(3, processed);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // DuplicateAt guard — CurrentItemCount < MaximumItemCount boundary
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task TransformAsync_when_DuplicateAt_would_exceed_MaximumItemCount_does_not_emit_the_duplicate()
+    {
+        // Kills the `CurrentItemCount < MaximumItemCount` guard on the duplicate path: after the
+        // first item is counted, count (1) is not < max (1), so no duplicate is emitted.
+        var extractor   = new FaultyExtractor<int>(new[] { 5, 6 });
+        var transformer = new FaultyTransformer<int>().DuplicateAt(0);
+        transformer.MaximumItemCount = 1;
+
+        var results = await transformer.TransformAsync(extractor.ExtractAsync()).ToListAsync();
+
+        Assert.Equal(new[] { 5 }, results);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_DuplicateAt_fits_within_MaximumItemCount_emits_the_duplicate()
+    {
+        // Complements the boundary test above: with room under the max, the duplicate IS emitted.
+        var extractor   = new FaultyExtractor<int>(new[] { 5, 6 });
+        var transformer = new FaultyTransformer<int>().DuplicateAt(0);
+        transformer.MaximumItemCount = 2;
+
+        var results = await transformer.TransformAsync(extractor.ExtractAsync()).ToListAsync();
+
+        Assert.Equal(new[] { 5, 5 }, results);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Dispose — no injected timer
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Dispose_when_no_injected_timer_does_not_throw()
+    {
+        var transformer = new FaultyTransformer<int>();
+
+        var exception = Record.Exception(() => transformer.Dispose());
+
+        Assert.Null(exception);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static async IAsyncEnumerable<int> EmptyIgnoringCancellationAsync()
+    {
+        await Task.CompletedTask.ConfigureAwait(false);
+        yield break;
+    }
+
+
+
+    private static async IAsyncEnumerable<int> CountingSourceIgnoringCancellationAsync()
+    {
+        for (var i = 1; i <= 100; i++)
+        {
+            await Task.Yield();
+            yield return i;
+        }
+    }
+
+
+
+    private sealed class ExposedFaultyTransformer : FaultyTransformer<int>
+    {
+        public ItemErrorAction CallOnItemError(ItemErrorContext context) => OnItemError(context);
+    }
+
+
+
+    private sealed class TimedFaultyTransformer : FaultyTransformer<int>
+    {
+        public TimedFaultyTransformer(IProgressTimer timer) : base(timer)
+        {
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyTransformerMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyTransformerMutationTests.cs
@@ -298,4 +298,20 @@ public class FaultyTransformerMutationTests
         {
         }
     }
+
+
+
+    [Fact]
+    public async Task Dispose_marks_the_transformer_disposed_so_a_later_TransformAsync_throws()
+    {
+        // Removing base.Dispose(disposing) leaves _disposed unset, so the use-after-dispose
+        // guard on TransformAsync would no longer fire.
+        var transformer = new FaultyTransformer<int>();
+        transformer.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>
+        (
+            async () => await transformer.TransformAsync(new[] { 1 }.ToAsyncEnumerable()).ToListAsync()
+        );
+    }
 }

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualProgressTimerCoreMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualProgressTimerCoreMutationTests.cs
@@ -1,0 +1,30 @@
+using System;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Mutation-hardening tests (#346) for <see cref="ManualProgressTimerCore"/>: they pin the exact
+/// text of the "timer has not started" exception, whose message is built from two string literals.
+/// </summary>
+public class ManualProgressTimerCoreMutationTests
+{
+    [Fact]
+    public void Tick_before_the_run_starts_reports_the_full_reason()
+    {
+        var timer = new ManualProgressTimerCore();
+
+        var ex = Assert.Throws<InvalidOperationException>
+        (
+            () => timer.Tick()
+        );
+
+        // Assert against text from BOTH concatenated literals so neither can be blanked.
+        Assert.Equal
+        (
+            "The progress timer has not started. Begin the run (start enumeration / invoke the " +
+            "loader) before calling Tick().",
+            ex.Message
+        );
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualTimeSourceMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualTimeSourceMutationTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Mutation-hardening tests (#346) for <see cref="ManualTimeSource"/>: they pin the
+/// <see cref="ManualTimeSource.Advance"/> validation boundary, its exception-message text, and the
+/// direction the clock moves.
+/// </summary>
+public class ManualTimeSourceMutationTests
+{
+    [Fact]
+    public void Advance_by_zero_is_allowed()
+    {
+        // Boundary: the guard is `delta < TimeSpan.Zero`, so a zero delta is VALID. The `<= Zero`
+        // mutant would reject it — advancing by zero must not throw.
+        var clock = new ManualTimeSource();
+
+        clock.Advance(TimeSpan.Zero);
+    }
+
+
+
+    [Fact]
+    public void Advance_when_delta_is_negative_reports_the_reason()
+    {
+        // Kills the string mutant on the negative-delta ArgumentOutOfRangeException message.
+        var clock = new ManualTimeSource();
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => clock.Advance(TimeSpan.FromSeconds(-1))
+        );
+
+        Assert.Contains("Cannot advance time by a negative amount", ex.Message);
+    }
+
+
+
+    [Fact]
+    public async Task Advance_moves_the_wall_clock_forward_by_the_delta()
+    {
+        // The wall clock (surfaced as Report.StartedAt when a run begins) must move FORWARD by the
+        // delta. The `_utcNow -= delta` mutant would move it backward instead. Advancing before the
+        // run means StartedAt is captured at the advanced instant.
+        var start = new DateTimeOffset(2020, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var clock = new ManualTimeSource(start);
+        var sut   = new ExposedExtractor<int>(new[] { 1, 2, 3 });
+        sut.WithTimeSource(clock);
+
+        clock.Advance(TimeSpan.FromSeconds(10));
+        await sut.ExtractAsync(CancellationToken.None).ToListAsync();
+
+        var report = sut.GetProgressReport();
+
+        Assert.Equal(start + TimeSpan.FromSeconds(10), report.StartedAt);
+    }
+
+
+
+    private sealed class ExposedExtractor<T> : TestExtractor<T>
+        where T : notnull
+    {
+        public ExposedExtractor(IEnumerable<T> items)
+            : base(items)
+        {
+        }
+
+
+
+        public Report GetProgressReport() => CreateProgressReport();
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/RecordingMiddlewareMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/RecordingMiddlewareMutationTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Mutation-hardening tests (#346) for <see cref="RecordingMiddleware{T}"/>: they pin the
+/// cancellation check at the top of <see cref="RecordingMiddleware{T}.OnItemAsync"/>.
+/// </summary>
+public class RecordingMiddlewareMutationTests
+{
+    [Fact]
+    public async Task OnItemAsync_when_token_is_already_cancelled_throws_and_records_nothing()
+    {
+        // The guard runs before the item is recorded, so a cancelled token must throw and leave
+        // Observed empty. Dropping the guard would record the item and return a result instead.
+        var middleware = new RecordingMiddleware<int>();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>
+        (
+            async () => await middleware.OnItemAsync(42, cts.Token)
+        );
+
+        Assert.Empty(middleware.Observed);
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/RetryingExtractorMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/RetryingExtractorMutationTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Mutation-hardening tests (#346) for <see cref="RetryingExtractor{T}"/>: they pin the exact
+/// exception-message text, the <c>maxAttempts</c> validation boundary, and the two cancellation
+/// checks in the worker that broader behavioural tests leave as surviving mutants.
+/// </summary>
+public class RetryingExtractorMutationTests
+{
+    // ------------------------------------------------------------------
+    // Constructor — exception message text
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Constructor_when_failFirstAttempts_is_negative_reports_the_reason()
+    {
+        // Kills the string mutant on the failFirstAttempts ArgumentOutOfRangeException message.
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => new RetryingExtractor<int>(new[] { 1 }, failFirstAttempts: -1, maxAttempts: 1)
+        );
+
+        Assert.Contains("Must not be negative", ex.Message);
+    }
+
+
+
+    [Fact]
+    public void Constructor_when_maxAttempts_is_less_than_one_reports_the_reason()
+    {
+        // Kills the string mutant on the maxAttempts ArgumentOutOfRangeException message.
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => new RetryingExtractor<int>(new[] { 1 }, failFirstAttempts: 0, maxAttempts: 0)
+        );
+
+        Assert.Contains("Must be at least 1", ex.Message);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // maxAttempts validation boundary
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Constructor_when_maxAttempts_is_exactly_one_is_valid()
+    {
+        // Boundary: the guard is `maxAttempts < 1`, so 1 is the smallest VALID value. The `<= 1`
+        // mutant would reject it — this run must construct cleanly and extract every item.
+        var sut = new RetryingExtractor<int>(new[] { 1, 2, 3 }, failFirstAttempts: 0, maxAttempts: 1);
+
+        var items = await sut.ExtractAsync(CancellationToken.None).ToListAsync();
+
+        Assert.Equal(new[] { 1, 2, 3 }, items);
+        Assert.Equal(1, sut.AttemptCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Transient-fault message — the LAST fault propagates
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_when_budget_is_exhausted_propagates_the_last_faults_message()
+    {
+        // failFirstAttempts (5) >= maxAttempts (3): every attempt faults and the budget runs out on
+        // attempt 3, so the fault carried by attempt 3 is the one that propagates. Pins the
+        // interpolated fault-message string and that the newest (not an earlier) fault surfaces.
+        var sut = new RetryingExtractor<int>(new[] { 1, 2, 3 }, failFirstAttempts: 5, maxAttempts: 3);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.ExtractAsync(CancellationToken.None))
+                {
+                }
+            }
+        );
+
+        Assert.Equal("Transient fault on attempt 3.", ex.Message);
+        Assert.Equal(3, sut.AttemptCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Cancellation — the pre-loop check (empty source removes the in-loop mask)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_with_empty_source_and_a_pre_cancelled_token_still_throws()
+    {
+        // With no items the in-loop ThrowIfCancellationRequested never runs, so the pre-loop check is
+        // the only cancellation guard — dropping it would let an empty, already-cancelled run
+        // complete silently. This isolates and kills that pre-loop statement.
+        var sut = new RetryingExtractor<int>(Array.Empty<int>(), failFirstAttempts: 0, maxAttempts: 3);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.ExtractAsync(cts.Token))
+                {
+                }
+            }
+        );
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Cancellation — the in-loop check (cancelled only after the pre-loop check passes)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_cancelled_while_iterating_items_throws_from_the_in_loop_check()
+    {
+        // The source cancels the token as its first item is pulled — after the pre-loop check has
+        // already passed — so only the in-loop ThrowIfCancellationRequested can observe it. Without
+        // that check every item would be yielded and the run would complete normally.
+        using var cts = new CancellationTokenSource();
+        var sut = new RetryingExtractor<int>
+        (
+            new CancellingSequence(cts, cancelAtIndex: 0, count: 5),
+            failFirstAttempts: 0,
+            maxAttempts: 3
+        );
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.ExtractAsync(cts.Token))
+                {
+                }
+            }
+        );
+
+        // Cancellation is not a retryable fault, so exactly one worker attempt ran.
+        Assert.Equal(1, sut.AttemptCount);
+    }
+
+
+
+    // A synchronous sequence that cancels the supplied source as a chosen item is produced, so the
+    // token flips from not-cancelled (at the pre-loop check) to cancelled (at the in-loop check).
+    private sealed class CancellingSequence : IEnumerable<int>
+    {
+        private readonly CancellationTokenSource _cts;
+        private readonly int _cancelAtIndex;
+        private readonly int _count;
+
+        public CancellingSequence(CancellationTokenSource cts, int cancelAtIndex, int count)
+        {
+            _cts           = cts;
+            _cancelAtIndex = cancelAtIndex;
+            _count         = count;
+        }
+
+
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            for (var i = 0; i < _count; i++)
+            {
+                if (i == _cancelAtIndex)
+                {
+                    _cts.Cancel();
+                }
+
+                yield return i;
+            }
+        }
+
+
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/SnapshotTestLoaderMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/SnapshotTestLoaderMutationTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Mutation-hardening tests (#346) for <see cref="SnapshotTestLoader{T}"/>: they pin the two
+/// cancellation checks in <c>LoadWorkerAsync</c> — the pre-loop guard and the per-item guard — that
+/// the behavioural tests leave as surviving statement mutants.
+/// </summary>
+public class SnapshotTestLoaderMutationTests
+{
+    [Fact]
+    public async Task LoadAsync_with_empty_source_and_a_pre_cancelled_token_still_throws()
+    {
+        // With no items the per-item ThrowIfCancellationRequested never runs, so the pre-loop check is
+        // the only cancellation guard. The source deliberately ignores the token, so dropping that
+        // pre-loop statement would let an already-cancelled run complete silently.
+        var loader = new SnapshotTestLoader<int>();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            () => loader.LoadAsync(EmptyIgnoringCancellation(), cts.Token)
+        );
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_cancelled_while_receiving_items_throws_from_the_per_item_check()
+    {
+        // The source cancels the token as its first item is produced — after the pre-loop check has
+        // passed — so only the per-item ThrowIfCancellationRequested can observe it. Without that
+        // check both items would be buffered and the load would complete normally.
+        var loader = new SnapshotTestLoader<int>();
+        using var cts = new CancellationTokenSource();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            () => loader.LoadAsync(CancelOnFirst(cts), cts.Token)
+        );
+
+        // The item that triggered cancellation was never captured.
+        Assert.Empty(loader.LoadedItems);
+    }
+
+
+
+    private static async IAsyncEnumerable<int> EmptyIgnoringCancellation()
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+
+
+    private static async IAsyncEnumerable<int> CancelOnFirst(CancellationTokenSource cts)
+    {
+        cts.Cancel();
+        yield return 1;
+        yield return 2;
+        await Task.CompletedTask;
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorMutationTests.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit.Xunit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Targeted mutation-hardening tests for <see cref="TestExtractor{T}"/> (#346).
+/// Each test kills a specific surviving mutant; the survivor's source line is noted
+/// in a comment so the mapping stays traceable.
+/// </summary>
+public class TestExtractorMutationTests
+{
+    // ------------------------------------------------------------------
+    // count == 0 boundary guards — kills `count < 0` -> `count <= 0`
+    // (Func<T>,count L205; Func<int,T>,count L269; +timer L340; +timer L416)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Constructor_func_count_when_count_is_zero_constructs_and_yields_no_items()
+    {
+        // L205: `count < 0`. A zero count is valid (yields nothing); the `<=` mutant would throw.
+        var sut = new TestExtractor<int>(() => 1, 0);
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Empty(results);
+    }
+
+
+
+    [Fact]
+    public async Task Constructor_indexed_factory_count_when_count_is_zero_constructs_and_yields_no_items()
+    {
+        // L269: `count < 0` on the indexed-factory + count constructor.
+        var sut = new TestExtractor<int>(i => i, 0);
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Empty(results);
+    }
+
+
+
+    [Fact]
+    public async Task Constructor_func_count_timer_when_count_is_zero_constructs_and_yields_no_items()
+    {
+        // L340: `count < 0` on the protected Func<T> + count + timer constructor.
+        using var timer = new ManualProgressTimer();
+        var sut = new ExposedTimerExtractor(() => 1, 0, timer);
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Empty(results);
+    }
+
+
+
+    [Fact]
+    public async Task Constructor_indexed_factory_count_timer_when_count_is_zero_constructs_and_yields_no_items()
+    {
+        // L416: `count < 0` on the protected Func<int,T> + count + timer constructor.
+        using var timer = new ManualProgressTimer();
+        var sut = new ExposedTimerExtractor(i => i, 0, timer);
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Empty(results);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Timer-injection wiring seam
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void CreateProgressTimer_called_twice_wires_Elapsed_only_once()
+    {
+        // Kills three survivors on the wiring seam:
+        //   L483 `!_progressTimerWired`  — remove `!` => never wires => 0 reports.
+        //   L485 `_progressTimerWired = true;` — flip/remove => re-wires => 2 reports.
+        //   L487 `_progressTimer.Elapsed += _elapsedHandler;` — remove => 0 reports.
+        // The guarded original wires exactly one handler, so one Fire() => exactly one report.
+        using var timer = new ManualProgressTimer();
+        var reportCount = 0;
+        var progress = new SynchronousProgress<Report>(_ => reportCount++);
+        var sut = new ExposedTimerExtractor(new List<int> { 1, 2, 3 }, timer);
+
+        sut.CallCreateProgressTimer(progress);
+        sut.CallCreateProgressTimer(progress);
+        timer.Fire();
+
+        Assert.Equal(1, reportCount);
+    }
+
+
+
+    [Fact]
+    public void Dispose_when_not_disposing_leaves_the_Elapsed_subscription_intact()
+    {
+        // L505: `disposing && _progressTimer is not null && _elapsedHandler is not null` (both &&).
+        // On the finalizer path (disposing == false) the original leaves the caller-owned timer
+        // untouched, so a subsequent Fire() still reports. Either `&&`->`||` mutant would
+        // unsubscribe here, producing zero reports.
+        using var timer = new ManualProgressTimer();
+        var reportCount = 0;
+        var progress = new SynchronousProgress<Report>(_ => reportCount++);
+        var sut = new ExposedTimerExtractor(new List<int> { 1, 2, 3 }, timer);
+
+        sut.CallCreateProgressTimer(progress); // wires the Elapsed handler
+        sut.CallDispose(false);                // finalizer path — must NOT unsubscribe
+        timer.Fire();
+
+        Assert.Equal(1, reportCount);
+    }
+
+
+
+    [Fact]
+    public void ExtractAsync_after_Dispose_throws_ObjectDisposedException()
+    {
+        // L511: `base.Dispose(disposing);`. Removing it leaves the base `_disposed` flag unset,
+        // so the use-after-dispose guard on ExtractAsync would no longer fire.
+        var sut = new TestExtractor<int>(new List<int> { 1, 2, 3 });
+
+        sut.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => sut.ExtractAsync());
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Worker statements
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_with_empty_source_and_a_pre_cancelled_token_still_throws()
+    {
+        // L533: the pre-loop `token.ThrowIfCancellationRequested()`. With an empty source the
+        // in-loop check never runs, so removing the pre-loop statement would let the run complete.
+        var sut = new TestExtractor<int>(new List<int>());
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.ExtractAsync(cts.Token))
+                {
+                }
+            }
+        );
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_stops_the_injected_timer_when_the_run_completes()
+    {
+        // L569: `_progressTimer?.StopTimer();` in the worker's finally. Running without a progress
+        // sink means the base never creates or touches the injected timer, so the only StopTimer
+        // call comes from this line — removing it leaves the recording timer untouched.
+        var timer = new RecordingProgressTimer();
+        var sut = new ExposedTimerExtractor(new List<int> { 1, 2, 3 }, timer);
+
+        await sut.ExtractAsync().ToListAsync();
+
+        Assert.True
+        (
+            timer.StopTimerCallCount >= 1,
+            "Expected the worker's finally to stop the injected timer."
+        );
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private sealed class ExposedTimerExtractor : TestExtractor<int>
+    {
+        public ExposedTimerExtractor(IEnumerable<int> items, IProgressTimer timer)
+            : base(items, timer) { }
+
+        public ExposedTimerExtractor(Func<int> factory, int count, IProgressTimer timer)
+            : base(factory, count, timer) { }
+
+        public ExposedTimerExtractor(Func<int, int> factory, int count, IProgressTimer timer)
+            : base(factory, count, timer) { }
+
+        public IProgressTimer CallCreateProgressTimer(IProgress<Report> progress) =>
+            CreateProgressTimer(progress);
+
+        public void CallDispose(bool disposing) => Dispose(disposing);
+    }
+
+
+
+    // A minimal IProgressTimer test double that records StopTimer invocations.
+    private sealed class RecordingProgressTimer : IProgressTimer
+    {
+        public int StopTimerCallCount { get; private set; }
+
+#pragma warning disable CS0067 // Elapsed is mandated by IProgressTimer but never raised by this recording double.
+        public event Action? Elapsed;
+#pragma warning restore CS0067
+
+        public void Start(int intervalMilliseconds) { }
+
+        public void StopTimer() => StopTimerCallCount++;
+
+        public void Dispose() { }
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorTests.cs
@@ -757,7 +757,7 @@ public class TestExtractorTests
     {
         var ex = Assert.Throws<ArgumentNullException>
         (
-            () => new TestExtractorWithTimer((Func<int, int>)(i => i), null!)
+            () => new TestExtractorWithTimer(i => i, null!)
         );
 
         Assert.Equal("timer", ex.ParamName);
@@ -785,7 +785,7 @@ public class TestExtractorTests
         using var timer = new ManualProgressTimer();
         var ex = Assert.Throws<ArgumentOutOfRangeException>
         (
-            () => new TestExtractorWithTimer((Func<int, int>)(i => i), -1, timer)
+            () => new TestExtractorWithTimer(i => i, -1, timer)
         );
 
         Assert.Equal("count", ex.ParamName);
@@ -798,7 +798,7 @@ public class TestExtractorTests
     {
         var ex = Assert.Throws<ArgumentNullException>
         (
-            () => new TestExtractorWithTimer((Func<int, int>)(i => i), 3, null!)
+            () => new TestExtractorWithTimer(i => i, 3, null!)
         );
 
         Assert.Equal("timer", ex.ParamName);

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestLoaderMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestLoaderMutationTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit.Xunit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Targeted tests that kill Stryker mutation survivors in <see cref="TestLoader{T}"/>
+/// (issue #346). Each test names the survivor it pins.
+/// </summary>
+public class TestLoaderMutationTests
+{
+    // ------------------------------------------------------------------
+    // CreateProgressTimer — `_progressTimer is null` guard (Equality)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_with_progress_and_no_injected_timer_loads_without_error()
+    {
+        // Kills the `_progressTimer is null` Equality: flipping it to `is not null` skips the
+        // base-timer path for a default-constructed loader and dereferences the null timer.
+        var loader   = new TestLoader<int>(collectItems: false);
+        var progress = new SynchronousProgress<Report>(_ => { });
+
+        await loader.LoadAsync
+        (
+            new TestExtractor<int>(new List<int> { 1, 2, 3 }).ExtractAsync(),
+            progress
+        );
+
+        Assert.Equal(3, loader.CurrentItemCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Progress-timer wiring seam
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateProgressTimer_across_two_runs_wires_the_Elapsed_handler_exactly_once()
+    {
+        // Kills the wiring seam: `!_progressTimerWired` (never wire), `_progressTimerWired = true`
+        // (re-wire every run -> two subscriptions), and `Elapsed +=` -> `-=` (never subscribe).
+        using var timer = new CountingProgressTimer();
+        var loader      = new TimedTestLoader(collectItems: false, timer);
+        var reportCount = 0;
+        var progress    = new SynchronousProgress<Report>(_ => reportCount++);
+
+        await loader.LoadAsync(new TestExtractor<int>(new List<int> { 1, 2, 3 }).ExtractAsync(), progress);
+        await loader.LoadAsync(new TestExtractor<int>(new List<int> { 4, 5, 6 }).ExtractAsync(), progress);
+
+        Assert.Equal(1, timer.SubscriberCount);
+
+        reportCount = 0;
+        timer.Fire();
+
+        Assert.Equal(1, reportCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Dispose — unsubscribe guard (Equality ×2) and Elapsed -= (assignment)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Dispose_after_timer_wired_unsubscribes_so_firing_produces_no_report()
+    {
+        // Kills the Dispose guard's `is not null` Equality mutations (either flip would skip the
+        // unsubscribe) and the `Elapsed -=` -> `+=` mutation (which would add a second handler).
+        using var timer = new CountingProgressTimer();
+        var reportCount = 0;
+        var progress    = new SynchronousProgress<Report>(_ => reportCount++);
+        var loader      = new TimedTestLoader(collectItems: false, timer);
+
+        await loader.LoadAsync(new TestExtractor<int>(new List<int> { 1, 2, 3 }).ExtractAsync(), progress);
+
+        Assert.Equal(1, timer.SubscriberCount);
+
+        loader.Dispose();
+
+        Assert.Equal(0, timer.SubscriberCount);
+
+        reportCount = 0;
+        timer.Fire();
+
+        Assert.Equal(0, reportCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Dispose — base.Dispose(disposing) (Statement)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_after_Dispose_throws_ObjectDisposedException()
+    {
+        // Kills the `base.Dispose(disposing)` Statement: without it the disposed flag is never
+        // set, so the use-after-dispose guard would not fire.
+        var loader = new TestLoader<int>(collectItems: true);
+        loader.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>
+        (
+            async () => await loader.LoadAsync(new TestExtractor<int>(new List<int> { 1 }).ExtractAsync())
+        );
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Worker finally — StopTimer (Statement)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_stops_the_injected_timer_when_the_worker_completes()
+    {
+        // Kills the `_progressTimer?.StopTimer()` Statement in the worker's finally.
+        using var timer = new CountingProgressTimer();
+        var loader = new TimedTestLoader(collectItems: false, timer);
+
+        await loader.LoadAsync(new TestExtractor<int>(new List<int> { 1, 2, 3 }).ExtractAsync());
+
+        Assert.Equal(1, timer.StopTimerCallCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Cancellation — pre-loop and in-loop ThrowIfCancellationRequested
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_with_empty_source_and_pre_cancelled_token_still_throws()
+    {
+        // Kills the pre-loop ThrowIfCancellationRequested Statement: with an empty, token-ignoring
+        // source the in-loop check never runs, so only the pre-loop check can throw.
+        var loader = new TestLoader<int>(collectItems: true);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () => await loader.LoadAsync(EmptyIgnoringCancellationAsync(), cts.Token)
+        );
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_cancelling_mid_stream_throws_after_processing_the_items_seen_so_far()
+    {
+        // Kills the in-loop ThrowIfCancellationRequested Statement: the source cancels the token
+        // as it produces the 4th item but never observes the token itself, so only the loader's
+        // per-iteration check can stop the load.
+        using var cts = new CancellationTokenSource();
+        var loader = new TestLoader<int>(collectItems: true);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () => await loader.LoadAsync(CancelAfterThreeAsync(cts), cts.Token)
+        );
+
+        Assert.Equal(3, loader.CurrentItemCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Buffering guard — `_collectItems && !IsDryRun` (Logical / Boolean)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_when_collectItems_true_and_IsDryRun_true_enumerates_but_buffers_nothing()
+    {
+        // Kills the buffering guard mutations: `&&` -> `||` and dropping `!` would both buffer the
+        // items in dry-run mode. The items must be counted but not collected.
+        var extractor = new TestExtractor<int>(new List<int> { 1, 2, 3 });
+        var loader    = new TestLoader<int>(collectItems: true) { IsDryRun = true };
+
+        await loader.LoadAsync(extractor.ExtractAsync());
+
+        var items = loader.GetCollectedItems();
+
+        Assert.NotNull(items);
+        Assert.Empty(items);
+        Assert.Equal(3, loader.CurrentItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_when_collectItems_true_and_IsDryRun_false_buffers_the_items()
+    {
+        // Complements the dry-run test: the buffering guard must be true when not dry-running.
+        var extractor = new TestExtractor<int>(new List<int> { 1, 2, 3 });
+        var loader    = new TestLoader<int>(collectItems: true) { IsDryRun = false };
+
+        await loader.LoadAsync(extractor.ExtractAsync());
+
+        Assert.Equal(new[] { 1, 2, 3 }, loader.GetCollectedItems());
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static async IAsyncEnumerable<int> EmptyIgnoringCancellationAsync()
+    {
+        await Task.CompletedTask.ConfigureAwait(false);
+        yield break;
+    }
+
+
+
+    private static async IAsyncEnumerable<int> CancelAfterThreeAsync(CancellationTokenSource cts)
+    {
+        for (var i = 1; i <= 100; i++)
+        {
+            if (i == 4)
+            {
+#pragma warning disable CA1849, VSTHRD103 // sync Cancel() — CancelAsync is net8+ only
+                cts.Cancel();
+#pragma warning restore CA1849, VSTHRD103
+            }
+
+            await Task.Yield();
+            yield return i;
+        }
+    }
+
+
+
+    private sealed class TimedTestLoader : TestLoader<int>
+    {
+        public TimedTestLoader(bool collectItems, IProgressTimer timer) : base(collectItems, timer)
+        {
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestTransformerMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestTransformerMutationTests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit.Xunit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Targeted mutation-hardening tests for <see cref="TestTransformer{T}"/> (#346).
+/// Each test kills a specific surviving mutant; the survivor's source line is noted
+/// in a comment so the mapping stays traceable.
+/// </summary>
+public class TestTransformerMutationTests
+{
+    // ------------------------------------------------------------------
+    // Timer-injection wiring seam
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void CreateProgressTimer_with_injected_timer_returns_that_timer()
+    {
+        // L86: `if (_progressTimer is null)`. With an injected (non-null) timer the original skips
+        // the base and returns the injected instance; the `is not null` mutant would delegate to the
+        // base and hand back a different, base-built timer.
+        using var timer = new ManualProgressTimer();
+        var progress = new SynchronousProgress<Report>(_ => { });
+        var sut = new ExposedTimerTransformer(timer);
+
+        var result = sut.CallCreateProgressTimer(progress);
+
+        Assert.Same(timer, result);
+    }
+
+
+
+    [Fact]
+    public void CreateProgressTimer_called_twice_wires_Elapsed_only_once()
+    {
+        // Kills three survivors on the wiring seam:
+        //   L91 `!_progressTimerWired` — remove `!` => never wires => 0 reports.
+        //   L93 `_progressTimerWired = true;` — flip/remove => re-wires => 2 reports.
+        //   L95 `_progressTimer.Elapsed += _elapsedHandler;` — remove => 0 reports.
+        using var timer = new ManualProgressTimer();
+        var reportCount = 0;
+        var progress = new SynchronousProgress<Report>(_ => reportCount++);
+        var sut = new ExposedTimerTransformer(timer);
+
+        sut.CallCreateProgressTimer(progress);
+        sut.CallCreateProgressTimer(progress);
+        timer.Fire();
+
+        Assert.Equal(1, reportCount);
+    }
+
+
+
+    [Fact]
+    public void Dispose_when_not_disposing_leaves_the_Elapsed_subscription_intact()
+    {
+        // L113: `disposing && _progressTimer is not null && _elapsedHandler is not null` (both &&).
+        // On the finalizer path (disposing == false) the original must not touch the caller-owned
+        // timer, so a subsequent Fire() still reports. Either `&&`->`||` mutant unsubscribes here.
+        using var timer = new ManualProgressTimer();
+        var reportCount = 0;
+        var progress = new SynchronousProgress<Report>(_ => reportCount++);
+        var sut = new ExposedTimerTransformer(timer);
+
+        sut.CallCreateProgressTimer(progress); // wires the Elapsed handler
+        sut.CallDispose(false);                // finalizer path — must NOT unsubscribe
+        timer.Fire();
+
+        Assert.Equal(1, reportCount);
+    }
+
+
+
+    [Fact]
+    public void TransformAsync_after_Dispose_throws_ObjectDisposedException()
+    {
+        // L119: `base.Dispose(disposing);`. Removing it leaves the base `_disposed` flag unset,
+        // so the use-after-dispose guard on TransformAsync would no longer fire.
+        var sut = new TestTransformer<int>();
+        var source = new TestExtractor<int>(new List<int> { 1 }).ExtractAsync();
+
+        sut.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => sut.TransformAsync(source));
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Worker statements
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task TransformAsync_with_empty_source_and_a_pre_cancelled_token_still_throws()
+    {
+        // L137: the pre-loop `token.ThrowIfCancellationRequested()`. The source is empty AND ignores
+        // cancellation, so the transformer's own pre-loop check is the ONLY thing that can throw —
+        // removing it would let the run complete without observing the cancel.
+        var transformer = new TestTransformer<int>();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in transformer.TransformAsync(UncancellableSource(0), cts.Token))
+                {
+                }
+            }
+        );
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_cancelling_mid_stream_throws_via_the_in_loop_check()
+    {
+        // L143: the in-loop `token.ThrowIfCancellationRequested()`. The source deliberately ignores
+        // cancellation, so the transformer's own in-loop check is the ONLY thing that can throw —
+        // removing it would let the transformer drain every item without observing the cancel.
+        var transformer = new TestTransformer<int>();
+        using var cts = new CancellationTokenSource();
+        var seen = 0;
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in transformer.TransformAsync(UncancellableSource(100), cts.Token))
+                {
+                    seen++;
+                    if (seen == 3)
+                    {
+#pragma warning disable CA1849, VSTHRD103 // sync Cancel() — CancelAsync is net8+ only
+                        cts.Cancel();
+#pragma warning restore CA1849, VSTHRD103
+                    }
+                }
+            }
+        );
+
+        Assert.True(seen <= 4, $"Expected a prompt in-loop stop (<= 4), but processed {seen}.");
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_stops_the_injected_timer_when_the_run_completes()
+    {
+        // L162: `_progressTimer?.StopTimer();` in the worker's finally. Running without a progress
+        // sink means the base never touches the injected timer, so this line is the only StopTimer
+        // caller — removing it leaves the recording timer untouched.
+        var timer = new RecordingProgressTimer();
+        var sut = new ExposedTimerTransformer(timer);
+        var source = new TestExtractor<int>(new List<int> { 1, 2, 3 }).ExtractAsync();
+
+        await sut.TransformAsync(source).ToListAsync();
+
+        Assert.True
+        (
+            timer.StopTimerCallCount >= 1,
+            "Expected the worker's finally to stop the injected timer."
+        );
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    // A source that ignores its cancellation token entirely, so only the transformer's own
+    // in-loop cancellation check (L143) can observe a mid-stream cancel.
+    private static async IAsyncEnumerable<int> UncancellableSource(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            await Task.Yield();
+            yield return i;
+        }
+    }
+
+
+
+    private sealed class ExposedTimerTransformer : TestTransformer<int>
+    {
+        public ExposedTimerTransformer(IProgressTimer timer) : base(timer) { }
+
+        public IProgressTimer CallCreateProgressTimer(IProgress<Report> progress) =>
+            CreateProgressTimer(progress);
+
+        public void CallDispose(bool disposing) => Dispose(disposing);
+    }
+
+
+
+    // A minimal IProgressTimer test double that records StopTimer invocations.
+    private sealed class RecordingProgressTimer : IProgressTimer
+    {
+        public int StopTimerCallCount { get; private set; }
+
+#pragma warning disable CS0067 // Elapsed is mandated by IProgressTimer but never raised by this recording double.
+        public event Action? Elapsed;
+#pragma warning restore CS0067
+
+        public void Start(int intervalMilliseconds) { }
+
+        public void StopTimer() => StopTimerCallCount++;
+
+        public void Dispose() { }
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/DelayingExtractorCancellationContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/DelayingExtractorCancellationContractTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,6 +17,10 @@ public sealed class DelayingExtractorCancellationContractTests
 
 
 
+    // The await-foreach normal-completion path is unreachable: this run always cancels mid-stream
+    // (the contract asserts the stream never drains), so the loop only ever exits via the thrown
+    // OperationCanceledException — never by the enumerator completing.
+    [ExcludeFromCodeCoverage]
     protected override async Task<CancellationOutcome> RunAndCancelMidStreamAsync(int itemCount, int cancelAfter)
     {
         var sut = new DelayingExtractor<int>(Enumerable.Range(0, itemCount).ToArray(), PerItemDelay);
@@ -48,6 +53,10 @@ public sealed class DelayingExtractorCancellationContractTests
 
 
 
+    // The loop body and normal-completion path are unreachable: an already-cancelled token makes the
+    // extractor throw before yielding any item (the contract asserts zero items are processed), so
+    // execution goes straight to the catch.
+    [ExcludeFromCodeCoverage]
     protected override async Task<CancellationOutcome> RunWithPreCancelledTokenAsync(int itemCount)
     {
         var sut   = new DelayingExtractor<int>(Enumerable.Range(0, itemCount).ToArray(), PerItemDelay);

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressAssertTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressAssertTests.cs
@@ -261,7 +261,7 @@ public class ProgressAssertTests
         var capture = new ProgressCapture<int>();
 
         Assert.Throws<ArgumentNullException>(() =>
-            ProgressAssert.FinalReportSatisfies<int>(capture, null!));
+            ProgressAssert.FinalReportSatisfies(capture, null!));
     }
 
 
@@ -331,7 +331,7 @@ public class ProgressAssertTests
         var capture = new ProgressCapture<int>();
 
         Assert.Throws<ArgumentNullException>(() =>
-            ProgressAssert.AllReportsSatisfy<int>(capture, null!));
+            ProgressAssert.AllReportsSatisfy(capture, null!));
     }
 
 

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/RetryingExtractorRetryContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/RetryingExtractorRetryContractTests.cs
@@ -25,7 +25,7 @@ public sealed class RetryingExtractorRetryContractTests
     private static async Task<RetryOutcome> DriveAsync(RetryingExtractor<int> sut)
     {
         var itemCount = 0;
-        var succeeded = false;
+        bool succeeded;
 
         try
         {

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestExtractorContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestExtractorContractTests.cs
@@ -24,19 +24,6 @@ public class TestExtractorContractTests
         Enumerable.Range(1, 5).ToList();
 
     /// <inheritdoc/>
-    protected override TestExtractor<int> CreateSutWithTimer(IProgressTimer timer) =>
-        new TestExtractorWithTimer(Enumerable.Range(1, 5).ToList(), timer);
-
-    /// <inheritdoc/>
     protected override TestExtractor<int> CreateSutOverSource(IEnumerable<int> source) =>
         new TestExtractor<int>(source);
-
-
-
-    // Exposes the protected timer constructor of TestExtractor<T> for contract testing.
-    private sealed class TestExtractorWithTimer : TestExtractor<int>
-    {
-        public TestExtractorWithTimer(IEnumerable<int> items, IProgressTimer timer)
-            : base(items, timer) { }
-    }
 }

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestLoaderContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestLoaderContractTests.cs
@@ -22,17 +22,4 @@ public class TestLoaderContractTests
     /// <inheritdoc/>
     protected override IReadOnlyList<int> CreateSourceItems() =>
         Enumerable.Range(1, 5).ToList();
-
-    /// <inheritdoc/>
-    protected override TestLoader<int> CreateSutWithTimer(IProgressTimer timer) =>
-        new TestLoaderWithTimer(collectItems: false, timer);
-
-
-
-    // Exposes the protected timer constructor of TestLoader<T> for contract testing.
-    private sealed class TestLoaderWithTimer : TestLoader<int>
-    {
-        public TestLoaderWithTimer(bool collectItems, IProgressTimer timer)
-            : base(collectItems, timer) { }
-    }
 }

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestTransformerContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestTransformerContractTests.cs
@@ -22,16 +22,4 @@ public class TestTransformerContractTests
     /// <inheritdoc/>
     protected override IReadOnlyList<int> CreateExpectedItems() =>
         Enumerable.Range(1, 5).ToList();
-
-    /// <inheritdoc/>
-    protected override TestTransformer<int> CreateSutWithTimer(IProgressTimer timer) =>
-        new TestTransformerWithTimer(timer);
-
-
-
-    // Exposes the protected timer constructor of TestTransformer<T> for contract testing.
-    private sealed class TestTransformerWithTimer : TestTransformer<int>
-    {
-        public TestTransformerWithTimer(IProgressTimer timer) : base(timer) { }
-    }
 }


### PR DESCRIPTION
**Release 0.23.1** (vNext → main). A lean **patch** — internal-only changes, **no public API change** (validates against the 0.23.0 baseline).

## What's in it
- **Supply-chain hardening (#394/#395):** reproducible hash-pinned NuGet restore via committed `packages.lock.json` + locked-mode CI; Semgrep from a digest-pinned container; zizmor via `--require-hashes`. Clears the Scorecard PinnedDependencies findings.
- **Packaging hygiene (#362):** `examples/`/`benchmarks/` are non-packable — `dotnet pack` emits only the four real packages.
- **Test/quality hardening:** unit test projects instrumented at 100% line coverage (#386); TestKit fault-injection doubles' mutation score 76% → ~99% (#346); per-PR benchmark gate gained an absolute-delta floor (#367); redundant-code analyzer findings cleared across test/contract-base code (#393). Also the InspectCode/CodeQL/Scorecard dashboard cleanup.

## Release sequence
1. Merge **#405** (protected split: version + pr-benchmarks gate) via **admin-bypass** first.
2. Merge **this PR** — after #405, the protected files match main, so full CI passes with no bypass. (CI here will fail until #405 lands; re-run after.)
3. Tag **v0.23.1** on main + create the GitHub Release → `release.yaml` publishes all four packages.

Verified locally: full-matrix Release build (net462…net10, TWAE) green; 1177 net8 tests pass; locked-mode restore clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
