### PR TITLE
chore: clear InspectCode findings in mutation-test code (#361)

### DIFF
--- a/src/Wolfgang.Etl.TestKit/SnapshotTestLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/SnapshotTestLoader.cs
@@ -140,9 +140,9 @@ public class SnapshotTestLoader<T> : LoaderBase<T, Report>
 
         _buffer.Clear();
 
-        // Stryker disable once Boolean : ConfigureAwait(false) is required on net462/netstandard2.0;
-        // (true) is behaviourally identical under the test host (no synchronization context), so the
-        // mutant is equivalent and unkillable.
+        // Stryker disable once Boolean : the false argument to ConfigureAwait is required on net462
+        // and netstandard2.0, and passing true instead is behaviourally identical under the test host
+        // with no synchronization context, so the mutant is equivalent and unkillable.
         await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
         {
             token.ThrowIfCancellationRequested();

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/OverloadDoubleCoverageTests.cs
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Unit/PipelineTests/OverloadDoubleCoverageTests.cs
@@ -37,10 +37,10 @@ public class OverloadDoubleCoverageTests
         var sut = new FullExtractor<int, string>(Items, "p");
 
         await Assert.ThrowsAsync<ArgumentNullException>(
-            async () => await sut.ExtractAsync((IProgress<string>)null!).ToListAsync());
+            async () => await sut.ExtractAsync(null!).ToListAsync());
 
         await Assert.ThrowsAsync<ArgumentNullException>(
-            async () => await sut.ExtractAsync((IProgress<string>)null!, CancellationToken.None).ToListAsync());
+            async () => await sut.ExtractAsync(null!, CancellationToken.None).ToListAsync());
     }
 
 
@@ -50,7 +50,7 @@ public class OverloadDoubleCoverageTests
         var sut = new ProgressOnlyExtractor<int, string>(Items, "p");
 
         await Assert.ThrowsAsync<ArgumentNullException>(
-            async () => await sut.ExtractAsync((IProgress<string>)null!).ToListAsync());
+            async () => await sut.ExtractAsync(null!).ToListAsync());
     }
 
 
@@ -78,10 +78,10 @@ public class OverloadDoubleCoverageTests
         var sut = new FullLoader<int, string>("p");
 
         await Assert.ThrowsAsync<ArgumentNullException>(
-            async () => await sut.LoadAsync(Source(), (IProgress<string>)null!));
+            async () => await sut.LoadAsync(Source(), null!));
 
         await Assert.ThrowsAsync<ArgumentNullException>(
-            async () => await sut.LoadAsync(Source(), (IProgress<string>)null!, CancellationToken.None));
+            async () => await sut.LoadAsync(Source(), null!, CancellationToken.None));
     }
 
 
@@ -91,7 +91,7 @@ public class OverloadDoubleCoverageTests
         var sut = new ProgressOnlyLoader<int, string>("p");
 
         await Assert.ThrowsAsync<ArgumentNullException>(
-            async () => await sut.LoadAsync(Source(), (IProgress<string>)null!));
+            async () => await sut.LoadAsync(Source(), null!));
     }
 
 
@@ -118,10 +118,10 @@ public class OverloadDoubleCoverageTests
         var sut = new FullTransformer<int, int, string>(x => x, "p");
 
         await Assert.ThrowsAsync<ArgumentNullException>(
-            async () => await sut.TransformAsync(Source(), (IProgress<string>)null!).ToListAsync());
+            async () => await sut.TransformAsync(Source(), null!).ToListAsync());
 
         await Assert.ThrowsAsync<ArgumentNullException>(
-            async () => await sut.TransformAsync(Source(), (IProgress<string>)null!, CancellationToken.None).ToListAsync());
+            async () => await sut.TransformAsync(Source(), null!, CancellationToken.None).ToListAsync());
     }
 
 
@@ -131,6 +131,6 @@ public class OverloadDoubleCoverageTests
         var sut = new ProgressOnlyTransformer<int, int, string>(x => x, "p");
 
         await Assert.ThrowsAsync<ArgumentNullException>(
-            async () => await sut.TransformAsync(Source(), (IProgress<string>)null!).ToListAsync());
+            async () => await sut.TransformAsync(Source(), null!).ToListAsync());
     }
 }

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
@@ -201,7 +201,7 @@ public class DelayingExtractorTests
         {
         }
 
