### PR TITLE
ci: enforce >=99% coverage on unit-test assemblies + release.yaml alignment (#386)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -771,19 +771,28 @@ jobs:
             # end-of-line.
             if echo "$line" | grep -qE '^[^ ].*[0-9]+(\.[0-9]+)?%$' && ! echo "$line" | grep -q '^Summary'; then
               module=$(echo "$line" | awk '{print $1}')
-              # Floor the percent to int (matches Stage 2 pwsh's [int][math]::Floor)
-              # so we can use bash's integer -lt comparator below without
-              # erroring on decimals like "90.4".
-              percent=$(echo "$line" | awk '{print $NF}' | tr -d '%' | awk '{print int($1)}')
+              # Raw decimal percent (last %-suffixed number on the row). Kept as a
+              # decimal and compared as a float below so the per-module threshold
+              # can be fractional.
+              raw=$(echo "$line" | awk '{print $NF}' | tr -d '%')
               matched_count=$((matched_count + 1))
 
-              echo "Checking module: '$module' - Coverage: ${percent}%"
+              # Per-module threshold (#386): unit-test assemblies must reach
+              # >= 99%, src assemblies keep CODECOV_MINIMUM. floor(x) >= N <=>
+              # x >= N, so the single raw >= threshold float comparison below
+              # leaves src behaviour identical to the previous floor+integer check.
+              case "$module" in
+                *.Tests.Unit) mod_threshold=99; mod_label="99%" ;;
+                *)            mod_threshold=$threshold; mod_label="${threshold}%" ;;
+              esac
 
-              if [ "$percent" -lt "$threshold" ]; then
-                echo "  ❌ FAIL: Below ${threshold}% threshold"
-                failed_projects="$failed_projects $module (${percent}%)"
+              echo "Checking module: '$module' - Coverage: ${raw}%"
+
+              if awk -v p="$raw" -v t="$mod_threshold" 'BEGIN { exit !(p+0 >= t+0) }'; then
+                echo "  ✅ PASS: Meets ${mod_label} threshold"
               else
-                echo "  ✅ PASS: Meets ${threshold}% threshold"
+                echo "  ❌ FAIL: Below ${mod_label} threshold"
+                failed_projects="$failed_projects $module (${raw}%)"
               fi
             fi
           done < CoverageReport/Summary.txt
@@ -1093,16 +1102,24 @@ jobs:
             #    the line to be captured intact.
             if ($line -match '^(\S+).*\s(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^Summary') {
               $module  = $Matches[1]
-              $percent = [int][math]::Floor([double]$Matches[2])
+              # Raw decimal percent, compared as a float so the per-module
+              # threshold can be fractional (see Stage 1 for the rationale).
+              $raw     = [double]$Matches[2]
               $matchedCount++
 
-              Write-Host "Checking module: '$module' - Coverage: ${percent}%"
+              # Per-module threshold (#386): unit-test assemblies must reach
+              # >= 99%; src assemblies keep CODECOV_MINIMUM. floor(x) >= N <=>
+              # x >= N, so the single float comparison leaves src unchanged.
+              if ($module -like '*.Tests.Unit') { $modThreshold = 99; $modLabel = '99%' }
+              else                              { $modThreshold = [double]$threshold; $modLabel = "${threshold}%" }
 
-              if ($percent -lt $threshold) {
-                Write-Host "  ❌ FAIL: Below ${threshold}% threshold" -ForegroundColor Red
-                $failedProjects += "$module (${percent}%)"
+              Write-Host "Checking module: '$module' - Coverage: ${raw}%"
+
+              if ($raw -lt $modThreshold) {
+                Write-Host "  ❌ FAIL: Below ${modLabel} threshold" -ForegroundColor Red
+                $failedProjects += "$module (${raw}%)"
               } else {
-                Write-Host "  ✅ PASS: Meets ${threshold}% threshold" -ForegroundColor Green
+                Write-Host "  ✅ PASS: Meets ${modLabel} threshold" -ForegroundColor Green
               }
             }
           }
@@ -1462,13 +1479,20 @@ jobs:
           while IFS= read -r line; do
             if echo "$line" | grep -qE '^[^ ]+.*[0-9]+%$' && ! echo "$line" | grep -q '^Summary'; then
               MODULE=$(echo "$line" | awk '{print $1}')
