### PR TITLE
fix(security): force System.Text.Json 8.0.5 in the Coyote test project

### DIFF
--- a/tests/Wolfgang.Etl.Abstractions.Tests.Concurrency/Wolfgang.Etl.Abstractions.Tests.Concurrency.csproj
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Concurrency/Wolfgang.Etl.Abstractions.Tests.Concurrency.csproj
@@ -19,6 +19,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Coyote" Version="1.7.11" />
     <PackageReference Include="Microsoft.Coyote.Test" Version="1.7.11" />
+    <!-- Force the patched System.Text.Json over Microsoft.Coyote's transitive 8.0.0, which is
+         vulnerable to CVE-2024-30105 and CVE-2024-43485 (.NET DoS). Test-only and never shipped,
+         but it is the sole remaining Scorecard Vulnerabilities finding. 8.0.5 patches both. -->
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Wolfgang.Etl.Abstractions.Tests.Concurrency/packages.lock.json
+++ b/tests/Wolfgang.Etl.Abstractions.Tests.Concurrency/packages.lock.json
@@ -74,6 +74,12 @@
         "resolved": "10.25.0.139117",
         "contentHash": "2iBZIkcgsaUNyIPFqR9ECv5PLbAwV9I/v/PeEiMdkfhWEAnqD7VyNXzukQDlL/D24f5OoUc4MbWF5SgYI7x3CA=="
       },
+      "System.Text.Json": {
+        "type": "Direct",
+        "requested": "[8.0.5, )",
+        "resolved": "8.0.5",
+        "contentHash": "0f1B50Ss7rqxXiaBJyzUu9bWFOO2/zSlifZ/UNMdiIpDYe4cY4LQQicP4nirK1OS31I43rn062UIJ1Q9bpmHpg=="
+      },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
         "resolved": "2.20.0",
@@ -172,14 +178,6 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "yev/k9GHAEGx2Rg3/tU6MQh4HGBXJs70y7j1LaM1i/ER9po+6nnQ6RRqTJn1E7Xu0fbIFK80Nh5EoODxrbxwBQ=="
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "OdrZO2WjkiEG6ajEFRABTRCi/wuXQPxeV6g8xvUJqdxMvvuCCEk86zPla8UiIQJz3durtUEbNyY/3lIhS0yZvQ==",
-        "dependencies": {
-          "System.Text.Encodings.Web": "8.0.0"
-        }
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",


### PR DESCRIPTION
Closes the only remaining OSSF Scorecard **Vulnerabilities** finding (2 CVEs).

## What
`Microsoft.Coyote` 1.7.11 pulls **System.Text.Json 8.0.0** transitively into `tests/Wolfgang.Etl.Abstractions.Tests.Concurrency`, which is vulnerable to:
- **CVE-2024-30105** (.NET DoS) — fixed in 8.0.4
- **CVE-2024-43485** (.NET DoS) — fixed in 8.0.5

Pin an explicit `System.Text.Json` **8.0.5** reference (patches both) and regenerate the committed lockfile.

## Scope / risk
- **Test-only, never shipped** — this transitive dep lives only in the Coyote concurrency-test project (not referenced by any `src` package), so no consumer was ever exposed. Dependabot correctly shows no alerts. This clears the Scorecard score, not a consumer-facing risk.
- 8.0.5 is a patch over 8.0.0 — fully compatible. Release build: **0 warnings, 0 errors**.

Closes the Scorecard `VulnerabilitiesID` alert on the next `main` re-scan (Scorecard 13 → 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)