### PR TITLE
chore(release): 0.23.2 — version + CHANGELOG + baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.23.2] - 2026-08-18
+
+### Changed
+
+- Raised the floor on the first-party Microsoft runtime dependencies to **10.0.11**
+  (`Microsoft.Bcl.AsyncInterfaces`, `Microsoft.Bcl.Memory`,
+  `Microsoft.Extensions.Logging.Abstractions`, `System.Threading.Channels`), and reconciled the
+  previous drift (Abstractions was on 10.0.5 while TestKit/TestKit.Xunit were on 10.0.10) (#415).
+  On net8.0+ these assemblies are framework-provided (`ExcludeAssets="runtime"`), so the change
+  only affects **down-level** (net462 / netstandard2.0) consumers, who now resolve the latest
+  serviced patch — carrying the current security and bug fixes — by default. No public API change.
+
+### Internal
+
+- Bumped every bundled analyzer to its current release — Roslynator 4.16.1, SonarAnalyzer 10.32,
+  Meziantou 3.0.163, BannedApiAnalyzers 5.6.0, PublicApiAnalyzers 5.6.0, and
+  VS.Threading.Analyzers 18.7.23 (#416, #417). No new diagnostics and no PublicAPI baseline change.
+- The PR/release coverage gate now holds unit-test assemblies to **≥ 99%** line coverage (src
+  stays at 90%), and `release.yaml` collects coverage through the shared `coverlet.runsettings`
+  so release-time coverage instruments the same code as PR-time (#386, #418).
+- Forced `System.Text.Json` 8.0.5 in the Coyote concurrency test project to clear a test-only
+  transitive advisory (CVE-2024-30105 / CVE-2024-43485); not shipped in any package (#412).
+
 ## [0.23.1] - 2026-08-16
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -100,7 +100,7 @@
     <!-- Single source of truth for the package version. All four packages are lockstep-versioned
          with the repository; bump this one value per release. (Per-csproj <Version> is intentionally
          absent so the versions can never drift out of sync.) -->
-    <Version>0.23.1</Version>
+    <Version>0.23.2</Version>
     <!-- AssemblyVersion is pinned to a fixed binding-stability baseline so consumers do not need to
          recompile / add binding redirects on every minor/patch bump — bump only on a deliberate
          breaking API change. FileVersion (and the auto-derived InformationalVersion) carry the actual

--- a/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
+++ b/src/Wolfgang.Etl.Abstractions/Wolfgang.Etl.Abstractions.csproj
@@ -11,7 +11,7 @@
          recorded in CompatibilitySuppressions.xml, regenerated with
          `dotnet pack /p:GenerateCompatibilitySuppressionFile=true`. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.23.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.23.1</PackageValidationBaselineVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Contains interfaces and base classes used to build ETL applications</Description>

--- a/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
+++ b/src/Wolfgang.Etl.ErrorPolicies/Wolfgang.Etl.ErrorPolicies.csproj
@@ -7,7 +7,7 @@
          previously-published baseline to compare against; enabled from 0.22.0 onward now that the
          package has published history. Baseline tracks the last PUBLISHED version. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.23.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.23.1</PackageValidationBaselineVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>$(AssemblyName)</Title>
     <Description>Ready-made item-error policies — skip, log, and dead-letter (to a collection or a channel) — assignable to the ErrorPolicy property of Wolfgang.Etl extractors, loaders, and transformers. Built on Wolfgang.Etl.Abstractions.</Description>

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -12,7 +12,7 @@
          is live on NuGet (otherwise pack fails NU1102). Intentional breaks in a
          MAJOR bump are recorded via a generated CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.23.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.23.1</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit.Xunit</Title>
     <Description>Abstract xUnit contract test base classes for verifying custom ETL extractors, transformers, and loaders built on Wolfgang.Etl.Abstractions.</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -12,7 +12,7 @@
          is live on NuGet (otherwise pack fails NU1102). Intentional breaks in a
          MAJOR bump are recorded via a generated CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.23.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.23.1</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit</Title>
     <Description>An implementation of Extractor, Transformer and Loader for use in ETL examples and benchmarks. Built on Wolfgang.Etl.Abstractions.</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>


### PR DESCRIPTION
Release-prep for **0.23.2** (patch — no public API change). First of the release steps; the protected-split to main + release PR follow.

## Changes
- `<Version>` **0.23.1 → 0.23.2**.
- **CHANGELOG** `[0.23.2]` section — *Changed*: the 10.0.11 dependency floor bump (#415, whose changelog entry was stranded on its feature branch and never reached vNext); *Internal*: analyzer bumps (#416/#417), the ≥99% test-assembly coverage gate + release.yaml coverage alignment (#386/#418), and the test-only System.Text.Json 8.0.5 CVE fix (#412).
- **PackageValidationBaselineVersion 0.23.0 → 0.23.1** on all four src packages — the 0.23.1 baseline bump never propagated to main/vNext after 0.23.1 shipped.

## Verification
- All four src packages **pack with PackageValidation passing** against the live **0.23.1** baseline.

## ⚠️ Routing
Touches protected **Directory.Build.props** → **admin-bypass merge** to vNext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)