-              PERCENT=$(echo "$line" | grep -oE '[0-9]+(\.[0-9]+)?%' | tail -1 | grep -oE '^[0-9]+')
-              echo "Checking module: '$MODULE' - Coverage: ${PERCENT}%"
-              if [ "$PERCENT" -lt "$THRESHOLD" ]; then
-                echo "  ❌ FAIL: Below ${THRESHOLD}% threshold"
-                FAILED=1
+              # Raw decimal percent (last %-suffixed number), compared as a float.
+              RAW=$(echo "$line" | grep -oE '[0-9]+(\.[0-9]+)?%' | tail -1 | tr -d '%')
+              # Per-module threshold (#386): unit-test assemblies must reach >= 99%;
+              # src assemblies keep CODECOV_MINIMUM (see Stage 1).
+              case "$MODULE" in
+                *.Tests.Unit) MOD_THRESHOLD=99; MOD_LABEL="99%" ;;
+                *)            MOD_THRESHOLD=$THRESHOLD; MOD_LABEL="${THRESHOLD}%" ;;
+              esac
+              echo "Checking module: '$MODULE' - Coverage: ${RAW}%"
+              if awk -v p="$RAW" -v t="$MOD_THRESHOLD" 'BEGIN { exit !(p+0 >= t+0) }'; then
+                echo "  ✅ PASS: Meets ${MOD_LABEL} threshold"
               else
-                echo "  ✅ PASS: Meets ${THRESHOLD}% threshold"
+                echo "  ❌ FAIL: Below ${MOD_LABEL} threshold"
+                FAILED=1
               fi
             fi
           done < CoverageReport/Summary.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -215,9 +215,10 @@ jobs:
                   --no-build `
                   --no-restore `
                   --collect:"XPlat Code Coverage" `
+                  --settings coverlet.runsettings `
                   --results-directory "./TestResults" `
                   --logger "console;verbosity=minimal"
-                
+
                 if ($LASTEXITCODE -ne 0) {
                   Write-Error "❌ Tests failed (no explicit TargetFramework) in $($testProj.Name)"
                   exit $LASTEXITCODE
@@ -236,6 +237,7 @@ jobs:
                   --no-build `
                   --no-restore `
                   --collect:"XPlat Code Coverage" `
+                  --settings coverlet.runsettings `
                   --results-directory "./TestResults" `
                   --logger "console;verbosity=minimal"
               } else {

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -207,14 +207,21 @@ if (-not $SkipTests -and -not $SkipCoverage -and $failed.Count -eq 0) {
             foreach ($line in (Get-Content "CoverageReport/Summary.txt")) {
                 if ($line -match '^\s*(\S+)\s+(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^\s*Summary') {
                     $module = $Matches[1]
-                    $percent = [int][math]::Floor([double]$Matches[2])
+                    # Raw decimal percent, compared as a float (see the pr.yaml gate).
+                    $raw = [double]$Matches[2]
 
-                    if ($percent -lt $CoverageThreshold) {
-                        Write-Fail "  $module — ${percent}% (below ${CoverageThreshold}%)"
-                        $failedProjects += "$module (${percent}%)"
+                    # Per-module threshold (#386): unit-test assemblies must reach
+                    # >= 99%; everything else keeps CoverageThreshold. Only the
+                    # assembly row ends in ".Tests.Unit" — class rows never do.
+                    if ($module -like '*.Tests.Unit') { $modThreshold = 99; $modLabel = '99%' }
+                    else                              { $modThreshold = [double]$CoverageThreshold; $modLabel = "${CoverageThreshold}%" }
+
+                    if ($raw -lt $modThreshold) {
+                        Write-Fail "  $module — ${raw}% (below ${modLabel})"
+                        $failedProjects += "$module (${raw}%)"
                     }
                     else {
-                        Write-Pass "  $module — ${percent}%"
+                        Write-Pass "  $module — ${raw}%"
                     }
                 }
             }


### PR DESCRIPTION
Completes the ETL-Abstractions half of **#386** phase-1 (the gate + release alignment). Prototyped here per the "ETL-Abstractions-first" decision; the repo-template back-port is a separate follow-up.

## Gate change — unit-test assemblies must reach ≥ 99%
Per-module threshold in **all four** coverage-gate implementations — `pr.yaml` Stage-1 (bash), Stage-2 (pwsh), Stage-3 (bash), and `scripts/build-pr.ps1` (pwsh):
- assemblies ending in **`.Tests.Unit`** → must reach **≥ 99%**
- every other assembly → **CODECOV_MINIMUM** (90), unchanged

Implemented as one raw-decimal float comparison; since `floor(x) ≥ N ⟺ x ≥ N`, **src behaviour is identical** to the old floored/integer check and only the test-assembly rows get the stricter bar. (Current real unit-test coverage is 99.9%, so it passes comfortably.)

## release.yaml alignment (step 5)
The two coverage-collecting `dotnet test` calls now pass `--settings coverlet.runsettings`, so release-time coverage instruments test assemblies like PR-time does (otherwise a release could fail a gate the PR passed).

## Verification
- Bash + pwsh gate logic run against a synthetic `Summary.txt` of boundary cases: test **99.9→pass, 99.0→pass, 98.5→fail**; src **90→pass, 89.9→fail** ✅
- Current **real** 99.9% test-assembly coverage **passes**.
- `pr.yaml` / `release.yaml` still parse as valid YAML.

## ⚠️ Routing & scope
- Touches protected **pr.yaml + release.yaml** → **admin-bypass merge**.
- Does **not** fully close #386 — the repo-template fanout and the phase-2 specialty suites (Fuzz/DocExamples/Concurrency/…) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)