-        // Items 0 and 1 are skipped (the selector is only consulted for yielded items);
+        // Items 0 and 1 are skipped — the selector is only consulted for yielded items.
         // the two yielded items are queried at their real indices 2 and 3.
         Assert.Equal(new[] { 2, 3 }, seen);
     }
@@ -255,7 +255,7 @@ public class DelayingExtractorTests
     {
         // With a large SkipItemCount, the per-item ThrowIfCancellationRequested is the ONLY
         // cancellation check reached while skipping — the Task.Delay (which also observes the token)
-        // runs only for non-skipped items. The source cancels the token as its 6th item is pulled;
+        // runs only for non-skipped items. The source cancels the token as its 6th item is pulled,
         // the in-loop check must throw right then, having skipped only a handful of items. Without
         // that check, skipping would race ahead to the full SkipItemCount before the delay finally
         // noticed cancellation — so a small skipped count proves the in-loop check fired.

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorMutationTests.cs
@@ -104,7 +104,7 @@ public class TestExtractorMutationTests
     [Fact]
     public void Dispose_when_not_disposing_leaves_the_Elapsed_subscription_intact()
     {
-        // L505: `disposing && _progressTimer is not null && _elapsedHandler is not null` (both &&).
+        // L505: the Dispose guard requires disposing plus progressTimer-not-null plus elapsedHandler-not-null, all three together.
         // On the finalizer path (disposing == false) the original leaves the caller-owned timer
         // untouched, so a subsequent Fire() still reports. Either `&&`->`||` mutant would
         // unsubscribe here, producing zero reports.
@@ -197,7 +197,7 @@ public class TestExtractorMutationTests
         public ExposedTimerExtractor(Func<int, int> factory, int count, IProgressTimer timer)
             : base(factory, count, timer) { }
 
-        public IProgressTimer CallCreateProgressTimer(IProgress<Report> progress) =>
+        public void CallCreateProgressTimer(IProgress<Report> progress) =>
             CreateProgressTimer(progress);
 
         public void CallDispose(bool disposing) => Dispose(disposing);

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestTransformerMutationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestTransformerMutationTests.cs
@@ -61,7 +61,7 @@ public class TestTransformerMutationTests
     [Fact]
     public void Dispose_when_not_disposing_leaves_the_Elapsed_subscription_intact()
     {
-        // L113: `disposing && _progressTimer is not null && _elapsedHandler is not null` (both &&).
+        // L113: the Dispose guard requires disposing plus progressTimer-not-null plus elapsedHandler-not-null, all three together.
         // On the finalizer path (disposing == false) the original must not touch the caller-owned
         // timer, so a subsequent Fire() still reports. Either `&&`->`||` mutant unsubscribes here.
         using var timer = new ManualProgressTimer();


### PR DESCRIPTION
Clears the 16 **fixable** InspectCode findings that the #346 mutation-test additions introduced, following the `.DotSettings` documented policy (fix `RedundantCast`/`S125` in code; dismiss `AccessToModifiedClosure`-class per instance).

## Fixed in code
- **RedundantCast ×9** (`OverloadDoubleCoverageTests`) — dropped `(IProgress<string>)null!` casts; each overload set has a single one-arg progress method so `null!` resolves unambiguously. Release build + the 9 tests confirm the `ArgumentNullException` behavior is unchanged.
- **S3241 / UnusedMethodReturnValue.Local** — `CallCreateProgressTimer`'s `IProgressTimer` return is never consumed (all 3 call sites use it for its wiring side effect) → made `void`.
- **S125 ×5** — reworded descriptive / Stryker-directive comments to strip the code-like tokens (backticks, `&&`, `ConfigureAwait(false)`, trailing `;`) that trip the commented-out-code heuristic. No behavior change; the `Stryker disable once Boolean` directive stays functional.

## Dismissed per instance (not in this PR — true FPs, handled on main)
`AccessToModifiedClosure ×8`, `AccessToDisposedClosure ×1`, `VSTHRD003 ×1` — structural false positives on idiomatic test code (the `reports++` counter-closure pattern; a test gate's `TaskCompletionSource.Task`).

## Verification
- Release build (TWAE) of both affected test projects: **0 errors** (no CS0121 from the cast removal).
- `OverloadDoubleCoverageTests` 9/9 pass, `TestExtractorMutationTests` 9/9 pass.

Contributes to #361 (drives InspectCode below its < 25/tool floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)