### PR TITLE
fix: clean lockfile churn breaking the benchmark workflows (gh-pages switch)

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -85,6 +85,12 @@ jobs:
           }' "${reports[@]}" > benchmarks-result.json
           echo "report=benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
 
+      - name: Reset build-time lockfile churn before the gh-pages switch
+        # `dotnet restore`/`build` above can rewrite packages.lock.json (RestorePackagesWithLockFile,
+        # #394). The publish action below runs `git switch gh-pages`, which aborts on a dirty tree.
+        # Revert tracked-file churn; the untracked benchmark outputs are preserved.
+        run: git checkout -- .
+
       - name: Publish chart to gh-pages
         # Pinned to v1.22.1 commit per repo convention (third-party actions
         # publishing to gh-pages are pinned by SHA, not mutable tag).

--- a/.github/workflows/pr-benchmarks.yaml
+++ b/.github/workflows/pr-benchmarks.yaml
@@ -86,6 +86,13 @@ jobs:
           }' "${reports[@]}" > benchmarks-result.json
           echo "report=benchmarks/Wolfgang.Etl.Abstractions.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
 
+      - name: Reset build-time lockfile churn before the gh-pages switch
+        # `dotnet restore`/`build` above can rewrite packages.lock.json (RestorePackagesWithLockFile,
+        # #394). The compare action below runs `git switch gh-pages`, which aborts on a dirty tree.
+        # Revert tracked-file churn; the untracked benchmark outputs (benchmarks-result.json,
+        # BenchmarkDotNet.Artifacts/) are preserved.
+        run: git checkout -- .
+
       - name: Compare against baseline & comment
         # Same action + SHA pin as benchmarks.yaml. Compares the PR result against
         # the gh-pages baseline (latest main data point) WITHOUT pushing:


### PR DESCRIPTION
The #394 `packages.lock.json` files get rewritten by `dotnet restore`/`build` on the Linux runner, leaving a dirty tree; `github-action-benchmark` then runs `git switch gh-pages` which **aborts on a dirty tree** — failing the pr-benchmarks gate (blocking release PR #406) and the gh-pages publish. Adds a `git checkout -- .` before each compare/publish step.

Protected workflow files → **admin-bypass**. Merge this so #406's benchmark check passes and #406 shows no protected diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)