### PR TITLE
chore(release): 0.23.2 protected-file bundle (ahead of the release PR)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -771,19 +771,28 @@ jobs:
             # end-of-line.
             if echo "$line" | grep -qE '^[^ ].*[0-9]+(\.[0-9]+)?%$' && ! echo "$line" | grep -q '^Summary'; then
               module=$(echo "$line" | awk '{print $1}')
-              # Floor the percent to int (matches Stage 2 pwsh's [int][math]::Floor)
-              # so we can use bash's integer -lt comparator below without
-              # erroring on decimals like "90.4".
-              percent=$(echo "$line" | awk '{print $NF}' | tr -d '%' | awk '{print int($1)}')
+              # Raw decimal percent (last %-suffixed number on the row). Kept as a
+              # decimal and compared as a float below so the per-module threshold
+              # can be fractional.
+              raw=$(echo "$line" | awk '{print $NF}' | tr -d '%')
               matched_count=$((matched_count + 1))
 
-              echo "Checking module: '$module' - Coverage: ${percent}%"
+              # Per-module threshold (#386): unit-test assemblies must reach
+              # >= 99%, src assemblies keep CODECOV_MINIMUM. floor(x) >= N <=>
+              # x >= N, so the single raw >= threshold float comparison below
+              # leaves src behaviour identical to the previous floor+integer check.
+              case "$module" in
+                *.Tests.Unit) mod_threshold=99; mod_label="99%" ;;
+                *)            mod_threshold=$threshold; mod_label="${threshold}%" ;;
+              esac
 
-              if [ "$percent" -lt "$threshold" ]; then
-                echo "  ❌ FAIL: Below ${threshold}% threshold"
-                failed_projects="$failed_projects $module (${percent}%)"
+              echo "Checking module: '$module' - Coverage: ${raw}%"
+
+              if awk -v p="$raw" -v t="$mod_threshold" 'BEGIN { exit !(p+0 >= t+0) }'; then
+                echo "  ✅ PASS: Meets ${mod_label} threshold"
               else
-                echo "  ✅ PASS: Meets ${threshold}% threshold"
+                echo "  ❌ FAIL: Below ${mod_label} threshold"
+                failed_projects="$failed_projects $module (${raw}%)"
               fi
             fi
           done < CoverageReport/Summary.txt
@@ -1093,16 +1102,24 @@ jobs:
             #    the line to be captured intact.
             if ($line -match '^(\S+).*\s(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^Summary') {
               $module  = $Matches[1]
-              $percent = [int][math]::Floor([double]$Matches[2])
+              # Raw decimal percent, compared as a float so the per-module
+              # threshold can be fractional (see Stage 1 for the rationale).
+              $raw     = [double]$Matches[2]
               $matchedCount++
 
-              Write-Host "Checking module: '$module' - Coverage: ${percent}%"
+              # Per-module threshold (#386): unit-test assemblies must reach
+              # >= 99%; src assemblies keep CODECOV_MINIMUM. floor(x) >= N <=>
+              # x >= N, so the single float comparison leaves src unchanged.
+              if ($module -like '*.Tests.Unit') { $modThreshold = 99; $modLabel = '99%' }
+              else                              { $modThreshold = [double]$threshold; $modLabel = "${threshold}%" }
 
-              if ($percent -lt $threshold) {
-                Write-Host "  ❌ FAIL: Below ${threshold}% threshold" -ForegroundColor Red
-                $failedProjects += "$module (${percent}%)"
+              Write-Host "Checking module: '$module' - Coverage: ${raw}%"
+
+              if ($raw -lt $modThreshold) {
+                Write-Host "  ❌ FAIL: Below ${modLabel} threshold" -ForegroundColor Red
+                $failedProjects += "$module (${raw}%)"
               } else {
-                Write-Host "  ✅ PASS: Meets ${threshold}% threshold" -ForegroundColor Green
+                Write-Host "  ✅ PASS: Meets ${modLabel} threshold" -ForegroundColor Green
               }
             }
           }
@@ -1462,13 +1479,20 @@ jobs:
           while IFS= read -r line; do
             if echo "$line" | grep -qE '^[^ ]+.*[0-9]+%$' && ! echo "$line" | grep -q '^Summary'; then
               MODULE=$(echo "$line" | awk '{print $1}')
