### PR TITLE
fix(ci): pin codeql-action to commit SHA (fixes OSSF Scorecard badge)

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -80,7 +80,7 @@ jobs:
 
     - name: Initialize CodeQL
       if: matrix.language == 'actions' || steps.check-csharp.outputs.has-csharp == 'true'
-      uses: github/codeql-action/init@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
+      uses: github/codeql-action/init@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4
       with:
         languages: ${{ matrix.language }}
         # security-extended adds the broader security query pack on top of the
@@ -162,7 +162,7 @@ jobs:
     - name: Perform CodeQL Analysis
       id: perform-codeql-analysis
       if: matrix.language == 'actions' || steps.check-csharp.outputs.has-csharp == 'true'
-      uses: github/codeql-action/analyze@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
+      uses: github/codeql-action/analyze@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4
       with:
         category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -399,7 +399,7 @@ jobs:
             --no-build
 
       - name: Upload SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
+        uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4
         with:
           sarif_file: inspect.sarif
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -47,6 +47,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
+        uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -61,6 +61,6 @@ jobs:
           args: scan --config p/csharp --config p/security-audit --config p/secrets --sarif --output semgrep.sarif src/
 
       - name: Upload Semgrep SARIF
-        uses: github/codeql-action/upload-sarif@e4c79b4e9ebfe577d446333c2e31ed81079e7b03 # v4
+        uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
## Problem
The README **OpenSSF Scorecard badge shows "invalid repo path"** (red).

Root cause is **not** the badge markup or ingestion lag. The OSSF scorecard-webapp **rejects every publish** from this repo:

```
error sending scorecard results to webapp: 400 Bad Request
"workflow verification failed: imposter commit:
 e4c79b4e9ebfe577d446333c2e31ed81079e7b03 does not belong to
 github/codeql-action/upload-sarif"
```

`e4c79b4…` is the **annotated tag object** for codeql-action `v4`, not a commit (`GET /commits/e4c79b4…` → 422 "No commit found"). GitHub Actions resolves a tag-object SHA, but OSSF's imposter-commit verifier requires a real **commit** SHA — so ingestion fails and shields.io renders the OSSF 404 as "invalid repo path".

Sibling repos that pin real commit SHAs (ETL-Xml, ETL-FixedWidth, …) are ingested same-day; the only two org repos that 404 (ETL-Abstractions, ETL-DbClient) are exactly the two pinning tag objects.

## Fix
Replace `e4c79b4…` (tag object) → `e0647621…` (the commit that tag points to — **byte-identical v4 code**) across all five pins:
- `codeql.yaml` init + analyze
- `pr.yaml` / `scorecard.yaml` / `semgrep.yaml` upload-sarif

No version or behavior change. After this merges to `main`, the next scorecard run publishes successfully and the badge resolves.

## Notes
- Touches protected `.github/workflows/*` files → admin-bypass merge.
- Must land on `main` (scorecard publishes only from the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)