### PR TITLE
fix: Stage 1 coverage gate mis-parses per-class rows (unblocks release #406)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -758,7 +758,12 @@ jobs:
           threshold=${CODECOV_MINIMUM:-90}
           matched_count=0
 
-          while read -r line; do
+          # IFS= so `read` preserves leading whitespace — otherwise ReportGenerator's
+          # indented per-class rows are un-indented before the `^[^ ]` module filter
+          # sees them and get gated as if they were assemblies (#386). Only bites once
+          # test assemblies are instrumented (IncludeTestAssembly); Stage 2's pwsh
+          # parser is unaffected.
+          while IFS= read -r line; do
             # Match lines with module names and percentages. The percent
             # capture is the LAST %-suffixed number on the line, matching
             # Stage 2's behavior — ReportGenerator Summary.txt rows often


### PR DESCRIPTION
**Unblocks the 0.23.1 release (#406).** The Stage 1 coverage gate uses `while read` which strips leading whitespace, so ReportGenerator's **indented per-class rows** get un-indented before the `^[^ ]` module filter and are gated as if they were assemblies. Sub-90% *classes* then fail a gate that should only check *modules* (overall coverage is 99.2%; every module is >90%). Invisible until #386 instrumented the test assemblies. One-char-class fix: `while IFS= read`.

This is the #386 Stage-1 parse fix. It was in #407 but orphaned by a concurrent merge; re-doing it standalone. Protected file → **admin-bypass**. After merge, re-run #406's checks (Stage 1 will pass) and sync main→vNext so #406 shows no protected diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)