-              PERCENT=$(echo "$line" | grep -oE '[0-9]+(\.[0-9]+)?%' | tail -1 | grep -oE '^[0-9]+')
-              echo "Checking module: '$MODULE' - Coverage: ${PERCENT}%"
-              if [ "$PERCENT" -lt "$THRESHOLD" ]; then
-                echo "  ❌ FAIL: Below ${THRESHOLD}% threshold"
-                FAILED=1
+              # Raw decimal percent (last %-suffixed number), compared as a float.
+              RAW=$(echo "$line" | grep -oE '[0-9]+(\.[0-9]+)?%' | tail -1 | tr -d '%')
+              # Per-module threshold (#386): unit-test assemblies must reach >= 99%;
+              # src assemblies keep CODECOV_MINIMUM (see Stage 1).
+              case "$MODULE" in
+                *.Tests.Unit) MOD_THRESHOLD=99; MOD_LABEL="99%" ;;
+                *)            MOD_THRESHOLD=$THRESHOLD; MOD_LABEL="${THRESHOLD}%" ;;
+              esac
+              echo "Checking module: '$MODULE' - Coverage: ${RAW}%"
+              if awk -v p="$RAW" -v t="$MOD_THRESHOLD" 'BEGIN { exit !(p+0 >= t+0) }'; then
+                echo "  ✅ PASS: Meets ${MOD_LABEL} threshold"
               else
-                echo "  ✅ PASS: Meets ${THRESHOLD}% threshold"
+                echo "  ❌ FAIL: Below ${MOD_LABEL} threshold"
+                FAILED=1
               fi
             fi
           done < CoverageReport/Summary.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -215,9 +215,10 @@ jobs:
                   --no-build `
                   --no-restore `
                   --collect:"XPlat Code Coverage" `
+                  --settings coverlet.runsettings `
                   --results-directory "./TestResults" `
                   --logger "console;verbosity=minimal"
-                
+
                 if ($LASTEXITCODE -ne 0) {
                   Write-Error "❌ Tests failed (no explicit TargetFramework) in $($testProj.Name)"
                   exit $LASTEXITCODE
@@ -236,6 +237,7 @@ jobs:
                   --no-build `
                   --no-restore `
                   --collect:"XPlat Code Coverage" `
+                  --settings coverlet.runsettings `
                   --results-directory "./TestResults" `
                   --logger "console;verbosity=minimal"
               } else {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <!-- Roslynator - Code quality and refactoring -->
-    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.16.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -45,25 +45,25 @@
     </PackageReference>
     
     <!-- Microsoft Threading Analyzers - Thread safety -->
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
     <!-- BannedApiAnalyzers - Prevent usage of specific APIs -->
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
     <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.58">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.163">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.25.0.139117">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.32.0.713">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -80,7 +80,7 @@
        is the correct fix: PublicAPI tracking does not apply to non-shipped
        assemblies. -->
   <ItemGroup Condition="Exists('PublicAPI.Shipped.txt')">
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" Condition="Exists('PublicAPI.Shipped.txt') or Exists('PublicAPI.Unshipped.txt')">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" Condition="Exists('PublicAPI.Shipped.txt') or Exists('PublicAPI.Unshipped.txt')">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -100,7 +100,7 @@
     <!-- Single source of truth for the package version. All four packages are lockstep-versioned
          with the repository; bump this one value per release. (Per-csproj <Version> is intentionally
          absent so the versions can never drift out of sync.) -->
-    <Version>0.23.1</Version>
+    <Version>0.23.2</Version>
     <!-- AssemblyVersion is pinned to a fixed binding-stability baseline so consumers do not need to
          recompile / add binding redirects on every minor/patch bump — bump only on a deliberate
          breaking API change. FileVersion (and the auto-derived InformationalVersion) carry the actual


### PR DESCRIPTION
**Protected-file split for the 0.23.2 release** — merge this **first** (admin-bypass), then the `vNext → main` release PR's guard will pass.

Brings the three protected files' current vNext state to main:
- **Directory.Build.props** — `<Version>` 0.23.2 + the bumped analyzers (#416/#417)
- **pr.yaml / release.yaml** — the ≥99% test-assembly coverage gate + coverlet.runsettings alignment (#386/#418)

**main is an ancestor of vNext**, so this is purely additive — no risk of downgrading main's protected config. Non-protected release content (code, csprojs, CHANGELOG, lockfiles) rides the separate release PR.

⚠️ **Admin-bypass merge** (protected files by definition trip the guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)